### PR TITLE
Add ability to get a random image from a folder.

### DIFF
--- a/backend/effects/builtin/showImage.js
+++ b/backend/effects/builtin/showImage.js
@@ -4,7 +4,7 @@ const { settings } = require("../../common/settings-access");
 const resourceTokenManager = require("../../resourceTokenManager");
 const mediaProcessor = require("../../common/handlers/mediaProcessor");
 const webServer = require("../../../server/httpServer");
-
+const fs = require('fs');
 const { ControlKind, InputEvent } = require('../../interactive/constants/MixplayConstants');
 const effectModels = require("../models/effectModels");
 const { EffectDependency, EffectTrigger } = effectModels;
@@ -53,6 +53,13 @@ const showImage = {
                 <input type="radio" ng-model="effect.imageType" value="url" ng-change="imageTypeUpdated()"/>
                 <div class="control__indicator"></div>
             </label>
+            <label class="control-fb control--radio">Random from folder
+                <input type="radio" ng-model="effect.imageType" value="folderRandom" ng-change="imageTypeUpdated()"/>
+                <div class="control__indicator"></div>
+            </label>
+        </div>
+        <div ng-if="effect.imageType === 'folderRandom'" style="display: flex;flex-direction: row;align-items: center;">
+            <input type="text" class="form-control" ng-model="effect.folder" placeholder="Enter full folder path">
         </div>
         <div ng-if="effect.imageType === 'local'" style="display: flex;flex-direction: row;align-items: center;">
             <file-chooser model="effect.file" options="{ filters: [ {name: 'Image', extensions: ['jpg', 'gif', 'png', 'jpeg']} ]}"></file-chooser>
@@ -130,8 +137,10 @@ const showImage = {
             let path;
             if ($scope.effect.imageType === "local") {
                 path = $scope.effect.file;
-            } else {
+            } else if ($scope.effect.imageType === "url") {
                 path = $scope.effect.url;
+            } else {
+                path = $scope.effect.folder;
             }
 
             return path;
@@ -140,7 +149,12 @@ const showImage = {
         $scope.imageTypeUpdated = function() {
             if ($scope.effect.imageType === "local") {
                 $scope.effect.url = undefined;
+                $scope.effect.folder = undefined;
+            } else if ($scope.effect.imageType === "url") {
+                $scope.effect.file = undefined;
+                $scope.effect.folder = undefined;
             } else {
+                $scope.effect.url = undefined;
                 $scope.effect.file = undefined;
             }
         };
@@ -154,8 +168,8 @@ const showImage = {
         if (effect.imageType == null) {
             errors.push("Please select an image type.");
         }
-        if (effect.file == null && effect.url == null) {
-            errors.push("Please select an image source, either file path or url.");
+        if (effect.file == null && effect.url == null && effect.folder == null) {
+            errors.push("Please select an image source, either file path, url, or folder.");
         }
         return errors;
     },
@@ -175,6 +189,7 @@ const showImage = {
             let data = {
                 filepath: effect.file,
                 url: effect.url,
+                folder: effect.folder,
                 imageType: effect.imageType,
                 imagePosition: position,
                 imageHeight: effect.height ? effect.height + "px" : "auto",
@@ -208,6 +223,22 @@ const showImage = {
                     effect.file,
                     effect.length
                 );
+                data.resourceToken = resourceToken;
+            }
+
+            if (effect.imageType === "folderRandom") {
+                let files = fs.readdirSync(effect.folder),
+                    filteredFiles = files.filter(function (img) {
+                        return (/\.(gif|jpg|jpeg|png)$/i).test(img);
+                    }),
+                    chosenFile = filteredFiles[Math.floor(Math.random() * filteredFiles.length)],
+                    trimFolderPath = effect.folder.replace(/\/+$/, ""),
+                    fullFilePath = trimFolderPath + '/' + chosenFile,
+                    resourceToken = resourceTokenManager.storeResourcePath(
+                        fullFilePath,
+                        effect.length
+                    );
+
                 data.resourceToken = resourceToken;
             }
 

--- a/backend/effects/builtin/showImage.js
+++ b/backend/effects/builtin/showImage.js
@@ -59,7 +59,7 @@ const showImage = {
             </label>
         </div>
         <div ng-if="effect.imageType === 'folderRandom'" style="display: flex;flex-direction: row;align-items: center;">
-            <input type="text" class="form-control" ng-model="effect.folder" placeholder="Enter full folder path">
+            <file-chooser model="effect.folder" options="{ directoryOnly: true, filters: [], title: 'Select Image Folder'}"></file-chooser>
         </div>
         <div ng-if="effect.imageType === 'local'" style="display: flex;flex-direction: row;align-items: center;">
             <file-chooser model="effect.file" options="{ filters: [ {name: 'Image', extensions: ['jpg', 'gif', 'png', 'jpeg']} ]}"></file-chooser>
@@ -232,8 +232,7 @@ const showImage = {
                         return (/\.(gif|jpg|jpeg|png)$/i).test(img);
                     }),
                     chosenFile = filteredFiles[Math.floor(Math.random() * filteredFiles.length)],
-                    trimFolderPath = effect.folder.replace(/\/+$/, ""),
-                    fullFilePath = trimFolderPath + '/' + chosenFile,
+                    fullFilePath = effect.folder + '/' + chosenFile,
                     resourceToken = resourceTokenManager.storeResourcePath(
                         fullFilePath,
                         effect.length


### PR DESCRIPTION
This adds in the ability for the Show Image effect to pull a random image from a folder. 

- Gets all files in given folder path.
- Filters out anything that isn't: .jpg, .jpeg, .gif. png
- Selects one randomly.
- Sends it to the overlay as if it were the "local file" option.