### PR TITLE
Active Chatter and Currency Adjustments

### DIFF
--- a/backend/chat/active-chatters.js
+++ b/backend/chat/active-chatters.js
@@ -16,6 +16,14 @@ let inactiveTimer = userInactiveTimeSetting * 60000;
 let cycleActiveTimer = [];
 let activeChatters = [];
 
+function isUsernameActiveChatter(username) {
+    let existingUserIndex = activeChatters.findIndex((obj => obj.username === username));
+    if (existingUserIndex !== -1) {
+        return true;
+    }
+    return false;
+}
+
 function addOrUpdateActiveChatter(user) {
     if (!activeUserListStatus) {
         return;
@@ -109,3 +117,4 @@ ipcMain.on("setActiveChatUserTimeout", function(event, value) {
 exports.getActiveChatters = getActiveChatters;
 exports.addOrUpdateActiveChatter = addOrUpdateActiveChatter;
 exports.cycleActiveChatters = cycleActiveChatters;
+exports.isUsernameActiveChatter = isUsernameActiveChatter;

--- a/backend/database/currencyDatabase.js
+++ b/backend/database/currencyDatabase.js
@@ -7,6 +7,7 @@ const { settings } = require("../common/settings-access.js");
 const channelAccess = require("../common/channel-access");
 const customRolesManager = require("../roles/custom-roles-manager");
 const mixerRolesManager = require("../../shared/mixer-roles");
+const firebotRolesManager = require("../roles/firebot-roles-manager");
 
 let currencyCache = {};
 
@@ -132,7 +133,8 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
                     .filter(mr => mr !== "User")
                     .map(mr => mixerRolesManager.mapMixerRole(mr));
                 let customRoles = customRolesManager.getAllCustomRolesForViewer(u.username);
-                u.allRoles = mixerRoles.concat(customRoles);
+                let firebotRoles = firebotRolesManager.getAllFirebotRolesForViewer(u.username);
+                u.allRoles = mixerRoles.concat(customRoles).concat(firebotRoles);
                 return u;
             })
             .filter(u => u.allRoles.some(r => roleIds.includes(r.id)))

--- a/backend/database/currencyDatabase.js
+++ b/backend/database/currencyDatabase.js
@@ -35,7 +35,7 @@ function getCurrencies() {
 
 // Adjust Currency
 // This adjust currency for a user. Can be given negative values. Provide it with the database record for a user.
-function adjustCurrency(user, currencyId, value) {
+function adjustCurrency(user, currencyId, value, adjustType = "adjust") {
     return new Promise(resolve => {
         if (!isViewerDBOn()) {
             return resolve();
@@ -43,18 +43,31 @@ function adjustCurrency(user, currencyId, value) {
 
         // Dont do anything if value is not a number or is 0.
         value = parseInt(value);
-        if (isNaN(value) || value === 0) {
-            return resolve();
-        }
+        adjustType = adjustType.toLowerCase();
+        let newUserValue = value;
 
-        // Okay, move on and finish everything.
-        logger.debug(
-            "Currency: Adjusting " + value + " currency to " + user.username + ". " + currencyId
-        );
+        switch (adjustType) {
+        case "set":
+            if (isNaN(value)) {
+                return resolve();
+            }
+            logger.debug(
+                "Currency: Setting " + user.username + " currency " + currencyId + " to: " + value + "."
+            );
+            newUserValue = value;
+            break;
+        default:
+            if (isNaN(value) || value === 0) {
+                return resolve();
+            }
+            logger.debug(
+                "Currency: Adjusting " + value + " currency to " + user.username + ". " + currencyId
+            );
+            newUserValue = (user.currency[currencyId] += parseInt(value));
+        }
 
         let db = userDatabase.getUserDb();
         let updateDoc = {};
-        let newUserValue = (user.currency[currencyId] += parseInt(value));
         let currencyLimit = isNaN(parseInt(currencyCache[currencyId].limit))
             ? 0
             : currencyCache[currencyId].limit;
@@ -74,7 +87,7 @@ function adjustCurrency(user, currencyId, value) {
             err
         ) {
             if (err) {
-                logger.error("Currency: Error adding currency to user.", err);
+                logger.error("Currency: Error setting currency on user.", err);
             }
             return resolve();
         });
@@ -83,7 +96,7 @@ function adjustCurrency(user, currencyId, value) {
 
 // Adjust currency for user.
 // This adjust currency when given a username. Can be given negative values to remove currency.
-function adjustCurrencyForUser(username, currencyId, value) {
+function adjustCurrencyForUser(username, currencyId, value, adjustType = "adjust") {
     return new Promise((resolve) => {
         if (!isViewerDBOn()) {
             return resolve(false);
@@ -103,7 +116,7 @@ function adjustCurrencyForUser(username, currencyId, value) {
         // Okay, it passes... let's try to add it.
         userDatabase.getUserByUsername(username).then(user => {
             if (user !== false) {
-                adjustCurrency(user, currencyId, value).then(() => {
+                adjustCurrency(user, currencyId, value, adjustType).then(() => {
                     return resolve(true);
                 });
             }
@@ -114,7 +127,7 @@ function adjustCurrencyForUser(username, currencyId, value) {
 
 // Add Currency to Usergroup
 // This will add an amount of currency to all online users in a usergroup.
-function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, ignoreDisable = false) {
+function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, ignoreDisable = false, adjustType = "adjust") {
     return new Promise(async resolve => {
         if (!isViewerDBOn()) {
             return resolve();
@@ -150,7 +163,7 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
         db.find({ online: true, _id: { $in: userIdsInRoles } }, async (err, docs) => {
             for (let user of docs) {
                 if (user != null && (ignoreDisable || !user.disableAutoStatAccrual)) {
-                    await adjustCurrency(user, currencyId, value);
+                    await adjustCurrency(user, currencyId, value, adjustType);
                 }
             }
 
@@ -161,7 +174,7 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
 
 // Add Currency to all Online Users
 // This will add an amount of currency to all users who are currently seen as online.
-function addCurrencyToOnlineUsers(currencyId, value, ignoreDisable = false) {
+function addCurrencyToOnlineUsers(currencyId, value, ignoreDisable = false, adjustType = "adjust") {
     return new Promise((resolve, reject) => {
         if (!isViewerDBOn()) {
             return reject();
@@ -183,7 +196,7 @@ function addCurrencyToOnlineUsers(currencyId, value, ignoreDisable = false) {
             // Do the loop!
             for (let user of docs) {
                 if (user != null && (ignoreDisable || !user.disableAutoStatAccrual)) {
-                    adjustCurrency(user, currencyId, value);
+                    adjustCurrency(user, currencyId, value, adjustType);
                 }
             }
             return resolve();

--- a/backend/effects/builtin/currency.js
+++ b/backend/effects/builtin/currency.js
@@ -98,6 +98,13 @@ const currency = {
                                 <div class="control__indicator"></div>
                             </label>
                         </div>
+                        <div style="margin-bottom: 10px;">
+                            <div style="font-size: 16px;font-weight: 900;color: #b9b9b9;font-family: 'Quicksand';margin-bottom: 5px;">Firebot</div>
+                            <label ng-repeat="firebotRole in getFirebotRoles()" class="control-fb control--checkbox">{{firebotRole.name}}
+                                <input type="checkbox" ng-click="toggleRole(firebotRole)" ng-checked="isRoleChecked(firebotRole)"  aria-label="..." >
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
                         <div style="font-size: 16px;font-weight: 900;color: #b9b9b9;font-family: 'Quicksand';margin-bottom: 5px;">Mixer</div>
                         <label ng-repeat="mixerRole in getMixerRoles()" class="control-fb control--checkbox">{{mixerRole.name}}
                             <input type="checkbox" ng-click="toggleRole(mixerRole)" ng-checked="isRoleChecked(mixerRole)"  aria-label="..." >
@@ -170,6 +177,7 @@ const currency = {
 
         $scope.hasCustomRoles = viewerRolesService.getCustomRoles().length > 0;
         $scope.getCustomRoles = viewerRolesService.getCustomRoles;
+        $scope.getFirebotRoles = viewerRolesService.getFirebotRoles;
         $scope.getMixerRoles = viewerRolesService.getMixerRoles;
 
         $scope.isRoleChecked = function(role) {

--- a/backend/effects/builtin/currency.js
+++ b/backend/effects/builtin/currency.js
@@ -64,6 +64,9 @@ const currency = {
                     <li ng-click="effect.action = 'Remove'">
                         <a href>Remove</a>
                     </li>
+                    <li ng-click="effect.action = 'Set'">
+                        <a href>Set</a>
+                    </li>
                 </ul>
             </div>
         </eos-container>
@@ -215,7 +218,7 @@ const currency = {
 
             // What should this do when triggered.
             let userTarget = event.effect.userTarget;
-
+            let adjustType = event.effect.action;
             let amount = event.effect.amount;
 
             if (isNaN(amount)) {
@@ -224,10 +227,7 @@ const currency = {
 
 
             // If "Remove" make number negative, otherwise just use number.
-            let currency =
-        event.effect.action === "Remove"
-            ? -Math.abs(amount)
-            : Math.abs(amount);
+            let currency = event.effect.action === "Remove" ? -Math.abs(amount) : Math.abs(amount);
 
             // PEOPLE GONNA GET PAID
             switch (event.effect.target) {
@@ -236,7 +236,8 @@ const currency = {
                 await currencyDatabase.adjustCurrencyForUser(
                     userTarget,
                     event.effect.currency,
-                    currency
+                    currency,
+                    adjustType
                 );
                 break;
             case "allOnline":
@@ -244,7 +245,8 @@ const currency = {
                 await currencyDatabase.addCurrencyToOnlineUsers(
                     event.effect.currency,
                     currency,
-                    true
+                    true,
+                    adjustType
                 );
                 break;
             case "group":
@@ -253,7 +255,8 @@ const currency = {
                     event.effect.roleIds,
                     event.effect.currency,
                     currency,
-                    true
+                    true,
+                    adjustType
                 );
                 break;
             default:

--- a/backend/restrictions/builtin/activeChatUsers.js
+++ b/backend/restrictions/builtin/activeChatUsers.js
@@ -25,18 +25,10 @@ const model = {
     */
     predicate: (triggerData, restrictionData) => {
         return new Promise(async (resolve, reject) => {
-            let passed = false;
             let activeChatter = require('../../../backend/chat/active-chatters');
-            let activeChatList = activeChatter.getActiveChatters();
             let username = triggerData.metadata.username;
 
-            let newActiveUserArray = activeChatList.filter(chatter => chatter.username === username);
-
-            if (newActiveUserArray.length > 0) {
-                passed = true;
-            }
-
-            if (passed) {
+            if (activeChatter.isUsernameActiveChatter(username)) {
                 resolve();
             } else {
                 reject("You haven't sent a chat message recently");

--- a/backend/roles/firebot-roles-manager.js
+++ b/backend/roles/firebot-roles-manager.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const logger = require("../logwrapper");
+const firebotRoles = require("../../shared/firebot-roles");
+const activeChatters = require("../chat/active-chatters");
+
+function userIsInFirebotRole(role, username) {
+    switch (role.id) {
+    case "ActiveChatters":
+        return activeChatters.isUsernameActiveChatter(username);
+    default:
+        return false;
+    }
+}
+
+function getAllFirebotRolesForViewer(username) {
+    const roles = firebotRoles.getFirebotRoles();
+    return roles
+        .filter(r => userIsInFirebotRole(r, username) !== false)
+        .map(r => {
+            return {
+                id: r.id,
+                name: r.name
+            };
+        });
+}
+
+exports.getAllFirebotRolesForViewer = getAllFirebotRolesForViewer;
+
+
+
+
+
+
+
+
+
+

--- a/gui/app/services/viewerRolesService.js
+++ b/gui/app/services/viewerRolesService.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const mixerRoleConstants = require("../../shared/mixer-roles");
+const firebotRoleConstants = require("../../shared/firebot-roles");
 
 (function() {
 
@@ -68,13 +69,18 @@ const mixerRoleConstants = require("../../shared/mixer-roles");
                 backendCommunicator.fireEvent("deleteCustomRole", roleId);
             };
 
+            const firebotRoles = firebotRoleConstants.getFirebotRoles();
+            service.getFirebotRoles = function() {
+                return firebotRoles;
+            };
+
             const mixerRoles = mixerRoleConstants.getMixerRoles();
             service.getMixerRoles = function() {
                 return mixerRoles;
             };
 
             service.getAllRoles = () => {
-                return service.getMixerRoles().concat(service.getCustomRoles());
+                return service.getMixerRoles().concat(service.getFirebotRoles()).concat(service.getCustomRoles());
             };
 
             service.getRoleById = function(id) {

--- a/gui/app/templates/_viewerroles.html
+++ b/gui/app/templates/_viewerroles.html
@@ -20,6 +20,20 @@
     <p ng-if="viewerRolesService.getCustomRoles().length < 1" class="muted">No custom roles saved.</p>
 </div>
 
+<h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Firebot Roles</h3>
+<p class="muted">These roles are predefined by Firebot and cannot be edited.</p>
+<div class="new-tile-grid" style="width: 100%">
+    <div ng-repeat="role in viewerRolesService.getFirebotRoles() track by $index" class="new-tile gray centered">
+        <div class="content row">
+            <div class="detail-wrapper nomargin">
+                <div class="detail" style="font-size: 1.6em;">
+                    {{role.name}}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 
 <h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Mixer Roles</h3>
 <p class="muted">These roles are predefined by Mixer and cannot be edited.</p>

--- a/gui/app/templates/_viewerroles.html
+++ b/gui/app/templates/_viewerroles.html
@@ -20,10 +20,10 @@
     <p ng-if="viewerRolesService.getCustomRoles().length < 1" class="muted">No custom roles saved.</p>
 </div>
 
-<h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Firebot Roles</h3>
-<p class="muted">These roles are predefined by Firebot and cannot be edited.</p>
+<h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Mixer Roles</h3>
+<p class="muted">These roles are predefined by Mixer and cannot be edited.</p>
 <div class="new-tile-grid" style="width: 100%">
-    <div ng-repeat="role in viewerRolesService.getFirebotRoles() track by $index" class="new-tile gray centered">
+    <div ng-repeat="role in viewerRolesService.getMixerRoles() track by $index" class="new-tile gray centered">
         <div class="content row">
             <div class="detail-wrapper nomargin">
                 <div class="detail" style="font-size: 1.6em;">
@@ -34,11 +34,10 @@
     </div>
 </div>
 
-
-<h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Mixer Roles</h3>
-<p class="muted">These roles are predefined by Mixer and cannot be edited.</p>
+<h3 style="text-transform: uppercase;font-weight: 200;font-size: 19px;margin-top:30px;">Firebot Roles</h3>
+<p class="muted">These roles are predefined by Firebot and cannot be edited.</p>
 <div class="new-tile-grid" style="width: 100%">
-    <div ng-repeat="role in viewerRolesService.getMixerRoles() track by $index" class="new-tile gray centered">
+    <div ng-repeat="role in viewerRolesService.getFirebotRoles() track by $index" class="new-tile gray centered">
         <div class="content row">
             <div class="detail-wrapper nomargin">
                 <div class="detail" style="font-size: 1.6em;">

--- a/shared/firebot-roles.js
+++ b/shared/firebot-roles.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const firebotRoles = [
+    {
+        id: "ActiveChatters",
+        name: "Active Chatters"
+    }
+];
+
+exports.getFirebotRoles = () => firebotRoles;
+


### PR DESCRIPTION
Changes:
- Set up active chatter as a "Firebot Role".
- Add Firebot Roles to the bonus currency area on the create/edit currency modal.
- Add Firebot Roles to the currency effect "role" option.
- Show Firebot Roles on the Viewer Roles screen.
- Add "Set" option to currency effect that will just set the currency to a specific value.
- Create isActiveChatterUsername function to see if a specific person is active.
- Cleaned up areas to use the isActiveChatterUsername function.

Notes:
- We already have "Active Viewers" as a filter. So, I left Firebot Roles out of the "permissions" filter. If we add more Firebot Roles later on that we want to show in the permissions area, we might need to figure out that problem. Probably "Active Viewers" would just map to that Firebot Role or something.

