### PR TITLE
Add ability to remove users from activeViewerList.

### DIFF
--- a/backend/chat/active-chatters.js
+++ b/backend/chat/active-chatters.js
@@ -25,18 +25,17 @@ function isUsernameActiveChatter(username) {
     return false;
 }
 
-function addOrUpdateActiveChatter(user) {
+async function addOrUpdateActiveChatter(user) {
     if (!activeUserListStatus) {
         return;
     }
 
     // Stop early if user shouldn't be in active chatter list.
-    userDatabase.getUserByUsername(user.user_name).then(userDB => {
-        if (userDB.disableActiveUserList) {
-            logger.debug(userDB.username + " is set to not join the active viewer list.");
-            return;
-        }
-    });
+    let userDB = await userDatabase.getUserByUsername(user.user_name);
+    if (userDB.disableActiveUserList) {
+        logger.debug(userDB.username + " is set to not join the active viewer list.");
+        return;
+    }
 
     // User should be okay, add them!
     let date = new Date;

--- a/backend/chat/active-chatters.js
+++ b/backend/chat/active-chatters.js
@@ -3,6 +3,7 @@
 const { ipcMain } = require("electron");
 const settings = require("../common/settings-access").settings;
 const logger = require("../logwrapper");
+const userDatabase = require("../database/userDatabase");
 const Chat = require("../common/mixer-chat");
 
 // Active user toggle
@@ -29,6 +30,15 @@ function addOrUpdateActiveChatter(user) {
         return;
     }
 
+    // Stop early if user shouldn't be in active chatter list.
+    userDatabase.getUserByUsername(user.user_name).then(userDB => {
+        if (userDB.disableActiveUserList) {
+            logger.debug(userDB.username + " is set to not join the active viewer list.");
+            return;
+        }
+    });
+
+    // User should be okay, add them!
     let date = new Date;
     let currentTime = date.getTime();
 

--- a/backend/database/userDatabase.js
+++ b/backend/database/userDatabase.js
@@ -205,6 +205,7 @@ function createNewUser(userId, username, channelRoles, isOnline = false) {
             mixplayInteractions: 0,
             chatMessages: 0,
             disableAutoStatAccrual: disableAutoStatAccrual,
+            disableActiveUserList: false,
             currency: {},
             ranks: {}
         };

--- a/gui/app/directives/modals/viewers/viewerDetailsModal.js
+++ b/gui/app/directives/modals/viewers/viewerDetailsModal.js
@@ -57,6 +57,13 @@
                             </label>
                         </div>
 
+                        <div ng-show="$ctrl.hasFirebotData" style="margin-top:20px; margin-bottom: 30px;">
+                            <label class="control-fb control--checkbox"> Don't allow on active user lists <tooltip text="'Prevent the user from showing up in active user lists, such as the $randomActiveViewer variable."></tooltip>
+                                <input type="checkbox" ng-model="$ctrl.viewerDetails.firebotData.disableActiveUserList" ng-change="$ctrl.disableActiveUserList()">
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
+
                         <div ng-hide="$ctrl.hasFirebotData" style="padding: left: 15px;">
                             <p class="muted">There is no Firebot data saved for this Mixer user.</p>
                             <button type="button" class="btn btn-default" ng-click="$ctrl.saveUser()">Save User in Firebot</button>
@@ -373,6 +380,14 @@
                         userId: $ctrl.resolve.userId,
                         field: "disableAutoStatAccrual",
                         value: $ctrl.viewerDetails.firebotData.disableAutoStatAccrual
+                    });
+                };
+
+                $ctrl.disableActiveUserList = () => {
+                    backendCommunicator.fireEvent("updateViewerDataField", {
+                        userId: $ctrl.resolve.userId,
+                        field: "disableActiveUserList",
+                        value: $ctrl.viewerDetails.firebotData.disableActiveUserList
                     });
                 };
 

--- a/gui/app/directives/modals/viewers/viewerDetailsModal.js
+++ b/gui/app/directives/modals/viewers/viewerDetailsModal.js
@@ -59,7 +59,7 @@
 
                         <div ng-show="$ctrl.hasFirebotData" style="margin-top:20px; margin-bottom: 30px;">
                             <label class="control-fb control--checkbox"> Don't allow on active user lists <tooltip text="'Prevent the user from showing up in active user lists, such as the $randomActiveViewer variable."></tooltip>
-                                <input type="checkbox" ng-model="$ctrl.viewerDetails.firebotData.disableActiveUserList" ng-change="$ctrl.disableActiveUserList()">
+                                <input type="checkbox" ng-model="$ctrl.viewerDetails.firebotData.disableActiveUserList" ng-change="$ctrl.disableActiveUserListChange()">
                                 <div class="control__indicator"></div>
                             </label>
                         </div>
@@ -383,7 +383,7 @@
                     });
                 };
 
-                $ctrl.disableActiveUserList = () => {
+                $ctrl.disableActiveUserListChange = () => {
                     backendCommunicator.fireEvent("updateViewerDataField", {
                         userId: $ctrl.resolve.userId,
                         field: "disableActiveUserList",


### PR DESCRIPTION
This puts a toggle into the viewer modal that will allow people to exempt certain users from the "Active Viewers" list. This will allow people to exclude their bots from things like the $randomActiveViewer variables.

If we decide to put in a separate $randomActiveMixplay variable for mixplay connections, this same toggle could exempt from that as well.