### PR TITLE
V5 cooldown effect updates

### DIFF
--- a/backend/effects/builtin/cooldowns.js
+++ b/backend/effects/builtin/cooldowns.js
@@ -35,43 +35,51 @@ const cooldown = {
         </eos-container>
 
         <div ng-show="effect.mixplayProject">
-            <eos-container header="Controls To Cooldown" pad-top="true">
-                <div style="display:flex; justify-content: space-between; align-items: center;">
-                    <div class="searchbar-wrapper">
-                        <input type="text" class="form-control" placeholder="Search controls..." ng-model="controlSearch" style="padding-left: 27px;">
-                        <span class="searchbar-icon"><i class="far fa-search"></i></span>
+            <eos-container header="What do you want to cooldown?" pad-top="true">
+                <dropdown-select options="{button: 'Button(s)', group: 'Cooldown Group'}" tooltip-append-to-body="true" selected="effect.cooldownTarget"></dropdown-select>
+            </eos-container>
+        </div>
+
+        <div ng-show="effect.cooldownTarget != null">
+            <eos-container header="Cooldown Type" pad-top="true" ng-show="effect.mixplayProject && effect.cooldownTarget != null">
+                <dropdown-select options="cooldownTypes" tooltip-append-to-body="true" selected="effect.cooldownType"></dropdown-select>
+            </eos-container>
+        </div>
+
+        <div ng-show="effect.cooldownType != null && effect.cooldownType !== 'clearAll'">
+            <div ng-show="effect.cooldownTarget === 'button' && effect.cooldownType != null">
+                <eos-container header="Controls To Cooldown" pad-top="true">
+                    <div style="display:flex; justify-content: space-between; align-items: center;">
+                        <div class="searchbar-wrapper">
+                            <input type="text" class="form-control" placeholder="Search controls..." ng-model="controlSearch" style="padding-left: 27px;">
+                            <span class="searchbar-icon"><i class="far fa-search"></i></span>
+                        </div>
+                        <div class="cooldown-group-button-reset">
+                            <button class="btn btn-default" ng-click="unselectAllControls()">Uncheck all</button>
+                        </div>
                     </div>
-                    <div class="cooldown-group-button-reset">
-                        <button class="btn btn-default" ng-click="unselectAllControls()">Uncheck all</button>
+                    <div class="cooldown-group-buttons">
+                        <div ng-repeat="controlData in availableControlData | filter:controlSearch track by controlData.controlId" class="cooldown-list-btn-wrapper">
+                            <label class="control-fb control--checkbox" style="margin-bottom: 0">{{controlData.controlName}} <span class="muted" style="font-size:12px;">(Scene: <b>{{controlData.sceneName}}</b>)</span>
+                                <input type="checkbox" ng-click="toggleControlSelected(controlData.controlId)" ng-checked="controlIsSelected(controlData.controlId)"/>
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
                     </div>
-                </div>
-                <div class="cooldown-group-buttons">
-                    <div ng-repeat="controlData in availableControlData | filter:controlSearch track by controlData.controlId" class="cooldown-list-btn-wrapper">
-                        <label class="control-fb control--checkbox" style="margin-bottom: 0">{{controlData.controlName}} <span class="muted" style="font-size:12px;">(Scene: <b>{{controlData.sceneName}}</b>)</span>
-                            <input type="checkbox" ng-click="toggleControlSelected(controlData.controlId)" ng-checked="controlIsSelected(controlData.controlId)"/>
+                </eos-container>
+            </div>
+
+            <eos-container header="Cooldown Duration" pad-top="true" ng-show="effect.cooldownType != null">
+                    <div class="input-group">
+                        <span class="input-group-addon" id="cooldown-amount-effect-type">Seconds</span>
+                        <input ng-model="effect.duration" type="text" class="form-control" id="cooldown-amount-setting" aria-describedby="cooldown-amount-effect-type" replace-variables>
+                    </div>
+                    <div style="padding-top: 10px;">
+                        <label class="control-fb control--checkbox"> Never Override Current Cooldown <tooltip text="'If unchecked, current cooldowns will only be overridden if this new cooldown is longer.'"></tooltip>
+                            <input type="checkbox" ng-model="effect.neverOverride">
                             <div class="control__indicator"></div>
                         </label>
                     </div>
-                </div>
-            </eos-container>
-
-            <eos-container header="Cooldown Duration" pad-top="true">
-                <div class="input-group">
-                    <span class="input-group-addon" id="cooldown-amount-effect-type">Seconds</span>
-                    <input ng-model="effect.duration" type="text" class="form-control" id="cooldown-amount-setting" aria-describedby="cooldown-amount-effect-type" replace-variables>
-                </div>
-                <div style="padding-top: 10px;">
-                    <label class="control-fb control--checkbox"> Never Override Current Cooldown <tooltip text="'If unchecked, current cooldowns will only be overridden if this new cooldown is longer.'"></tooltip>
-                        <input type="checkbox" ng-model="effect.neverOverride">
-                        <div class="control__indicator"></div>
-                    </label>
-                </div>
-            </eos-container>
-
-            <eos-container>
-                <div class="effect-info alert alert-info">
-                    If you want to cool down a lot of buttons at the same time, try Cooldown Groups located in the Controls tab.
-                </div>
             </eos-container>
         </div>
     `,
@@ -117,6 +125,15 @@ const cooldown = {
                 $scope.effect.mixplayProject = null;
             }
         }
+
+        $scope.cooldownTypes = {
+            setIfLonger: "Set if new cooldown is longer",
+            setIfShorter: "Set if new cooldown is shorter",
+            addCooldown: "Add on to current cooldown",
+            subtractCooldown: "Subtract from current cooldown",
+            override: "Override current cooldown",
+            clearAll: "Clear all cooldowns"
+        };
 
         $scope.getTooltip = function() {
             return $scope.disableProjectDropdown ? "You can only create cooldowns for the current project when adding to a control." : "";

--- a/backend/effects/builtin/cooldowns.js
+++ b/backend/effects/builtin/cooldowns.js
@@ -41,13 +41,19 @@ const cooldown = {
         </div>
 
         <div ng-show="effect.cooldownTarget != null">
-            <eos-container header="Cooldown Type" pad-top="true" ng-show="effect.mixplayProject && effect.cooldownTarget != null">
+            <eos-container header="Cooldown Type" pad-top="true" ng-show="effect.cooldownTarget != null">
                 <dropdown-select options="cooldownTypes" tooltip-append-to-body="true" selected="effect.cooldownType"></dropdown-select>
             </eos-container>
         </div>
 
-        <div ng-show="effect.cooldownType != null && effect.cooldownType !== 'clearAll'">
-            <div ng-show="effect.cooldownTarget === 'button' && effect.cooldownType != null">
+        <div ng-show="effect.cooldownType === 'update'">
+            <eos-container header="Update Type" pad-top="true" ng-show="effect.cooldownType != null">
+                <dropdown-select options="updateTypes" tooltip-append-to-body="true" selected="effect.updateType"></dropdown-select>
+            </eos-container>
+        </div>
+
+        <div ng-show="effect.cooldownType != null">
+            <div ng-show="effect.cooldownTarget === 'button'">
                 <eos-container header="Controls To Cooldown" pad-top="true">
                     <div style="display:flex; justify-content: space-between; align-items: center;">
                         <div class="searchbar-wrapper">
@@ -69,16 +75,32 @@ const cooldown = {
                 </eos-container>
             </div>
 
+            <div ng-show="effect.cooldownTarget === 'group'">
+                <eos-container header="Cooldown Groups To Cooldown" pad-top="true">
+                    <div style="display:flex; justify-content: space-between; align-items: center;">
+                        <div class="searchbar-wrapper">
+                            <input type="text" class="form-control" placeholder="Search groups..." ng-model="groupSearch" style="padding-left: 27px;">
+                            <span class="searchbar-icon"><i class="far fa-search"></i></span>
+                        </div>
+                        <div class="cooldown-group-button-reset">
+                            <button class="btn btn-default" ng-click="unselectAllGroups()">Uncheck all</button>
+                        </div>
+                    </div>
+                    <div class="cooldown-group-buttons">
+                        <div ng-repeat="groupData in availableGroupData | filter:groupSearch track by groupData.id" class="cooldown-list-btn-wrapper">
+                            <label class="control-fb control--checkbox" style="margin-bottom: 0">{{groupData.name}} <span class="muted" style="font-size:12px;">(Buttons: <b>{{groupData.controlIds.length}}</b>)</span>
+                                <input type="checkbox" ng-click="toggleGroupSelected(groupData.id)" ng-checked="groupIsSelected(groupData.id)"/>
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
+                    </div>
+                </eos-container>
+            </div>
+
             <eos-container header="Cooldown Duration" pad-top="true" ng-show="effect.cooldownType != null">
                     <div class="input-group">
                         <span class="input-group-addon" id="cooldown-amount-effect-type">Seconds</span>
                         <input ng-model="effect.duration" type="text" class="form-control" id="cooldown-amount-setting" aria-describedby="cooldown-amount-effect-type" replace-variables>
-                    </div>
-                    <div style="padding-top: 10px;">
-                        <label class="control-fb control--checkbox"> Never Override Current Cooldown <tooltip text="'If unchecked, current cooldowns will only be overridden if this new cooldown is longer.'"></tooltip>
-                            <input type="checkbox" ng-model="effect.neverOverride">
-                            <div class="control__indicator"></div>
-                        </label>
                     </div>
             </eos-container>
         </div>
@@ -94,6 +116,22 @@ const cooldown = {
             $scope.effect.controlIds = [];
         }
 
+        if (!$scope.effect.groupIds) {
+            $scope.effect.groupIds = [];
+        }
+
+        $scope.cooldownTypes = {
+            update: "Update",
+            add: "Add",
+            subtract: "Subtract"
+        };
+
+        $scope.updateTypes = {
+            longer: "Only if longer",
+            shorter: "Only if shorter",
+            always: "Always update"
+        };
+
         $scope.toggleControlSelected = function(controlId) {
             if ($scope.controlIsSelected(controlId)) {
                 $scope.effect.controlIds = $scope.effect.controlIds.filter(c => c !== controlId);
@@ -102,12 +140,28 @@ const cooldown = {
             }
         };
 
+        $scope.toggleGroupSelected = function(groupId) {
+            if ($scope.groupIsSelected(groupId)) {
+                $scope.effect.groupIds = $scope.effect.groupIds.filter(g => g !== groupId);
+            } else {
+                $scope.effect.groupIds.push(groupId);
+            }
+        };
+
         $scope.controlIsSelected = function(controlId) {
             return $scope.effect.controlIds.includes(controlId);
         };
 
+        $scope.groupIsSelected = function(groupId) {
+            return $scope.effect.groupIds.includes(groupId);
+        };
+
         $scope.unselectAllControls = function() {
             $scope.effect.controlIds = [];
+        };
+
+        $scope.unselectAllGroups = function() {
+            $scope.effect.groupIds = [];
         };
 
         $scope.hasProjects = false;
@@ -125,15 +179,6 @@ const cooldown = {
                 $scope.effect.mixplayProject = null;
             }
         }
-
-        $scope.cooldownTypes = {
-            setIfLonger: "Set if new cooldown is longer",
-            setIfShorter: "Set if new cooldown is shorter",
-            addCooldown: "Add on to current cooldown",
-            subtractCooldown: "Subtract from current cooldown",
-            override: "Override current cooldown",
-            clearAll: "Clear all cooldowns"
-        };
 
         $scope.getTooltip = function() {
             return $scope.disableProjectDropdown ? "You can only create cooldowns for the current project when adding to a control." : "";
@@ -160,8 +205,19 @@ const cooldown = {
         }
         getControlData();
 
+        $scope.availableGroupData = [];
+        function getGroupData() {
+            if ($scope.effect.mixplayProject) {
+                let currentProject = mixplayService.getCurrentProject();
+                $scope.availableGroupData = currentProject.cooldownGroups
+                    .filter(group => group.active === true);
+            }
+        }
+        getGroupData();
+
         $scope.onProjectUpdate = function() {
             getControlData();
+            getGroupData();
         };
 
     },
@@ -174,6 +230,11 @@ const cooldown = {
         if (effect.duration == null) {
             errors.push("Please input a cooldown time.");
         }
+
+        if (effect.updateType == null) {
+            errors.push("Please select an update type.");
+        }
+
         return errors;
     },
     /**
@@ -182,9 +243,34 @@ const cooldown = {
     onTriggerEvent: event => {
         return new Promise((resolve) => {
             const effect = event.effect;
+            let cooldownIds = [];
 
-            if (effect.controlIds && effect.controlIds.length > 0) {
-                cooldownManager.cooldownControls(effect.controlIds, effect.duration, effect.neverOverride);
+            if (effect.cooldownTarget === 'group') {
+                cooldownIds = effect.groupIds;
+            } else {
+                cooldownIds = effect.controlIds;
+            }
+
+            if (effect.cooldownType === 'update') {
+                // Update cooldowns
+                cooldownManager.advancedUpdate({
+                    target: effect.cooldownTarget,
+                    ids: cooldownIds,
+                    type: effect.updateType,
+                    duration: effect.duration
+                });
+                resolve(true);
+            }
+
+            if (effect.cooldownType === 'add' || effect.cooldownType === 'subtract') {
+                // Math cooldowns
+                cooldownManager.mathUpdate({
+                    target: effect.cooldownTarget,
+                    ids: cooldownIds,
+                    type: effect.cooldownType,
+                    duration: effect.duration
+                });
+                resolve(true);
             }
 
             resolve(true);

--- a/backend/effects/builtin/cooldowns.js
+++ b/backend/effects/builtin/cooldowns.js
@@ -120,6 +120,17 @@ const cooldown = {
             $scope.effect.groupIds = [];
         }
 
+        // Cooldown revamp bridge
+        if (!$scope.effect.cooldownTarget) {
+            $scope.effect.cooldownTarget = 'button';
+        }
+        if (!$scope.effect.cooldownType) {
+            $scope.effect.cooldownType = 'update';
+        }
+        if (!$scope.effect.updateType) {
+            $scope.effect.updateType = 'longer';
+        }
+
         $scope.cooldownTypes = {
             update: "Update",
             add: "Add",

--- a/backend/effects/builtin/cooldowns.js
+++ b/backend/effects/builtin/cooldowns.js
@@ -231,7 +231,7 @@ const cooldown = {
             errors.push("Please input a cooldown time.");
         }
 
-        if (effect.updateType == null) {
+        if (effect.cooldownType === "update" && effect.updateType == null) {
             errors.push("Please select an update type.");
         }
 

--- a/backend/effects/builtin/cooldowns.js
+++ b/backend/effects/builtin/cooldowns.js
@@ -245,6 +245,17 @@ const cooldown = {
             const effect = event.effect;
             let cooldownIds = [];
 
+            // Cooldown revamp bridge
+            if (effect.cooldownTarget == null) {
+                effect.cooldownTarget = 'button';
+            }
+            if (effect.cooldownType == null) {
+                effect.cooldownType = 'update';
+            }
+            if (effect.updateType == null) {
+                effect.updateType = 'longer';
+            }
+
             if (effect.cooldownTarget === 'group') {
                 cooldownIds = effect.groupIds;
             } else {
@@ -252,7 +263,6 @@ const cooldown = {
             }
 
             if (effect.cooldownType === 'update') {
-                // Update cooldowns
                 cooldownManager.advancedUpdate({
                     target: effect.cooldownTarget,
                     ids: cooldownIds,
@@ -263,7 +273,6 @@ const cooldown = {
             }
 
             if (effect.cooldownType === 'add' || effect.cooldownType === 'subtract') {
-                // Math cooldowns
                 cooldownManager.mathUpdate({
                     target: effect.cooldownTarget,
                     ids: cooldownIds,

--- a/backend/interactive/control-manager.js
+++ b/backend/interactive/control-manager.js
@@ -97,7 +97,7 @@ async function handleInput(inputType, sceneId, inputEvent, participant) {
     // Handle any cooldowns
     if (control.kind === "button" || control.kind === "textbox") {
         if (inputType !== "mouseup" && inputType !== "keyup") {
-            const alreadyOnCooldown = cooldownManager.handleControlCooldown(control);
+            const alreadyOnCooldown = await cooldownManager.handleControlCooldown(control);
             if (alreadyOnCooldown) {
                 logger.info("Control " + control.id + " is still on cooldown. Ignoring press.");
                 return;

--- a/backend/interactive/mixplay.js
+++ b/backend/interactive/mixplay.js
@@ -323,20 +323,26 @@ function moveAllViewersToScene(newSceneId) {
     }
 }
 
-function updateCooldownForControls(controlIds, cooldown) {
+async function updateCooldownForControls(controlIds, cooldown) {
+    let promises = [];
+
     for (let controlId of controlIds) {
         try {
             let control = mixplayClient.state.getControl(controlId);
             if (control) {
-                control.update({
-                    cooldown: cooldown
-                });
+                promises.push(
+                    control.update({
+                        cooldown: cooldown
+                    })
+                );
             }
         } catch (err) {
             // something weird happened
             logger.debug("Error when cooling down control", err);
         }
     }
+
+    return Promise.all(promises);
 }
 
 async function updateParticipantWithData(userId, data, participant = null) {


### PR DESCRIPTION
Changes:
- Add ability to cooldown buttons or cooldown groups.
- Add options for updating, adding, or subtracting to cooldown.
-- Updating allows for force updating, updating if new cooldown is longer, or updating if new cooldown is shorter.
-- Adding and subtracting to the current cooldown time.
- This has fallback for "old" cooldown effects and will default to cooling down buttons if the cooldown is longer than the current cooldown.
- Makes cooldowns async.

Testing:
- Individual cooldown set on button itself: OK
- Cooldown groups: OK
- Individual cooldown set on button AND button in cooldown group: OK
- Button in cooldown group AND button has cooldown effect that targets itself: OK
- Button has individual cooldown, cooldown group, and effect that targets self: OK
- Button is in cooldown group, and has effect that targets the same cooldown group: OK
- Cooldown button, then use command to update, add, and subtract with cooldown effect: OK

Possible issues:
This messes with the main cooldown functions to make them async. So, this could mess up cooldowns but I've tested quite a bit and it seems okay.