### PR TITLE
V5 mixplay active users

### DIFF
--- a/backend/common/mixer-chat.js
+++ b/backend/common/mixer-chat.js
@@ -20,7 +20,7 @@ const apiAccess = require("../api-access");
 let linkHeaderParser = require('parse-link-header');
 const timerManager = require("../timers/timer-manager");
 const emotesManager = require("./emotes-manager");
-const activeChatter = require('../chat/active-chatters');
+const activeChatter = require('../roles/role-managers/active-chatters');
 
 const chatModerationManager = require("../chat/moderation/chat-moderation-manager");
 

--- a/backend/common/settings-access.js
+++ b/backend/common/settings-access.js
@@ -184,6 +184,16 @@ settings.getActiveChatUserListTimeout = function() {
     return inactiveTimer != null ? parseInt(inactiveTimer) : 10;
 };
 
+settings.getActiveMixplayUserList = function() {
+    let status = getDataFromFile("/settings/activeMixplayUsers/status");
+    return status != null ? status : "On";
+};
+
+settings.getActiveMixplayUserListTimeout = function() {
+    let inactiveTimer = getDataFromFile("/settings/activeMixplayUsers/inactiveTimer");
+    return inactiveTimer != null ? parseInt(inactiveTimer) : 10;
+};
+
 settings.sparkExemptionEnabled = function() {
     let enabled = getDataFromFile('/settings/sparkExemptionEnabled');
     return enabled != null ? enabled : false;

--- a/backend/common/settings-access.js
+++ b/backend/common/settings-access.js
@@ -174,9 +174,9 @@ settings.setMaxBackupCount = function(maxBackupCount) {
     pushDataToFile("/settings/maxBackupCount", maxBackupCount);
 };
 
-settings.getActiveChatUserList = function() {
-    let status = getDataFromFile("/settings/activeChatUsers/status");
-    return status != null ? status : "On";
+settings.getActiveChatUserListEnabled = function() {
+    let enabled = getDataFromFile("/settings/activeChatUsers/status");
+    return enabled != null ? enabled : true;
 };
 
 settings.getActiveChatUserListTimeout = function() {
@@ -184,9 +184,9 @@ settings.getActiveChatUserListTimeout = function() {
     return inactiveTimer != null ? parseInt(inactiveTimer) : 10;
 };
 
-settings.getActiveMixplayUserList = function() {
-    let status = getDataFromFile("/settings/activeMixplayUsers/status");
-    return status != null ? status : "On";
+settings.getActiveMixplayUserListEnabled = function() {
+    let enabled = getDataFromFile("/settings/activeMixplayUsers/status");
+    return enabled !== undefined ? enabled : true;
 };
 
 settings.getActiveMixplayUserListTimeout = function() {

--- a/backend/interactive/control-manager.js
+++ b/backend/interactive/control-manager.js
@@ -1,6 +1,7 @@
 "use strict";
 const mixplayProjectManager = require("./mixplay-project-manager");
 const mixplay = require("./mixplay");
+const activeMixplayUsers = require('../roles/role-managers/active-mixplay-users');
 
 const effectManager = require("../effects/effectManager");
 const effectRunner = require("../common/effect-runner");
@@ -119,12 +120,14 @@ async function handleInput(inputType, sceneId, inputEvent, participant) {
                 }
             };
 
-            // Increment Total Interactions for User in UserDB.
-            if (inputType === "mousedown") {
+            if (inputType === "mousedown" && !participant.anonymous) {
+                // Increment Total Interactions for User in UserDB.
                 userDatabase.incrementDbField(
                     participant.userID,
                     "mixplayInteractions"
                 );
+
+                activeMixplayUsers.addOrUpdateActiveUser(participant);
             }
 
             effectRunner.processEffects(processEffectsRequest).catch(reason => {

--- a/backend/interactive/mixplay.js
+++ b/backend/interactive/mixplay.js
@@ -119,7 +119,9 @@ function addControlHandlers(controls) {
 
             controlManager.handleInput(event, sceneId, inputEvent, participant);
 
-            activeMixplayUsers.addOrUpdateActiveUser(participant);
+            if (participant.anonymous !== true) {
+                activeMixplayUsers.addOrUpdateActiveUser(participant);
+            }
         };
 
         //remove previous listener just in case one exists

--- a/backend/interactive/mixplay.js
+++ b/backend/interactive/mixplay.js
@@ -388,18 +388,9 @@ mixplayClient.state.on('participantJoin', async participant => {
             await updateParticipantWithUserData(firebotUser, participant);
         }
 
-        activeMixplayUsers.addOrUpdateActiveUser(participant.username);
-
         eventManager.triggerEvent("mixer", "user-joined-mixplay", {
             username: participant.username
         });
-    }
-});
-
-mixplayClient.state.on('participantLeave', async participant => {
-    logger.debug(`${participant.username} (${participant.sessionID}) Left`);
-    if (!participant.anonymous) {
-        activeMixplayUsers.removeLeavingUser(participant.username);
     }
 });
 

--- a/backend/interactive/mixplay.js
+++ b/backend/interactive/mixplay.js
@@ -118,10 +118,6 @@ function addControlHandlers(controls) {
             logger.debug(`Control event "${event}" for control "${inputData.controlID}" in scene "${sceneId}"`);
 
             controlManager.handleInput(event, sceneId, inputEvent, participant);
-
-            if (participant.anonymous !== true) {
-                activeMixplayUsers.addOrUpdateActiveUser(participant);
-            }
         };
 
         //remove previous listener just in case one exists
@@ -243,6 +239,8 @@ async function connectToMixplay() {
         eventManager.triggerEvent("firebot", "mixplay-connected", {
             username: "Firebot"
         });
+
+        activeMixplayUsers.cycleActiveMixplayUsers();
 
     } catch (error) {
         logger.warn("Failed to connect to MixPlay", error);
@@ -396,21 +394,12 @@ mixplayClient.state.on('participantJoin', async participant => {
     }
 });
 
-async function getCurrentUsers() {
-    let participantMap = mixplayClient.state.getParticipants();
-    let participants = Array.from(participantMap);
-    let participantNames = [];
+function getConnectedUsernames() {
+    let participants = [...mixplayClient.state.getParticipants().values()];
 
-    for (let user in participants) {
-        if (user != null) {
-            user = participants[user][1];
-            if (user.anonymous !== true) {
-                participantNames.push(user);
-            }
-        }
-    }
-
-    return participantNames;
+    return participants
+        .filter(p => p != null && !p.anonymous)
+        .map(p => p.username);
 }
 
 // checks if this sceneId is set as default and returns "default" if so,
@@ -521,5 +510,5 @@ exports.moveAllViewersToScene = moveAllViewersToScene;
 exports.updateCooldownForControls = updateCooldownForControls;
 exports.updateParticipantWithData = updateParticipantWithData;
 exports.updateParticipantWithUserData = updateParticipantWithUserData;
-exports.getCurrentUsers = getCurrentUsers;
+exports.getConnectedUsernames = getConnectedUsernames;
 

--- a/backend/interactive/mixplay.js
+++ b/backend/interactive/mixplay.js
@@ -119,7 +119,7 @@ function addControlHandlers(controls) {
 
             controlManager.handleInput(event, sceneId, inputEvent, participant);
 
-            activeMixplayUsers.addOrUpdateActiveUser(participant.username);
+            activeMixplayUsers.addOrUpdateActiveUser(participant);
         };
 
         //remove previous listener just in case one exists
@@ -394,6 +394,23 @@ mixplayClient.state.on('participantJoin', async participant => {
     }
 });
 
+async function getCurrentUsers() {
+    let participantMap = mixplayClient.state.getParticipants();
+    let participants = Array.from(participantMap);
+    let participantNames = [];
+
+    for (let user in participants) {
+        if (user != null) {
+            user = participants[user][1];
+            if (user.anonymous !== true) {
+                participantNames.push(user);
+            }
+        }
+    }
+
+    return participantNames;
+}
+
 // checks if this sceneId is set as default and returns "default" if so,
 // otherwise it returns the original scene id
 function translateSceneIdForMixplay(sceneId) {
@@ -502,4 +519,5 @@ exports.moveAllViewersToScene = moveAllViewersToScene;
 exports.updateCooldownForControls = updateCooldownForControls;
 exports.updateParticipantWithData = updateParticipantWithData;
 exports.updateParticipantWithUserData = updateParticipantWithUserData;
+exports.getCurrentUsers = getCurrentUsers;
 

--- a/backend/restrictions/builtin/activeChatUsers.js
+++ b/backend/restrictions/builtin/activeChatUsers.js
@@ -25,7 +25,7 @@ const model = {
     */
     predicate: (triggerData, restrictionData) => {
         return new Promise(async (resolve, reject) => {
-            let activeChatter = require('../../../backend/chat/active-chatters');
+            let activeChatter = require('../../../backend/roles/role-managers/active-chatters');
             let username = triggerData.metadata.username;
 
             if (activeChatter.isUsernameActiveChatter(username)) {

--- a/backend/roles/firebot-roles-manager.js
+++ b/backend/roles/firebot-roles-manager.js
@@ -2,12 +2,16 @@
 
 const logger = require("../logwrapper");
 const firebotRoles = require("../../shared/firebot-roles");
-const activeChatters = require("./role-managers/active-chatters");
+
+const ActiveChatters = require("./role-managers/active-chatters");
+const ActiveMixplayUsers = require('./role-managers/active-mixplay-users');
 
 function userIsInFirebotRole(role, username) {
     switch (role.id) {
     case "ActiveChatters":
-        return activeChatters.isUsernameActiveChatter(username);
+        return ActiveChatters.isUsernameActiveChatter(username);
+    case "ActiveMixplayUsers":
+        return ActiveMixplayUsers.isUsernameActiveUser(username);
     default:
         return false;
     }

--- a/backend/roles/firebot-roles-manager.js
+++ b/backend/roles/firebot-roles-manager.js
@@ -2,7 +2,7 @@
 
 const logger = require("../logwrapper");
 const firebotRoles = require("../../shared/firebot-roles");
-const activeChatters = require("../chat/active-chatters");
+const activeChatters = require("./role-managers/active-chatters");
 
 function userIsInFirebotRole(role, username) {
     switch (role.id) {

--- a/backend/roles/role-managers/active-chatters.js
+++ b/backend/roles/role-managers/active-chatters.js
@@ -102,11 +102,11 @@ ipcMain.on("setActiveChatUserTimeout", function(event, value) {
     logger.debug('Changing active chat user timeout to: ' + value);
 
     // Make sure we have a valid value, then set it.
-    value = parseInt(inactiveTimer);
     if (isNaN(value)) {
-        return 10;
+        inactiveTimer = 10;
+    } else {
+        inactiveTimer = parseInt(value);
     }
-    inactiveTimer = value;
 
     // Restart our timer with the new value.
     cycleActiveChatters();

--- a/backend/roles/role-managers/active-chatters.js
+++ b/backend/roles/role-managers/active-chatters.js
@@ -1,10 +1,10 @@
 "use strict";
 
 const { ipcMain } = require("electron");
-const settings = require("../common/settings-access").settings;
-const logger = require("../logwrapper");
-const userDatabase = require("../database/userDatabase");
-const Chat = require("../common/mixer-chat");
+const settings = require("../../common/settings-access").settings;
+const logger = require("../../logwrapper");
+const userDatabase = require("../../database/userDatabase");
+const Chat = require("../../common/mixer-chat");
 
 // Active user toggle
 let activeUserListStatus = settings.getActiveChatUserList() === false ? false : true;

--- a/backend/roles/role-managers/active-chatters.js
+++ b/backend/roles/role-managers/active-chatters.js
@@ -7,10 +7,10 @@ const userDatabase = require("../../database/userDatabase");
 const Chat = require("../../common/mixer-chat");
 
 // Active user toggle
-let activeUserListStatus = settings.getActiveChatUserList() === false ? false : true;
+let activeUserListStatus = settings.getActiveChatUserListEnabled();
 
 // User Timeout Settings
-let userInactiveTimeSetting = settings.getActiveChatUserListTimeout() != null ? settings.getActiveChatUserListTimeout() : 10;
+let userInactiveTimeSetting = settings.getActiveChatUserListTimeout();
 let inactiveTimer = userInactiveTimeSetting * 60000;
 
 // Timer and chatter list.
@@ -41,7 +41,7 @@ async function addOrUpdateActiveChatter(user) {
     let date = new Date;
     let currentTime = date.getTime();
 
-    let existingUserIndex = activeChatters.findIndex((obj => obj.userId === user.user_id));
+    let existingUserIndex = activeChatters.findIndex(obj => obj.userId === user.user_id);
 
     // If user exists, update their time and stop.
     if (existingUserIndex !== -1) {
@@ -62,18 +62,8 @@ async function addOrUpdateActiveChatter(user) {
 
 function clearInactiveChatters() {
     logger.debug("Clearing inactive people from active chatters list.");
-    let date = new Date;
-    let currentTime = date.getTime();
-    let expiredTime = currentTime - inactiveTimer;
-    for (let userIndex in activeChatters) {
-        if (activeChatters[userIndex] != null) {
-            let user = activeChatters[userIndex];
-            if (user.time <= expiredTime) {
-                logger.debug(user.username + " has gone inactive in chat. Removing them from active chatter list.");
-                activeChatters.splice(userIndex, 1);
-            }
-        }
-    }
+    let expiredTime = new Date().getTime() - inactiveTimer;
+    activeChatters = activeChatters.filter(u => u != null && u.time >= expiredTime);
 }
 
 function getActiveChatters() {
@@ -105,7 +95,7 @@ ipcMain.on("setActiveChatUsers", function(event, value) {
         logger.debug('Stopping active user timeout cycle.');
         clearInterval(cycleActiveTimer);
     }
-    activeUserListStatus = settings.getActiveChatUserList() === false ? false : true;
+    activeUserListStatus = settings.getActiveChatUserListEnabled() ? true : false;
 });
 
 ipcMain.on("setActiveChatUserTimeout", function(event, value) {

--- a/backend/roles/role-managers/active-mixplay-users.js
+++ b/backend/roles/role-managers/active-mixplay-users.js
@@ -110,11 +110,11 @@ ipcMain.on("setActiveMixplayUserTimeout", function(event, value) {
     logger.debug('Changing active mixplay user timeout to: ' + value);
 
     // Make sure we have a valid value, then set it.
-    value = parseInt(inactiveTimer);
     if (isNaN(value)) {
-        return 10;
+        inactiveTimer = 10;
+    } else {
+        inactiveTimer = parseInt(value);
     }
-    inactiveTimer = value;
 
     // Restart our timer with the new value.
     cycleActiveMixplayUsers();

--- a/backend/roles/role-managers/active-mixplay-users.js
+++ b/backend/roles/role-managers/active-mixplay-users.js
@@ -1,0 +1,142 @@
+"use strict";
+
+const { ipcMain } = require("electron");
+const settings = require("../../common/settings-access").settings;
+const logger = require("../../logwrapper");
+const userDatabase = require("../../database/userDatabase");
+const Mixplay = require("../../interactive/mixplay");
+
+// Active user toggle
+let activeUserListStatus = settings.getActiveMixplayUserList() === false ? false : true;
+
+// User Timeout Settings
+let userInactiveTimeSetting = settings.getActiveMixplayUserListTimeout() != null ? settings.getActiveMixplayUserListTimeout() : 10;
+let inactiveTimer = userInactiveTimeSetting * 60000;
+
+// Timer and chatter list.
+let cycleActiveTimer = [];
+let activeMixplayUsers = [];
+
+function isUsernameActiveUser(username) {
+    let existingUserIndex = activeMixplayUsers.findIndex((obj => obj.username === username));
+    if (existingUserIndex !== -1) {
+        return true;
+    }
+    return false;
+}
+
+async function addOrUpdateActiveUser(user) {
+    if (!activeUserListStatus) {
+        return;
+    }
+
+    // Stop early if user shouldn't be in active chatter list.
+    let userDB = await userDatabase.getUserByUsername(user.user_name);
+    if (userDB.disableActiveUserList) {
+        logger.debug(userDB.username + " is set to not join the active mixplay user list.");
+        return;
+    }
+
+    // User should be okay, add them!
+    let date = new Date;
+    let currentTime = date.getTime();
+
+    let existingUserIndex = activeMixplayUsers.findIndex((obj => obj.userId === user.user_id));
+
+    // If user exists, update their time and stop.
+    if (existingUserIndex !== -1) {
+        logger.debug(user.user_name + " is still active in mixplay. Updating their time.");
+        activeMixplayUsers[existingUserIndex].time = currentTime;
+        return;
+    }
+
+    // Else, we're going to push the new user to the active array.
+    logger.debug(user.user_name + " has become active on mixplay. Adding them to active mixplay list.");
+    user = {
+        userId: user.user_id,
+        username: user.user_name,
+        time: currentTime
+    };
+    activeMixplayUsers.push(user);
+}
+
+function removeLeavingUser(username) {
+    for (let userIndex in activeMixplayUsers) {
+        if (activeMixplayUsers[userIndex] != null) {
+            let user = activeMixplayUsers[userIndex];
+            if (user.username === username) {
+                logger.debug(user.username + " has left mixplay. Removing from active mixplay list.");
+                activeMixplayUsers.splice(userIndex, 1);
+            }
+        }
+    }
+}
+
+function clearInactiveUsers() {
+    logger.debug("Clearing inactive people from active mixplay users list.");
+    let date = new Date;
+    let currentTime = date.getTime();
+    let expiredTime = currentTime - inactiveTimer;
+    for (let userIndex in activeMixplayUsers) {
+        if (activeMixplayUsers[userIndex] != null) {
+            let user = activeMixplayUsers[userIndex];
+            if (user.time <= expiredTime) {
+                logger.debug(user.username + " has gone inactive on mixplay. Removing them from active mixplay list.");
+                activeMixplayUsers.splice(userIndex, 1);
+            }
+        }
+    }
+}
+
+function getActiveMixplayUsers() {
+    return activeMixplayUsers;
+}
+
+function cycleActiveMixplayUsers() {
+    let mixplayConnected = Mixplay.mixplayIsConnected;
+    if (!mixplayConnected) {
+        return;
+    }
+
+    logger.info("Starting Active Mixplay Users Loop");
+
+    // Just in case
+    clearInterval(cycleActiveTimer);
+
+    // We have permission to start up the loop now. Let's do this...
+    cycleActiveTimer = setInterval(function() {
+        clearInactiveUsers();
+    }, 60000);
+
+    return;
+}
+
+ipcMain.on("setActiveMixplayUsers", function(event, value) {
+    logger.debug('Changing active mixplay user enabled to: ' + value);
+    if (value === false) {
+        logger.debug('Stopping active mixplay user timeout cycle.');
+        clearInterval(cycleActiveTimer);
+    }
+    activeUserListStatus = settings.getActiveMixplayUserList() === false ? false : true;
+});
+
+ipcMain.on("setActiveMixplayUserTimeout", function(event, value) {
+    logger.debug('Changing active mixplay user timeout to: ' + value);
+
+    // Make sure we have a valid value, then set it.
+    value = parseInt(inactiveTimer);
+    if (isNaN(value)) {
+        return 10;
+    }
+    inactiveTimer = value;
+
+    // Restart our timer with the new value.
+    cycleActiveMixplayUsers();
+});
+
+// Export Functions
+exports.getActiveMixplayUsers = getActiveMixplayUsers;
+exports.addOrUpdateActiveUser = addOrUpdateActiveUser;
+exports.cycleActiveMixplayUsers = cycleActiveMixplayUsers;
+exports.isUsernameActiveUser = isUsernameActiveUser;
+exports.removeLeavingUser = removeLeavingUser;

--- a/backend/roles/role-managers/active-mixplay-users.js
+++ b/backend/roles/role-managers/active-mixplay-users.js
@@ -31,7 +31,7 @@ async function addOrUpdateActiveUser(user) {
     }
 
     // Stop early if user shouldn't be in active chatter list.
-    let userDB = await userDatabase.getUserByUsername(user.user_name);
+    let userDB = await userDatabase.getUserByUsername(user.username);
     if (userDB.disableActiveUserList) {
         logger.debug(userDB.username + " is set to not join the active mixplay user list.");
         return;
@@ -45,16 +45,16 @@ async function addOrUpdateActiveUser(user) {
 
     // If user exists, update their time and stop.
     if (existingUserIndex !== -1) {
-        logger.debug(user.user_name + " is still active in mixplay. Updating their time.");
+        logger.debug(user.username + " is still active in mixplay. Updating their time.");
         activeMixplayUsers[existingUserIndex].time = currentTime;
         return;
     }
 
     // Else, we're going to push the new user to the active array.
-    logger.debug(user.user_name + " has become active on mixplay. Adding them to active mixplay list.");
+    logger.debug(user.username + " has become active on mixplay. Adding them to active mixplay list.");
     user = {
-        userId: user.user_id,
-        username: user.user_name,
+        userId: user.userID,
+        username: user.username,
         time: currentTime
     };
     activeMixplayUsers.push(user);

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -5,6 +5,7 @@ const replaceVariableManager = require("./replace-variable-manager");
 exports.loadReplaceVariables = () => {
     [
         'active-chat-user-count',
+        'active-mixplay-user-count',
         'arg',
         'bot',
         'capitalize',
@@ -46,6 +47,8 @@ exports.loadReplaceVariables = () => {
         'random-active-viewer',
         'random-number',
         'random-viewer',
+        'random-mixplay-user',
+        'random-active-mixplay-user',
         'read-api',
         'read-file',
         'skill-cost',

--- a/backend/variables/builtin/active-chat-user-count.js
+++ b/backend/variables/builtin/active-chat-user-count.js
@@ -1,6 +1,6 @@
 "use strict";
 const logger = require("../../logwrapper");
-const activeViewerHandler = require('../../chat/active-chatters');
+const activeViewerHandler = require('../../roles/role-managers/active-chatters');
 
 const { OutputDataType } = require("../../../shared/variable-contants");
 

--- a/backend/variables/builtin/active-mixplay-user-count.js
+++ b/backend/variables/builtin/active-mixplay-user-count.js
@@ -1,0 +1,26 @@
+"use strict";
+const logger = require("../../logwrapper");
+const activeViewerHandler = require('../../roles/role-managers/active-mixplay-users');
+
+const { OutputDataType } = require("../../../shared/variable-contants");
+
+const model = {
+    definition: {
+        handle: "activeMixplayUserCount",
+        description: "Get the number of active mixplay users.",
+        possibleDataOutput: [OutputDataType.NUMBER]
+    },
+    evaluator: async () => {
+        logger.debug("Getting number of active mixplay users.");
+
+        let activeViewers = activeViewerHandler.getActiveMixplayUsers();
+
+        if (activeViewers && activeViewers.length > 0) {
+            return activeViewers.length;
+        }
+
+        return 0;
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/random-active-mixplay-user.js
+++ b/backend/variables/builtin/random-active-mixplay-user.js
@@ -1,20 +1,20 @@
 "use strict";
 const util = require("../../utility");
 const logger = require("../../logwrapper");
-const activeViewerHandler = require('../../roles/role-managers/active-chatters');
+const activeViewerHandler = require('../../roles/role-managers/active-mixplay-users');
 
 const { OutputDataType } = require("../../../shared/variable-contants");
 
 const model = {
     definition: {
-        handle: "randomActiveViewer",
-        description: "Get a random active viewer in chat.",
+        handle: "randomActiveMixplayUser",
+        description: "Get a random active mixplay user.",
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: async () => {
-        logger.debug("Getting random active viewer...");
+        logger.debug("Getting random active mixplay user...");
 
-        let activeViewers = activeViewerHandler.getActiveChatters();
+        let activeViewers = activeViewerHandler.getActiveMixplayUsers();
 
         if (activeViewers && activeViewers.length > 0) {
             let randIndex = util.getRandomInt(0, activeViewers.length - 1);

--- a/backend/variables/builtin/random-active-viewer.js
+++ b/backend/variables/builtin/random-active-viewer.js
@@ -1,7 +1,7 @@
 "use strict";
 const util = require("../../utility");
 const logger = require("../../logwrapper");
-const activeViewerHandler = require('../../chat/active-chatters');
+const activeViewerHandler = require('../../roles/role-managers/active-chatters');
 
 const { OutputDataType } = require("../../../shared/variable-contants");
 

--- a/backend/variables/builtin/random-mixplay-user.js
+++ b/backend/variables/builtin/random-mixplay-user.js
@@ -1,0 +1,28 @@
+"use strict";
+const mixplay = require("../../interactive/mixplay");
+const util = require("../../utility");
+const logger = require("../../logwrapper");
+
+const { OutputDataType } = require("../../../shared/variable-contants");
+
+const model = {
+    definition: {
+        handle: "randomMixplayUser",
+        description: "Get a random mixplay user.",
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async () => {
+        logger.debug("Getting random mixplay user...");
+
+        let currentUsers = await mixplay.getCurrentUsers();
+
+        if (currentUsers && currentUsers.length > 0) {
+            let randIndex = util.getRandomInt(0, currentUsers.length - 1);
+            return currentUsers[randIndex].username;
+        }
+
+        return "[Unable to get random mixplay user]";
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/random-mixplay-user.js
+++ b/backend/variables/builtin/random-mixplay-user.js
@@ -14,11 +14,11 @@ const model = {
     evaluator: async () => {
         logger.debug("Getting random mixplay user...");
 
-        let currentUsers = await mixplay.getCurrentUsers();
+        let currentUsers = mixplay.getConnectedUsernames();
 
         if (currentUsers && currentUsers.length > 0) {
             let randIndex = util.getRandomInt(0, currentUsers.length - 1);
-            return currentUsers[randIndex].username;
+            return currentUsers[randIndex];
         }
 
         return "[Unable to get random mixplay user]";

--- a/gui/app/controllers/settingsController.js
+++ b/gui/app/controllers/settingsController.js
@@ -184,6 +184,20 @@
                 ipcRenderer.send('setActiveChatUserTimeout', value);
             };
 
+            $scope.setActiveMixplayUsers = (value) => {
+                value = value === true;
+                settingsService.setActiveMixplayUsers(value);
+                ipcRenderer.send("setActiveMixplayUsers", value);
+            };
+
+            $scope.setActiveMixplayUserTimeout = (value) => {
+                if (value == null) {
+                    value = "10";
+                }
+                settingsService.setActiveMixplayUserListTimeout(value);
+                ipcRenderer.send('setActiveMixplayUserTimeout', value);
+            };
+
             $scope.audioOutputDevices = [{
                 label: "System Default",
                 deviceId: "default"

--- a/gui/app/directives/modals/viewers/viewerDetailsModal.js
+++ b/gui/app/directives/modals/viewers/viewerDetailsModal.js
@@ -58,7 +58,7 @@
                         </div>
 
                         <div ng-show="$ctrl.hasFirebotData" style="margin-top:20px; margin-bottom: 30px;">
-                            <label class="control-fb control--checkbox"> Don't allow on active user lists <tooltip text="'Prevent the user from showing up in active user lists, such as the $randomActiveViewer variable."></tooltip>
+                            <label class="control-fb control--checkbox"> Don't allow on active user lists <tooltip text="'Prevent the user from showing up in active user lists, such as the $randomActiveViewer variable.'"></tooltip>
                                 <input type="checkbox" ng-model="$ctrl.viewerDetails.firebotData.disableActiveUserList" ng-change="$ctrl.disableActiveUserListChange()">
                                 <div class="control__indicator"></div>
                             </label>

--- a/gui/app/services/settingsService.js
+++ b/gui/app/services/settingsService.js
@@ -320,6 +320,24 @@
                 pushDataToFile("/settings/activeChatUsers/inactiveTimer", inactiveTimer);
             };
 
+            service.getActiveMixplayUserList = function() {
+                let status = getDataFromFile("/settings/activeMixplayUsers/status");
+                return status != null ? status : "On";
+            };
+
+            service.setActiveMixplayUsers = function(status) {
+                pushDataToFile("/settings/activeMixplayUsers/status", status);
+            };
+
+            service.getActiveMixplayUserListTimeout = function() {
+                let inactiveTimer = getDataFromFile("/settings/activeMixplayUsers/inactiveTimer");
+                return inactiveTimer != null ? inactiveTimer : "10";
+            };
+
+            service.setActiveMixplayUserListTimeout = function(inactiveTimer) {
+                pushDataToFile("/settings/activeMixplayUsers/inactiveTimer", inactiveTimer);
+            };
+
             /*
             * 0 = off,
             * 1 = bugfix,

--- a/gui/app/services/settingsService.js
+++ b/gui/app/services/settingsService.js
@@ -302,9 +302,9 @@
                 pushDataToFile("/settings/sounds", enabled);
             };
 
-            service.getActiveChatUserList = function() {
+            service.getActiveChatUserListEnabled = function() {
                 let status = getDataFromFile("/settings/activeChatUsers/status");
-                return status != null ? status : "On";
+                return status != null ? status : true;
             };
 
             service.setActiveChatUsers = function(status) {
@@ -320,9 +320,9 @@
                 pushDataToFile("/settings/activeChatUsers/inactiveTimer", inactiveTimer);
             };
 
-            service.getActiveMixplayUserList = function() {
+            service.getActiveMixplayUserListEnabled = function() {
                 let status = getDataFromFile("/settings/activeMixplayUsers/status");
-                return status != null ? status : "On";
+                return status != null ? status : true;
             };
 
             service.setActiveMixplayUsers = function(status) {

--- a/gui/app/templates/_settings.html
+++ b/gui/app/templates/_settings.html
@@ -87,24 +87,51 @@
         </uib-tab>
 
         <!-- Interactive Settings -->
-        <!--<uib-tab index="1" heading="MixPlay">
-          <div class="row" style="margin-top: 15px">
-            <div class="setting col-sm-6">
-              <div class="setting-heading">Spark Exemption</div>
-                <div class="setting-description">Enable or disable the spark exemption feature, which lets you specify users or groups who dont get charged sparks.</div>
-                <div class="dropdown options-customscript-dropdown"style="display: inline-block">
-                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                      <span class="dropdown-text">{{settings.sparkExemptionEnabled() ? 'On' : 'Off'}}</span>
-                      <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu" aria-labelledby="options-customscript">
-                      <li><a href ng-click="setSparkExemption(true)">On</a></li>
-                      <li><a href ng-click="setSparkExemption(false)">Off</a></li>
-                    </ul>
-                  </div>
-            </div>
+        <uib-tab index="1" heading="MixPlay">
+          <div class="setting col-sm-6">
+            <div class="setting-heading">Active Mixplay Users List</div>
+              <div class="setting-description">
+                Keep track of active users in the backend for use in variables and other things. Deactivating may slightly improve performance on larger channels.
+              </div>
+              <div class="dropdown options-activeMixplayUserList-dropdown"style="display: inline-block">
+                  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    <span class="dropdown-text">{{settings.getActiveMixplayUserList() ? 'On' : 'Off'}}</span>
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserList">
+                    <li><a href ng-click="setActiveMixplayUsers(true)">On</a></li>
+                    <li><a href ng-click="setActiveMixplayUsers(false)">Off</a></li>
+                  </ul>
+                </div>
           </div>
-        </uib-tab>-->
+          <div class="setting col-sm-6">
+            <div class="setting-heading">Inactive User Time</div>
+              <div class="setting-description">
+                The amount of time it takes for an active user to be marked as inactive after their last mixplay interaction. Doesn't have any affect unless active mixplay user list is on.
+              </div>
+              <div class="dropdown options-activeMixplayUserTimeout-dropdown"style="display: inline-block">
+                  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    <span class="dropdown-text">{{settings.getActiveMixplayUserListTimeout()}}</span>
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserTimeout">
+                    <li><a href ng-click="setActiveMixplayUserTimeout('5')">5</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('10')">10</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('15')">15</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('20')">20</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('25')">25</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('30')">30</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('35')">35</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('40')">40</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('45')">45</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('50')">50</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('55')">55</a></li>
+                    <li><a href ng-click="setActiveMixplayUserTimeout('60')">60</a></li>
+                  </ul>
+                  <span> minutes</span>
+                </div>
+          </div>
+        </uib-tab>
 
         <!-- Chat Settings -->
         <uib-tab index="2" heading="Chat">

--- a/gui/app/templates/_settings.html
+++ b/gui/app/templates/_settings.html
@@ -88,48 +88,50 @@
 
         <!-- Interactive Settings -->
         <uib-tab index="1" heading="MixPlay">
-          <div class="setting col-sm-6">
-            <div class="setting-heading">Active Mixplay Users List</div>
-              <div class="setting-description">
-                Keep track of active users in the backend for use in variables and other things. Deactivating may slightly improve performance on larger channels.
-              </div>
-              <div class="dropdown options-activeMixplayUserList-dropdown"style="display: inline-block">
-                  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                    <span class="dropdown-text">{{settings.getActiveMixplayUserList() ? 'On' : 'Off'}}</span>
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserList">
-                    <li><a href ng-click="setActiveMixplayUsers(true)">On</a></li>
-                    <li><a href ng-click="setActiveMixplayUsers(false)">Off</a></li>
-                  </ul>
+          <div class="row" style="margin-top: 15px">
+            <div class="setting col-sm-6">
+              <div class="setting-heading">Active Mixplay Users List</div>
+                <div class="setting-description">
+                  Keep track of active users in the backend for use in variables and other things. Deactivating may slightly improve performance on larger channels.
                 </div>
-          </div>
-          <div class="setting col-sm-6">
-            <div class="setting-heading">Inactive User Time</div>
-              <div class="setting-description">
-                The amount of time it takes for an active user to be marked as inactive after their last mixplay interaction. Doesn't have any affect unless active mixplay user list is on.
-              </div>
-              <div class="dropdown options-activeMixplayUserTimeout-dropdown"style="display: inline-block">
-                  <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                    <span class="dropdown-text">{{settings.getActiveMixplayUserListTimeout()}}</span>
-                    <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserTimeout">
-                    <li><a href ng-click="setActiveMixplayUserTimeout('5')">5</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('10')">10</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('15')">15</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('20')">20</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('25')">25</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('30')">30</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('35')">35</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('40')">40</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('45')">45</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('50')">50</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('55')">55</a></li>
-                    <li><a href ng-click="setActiveMixplayUserTimeout('60')">60</a></li>
-                  </ul>
-                  <span> minutes</span>
+                <div class="dropdown options-activeMixplayUserList-dropdown"style="display: inline-block">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                      <span class="dropdown-text">{{settings.getActiveMixplayUserListEnabled() ? 'On' : 'Off'}}</span>
+                      <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserList">
+                      <li><a href ng-click="setActiveMixplayUsers(true)">On</a></li>
+                      <li><a href ng-click="setActiveMixplayUsers(false)">Off</a></li>
+                    </ul>
+                  </div>
+            </div>
+            <div class="setting col-sm-6">
+              <div class="setting-heading">Inactive User Time</div>
+                <div class="setting-description">
+                  The amount of time it takes for an active user to be marked as inactive after their last mixplay interaction. Doesn't have any affect unless active mixplay user list is on.
                 </div>
+                <div class="dropdown options-activeMixplayUserTimeout-dropdown"style="display: inline-block">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                      <span class="dropdown-text">{{settings.getActiveMixplayUserListTimeout()}}</span>
+                      <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" aria-labelledby="options-activeMixplayUserTimeout">
+                      <li><a href ng-click="setActiveMixplayUserTimeout('5')">5</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('10')">10</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('15')">15</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('20')">20</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('25')">25</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('30')">30</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('35')">35</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('40')">40</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('45')">45</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('50')">50</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('55')">55</a></li>
+                      <li><a href ng-click="setActiveMixplayUserTimeout('60')">60</a></li>
+                    </ul>
+                    <span> minutes</span>
+                  </div>
+            </div>
           </div>
         </uib-tab>
 
@@ -143,7 +145,7 @@
                 </div>
                 <div class="dropdown options-activeChatUserList-dropdown"style="display: inline-block">
                     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                      <span class="dropdown-text">{{settings.getActiveChatUserList() ? 'On' : 'Off'}}</span>
+                      <span class="dropdown-text">{{settings.getActiveChatUserListEnabled() ? 'On' : 'Off'}}</span>
                       <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" aria-labelledby="options-activeChatUserList">

--- a/shared/firebot-roles.js
+++ b/shared/firebot-roles.js
@@ -4,6 +4,10 @@ const firebotRoles = [
     {
         id: "ActiveChatters",
         name: "Active Chatters"
+    },
+    {
+        id: "ActiveMixplayUsers",
+        name: "Active Mixplay Users"
     }
 ];
 


### PR DESCRIPTION
Changes:
- Keep list of active mixplay users on backend.
- Add randomActiveMixplayUser variable
- Add randomMixplayUser variable
- Add activeMixplayUserCount variable
- Add settings to turn active mixplay list on or off and adjust inactive timeout.
- Move active-chatters file and active-mixplay-users files to the roles folder to keep role specific logic together.

Tests:
- Tested to make sure tagging a person in the viewer db to keep them off active lists works on this as well.
- Tested all three new variables.
- Tested to make sure anonymous users are not placed on the active user list. (Would be pointless for the vast majority of uses).

Notes:
- This moves the active-chatters file, so it could have impact on old active chatters variable. But, I believe I got everything pointing to the correct new location.