### PR TITLE
Clear all users in role

### DIFF
--- a/backend/effects/builtin/update-role.js
+++ b/backend/effects/builtin/update-role.js
@@ -17,7 +17,7 @@ const delay = {
     definition: {
         id: "firebot:update-roles",
         name: "Update Viewer Roles",
-        description: "Add or remove a viewer from custom roles",
+        description: "Add, remove, or clear users from a custom role.",
         tags: ["Logic control", "Built in"],
         dependencies: [],
         triggers: effectModels.buildEffectTriggersObject(
@@ -29,25 +29,9 @@ const delay = {
     globalSettings: {},
     optionsTemplate: `
 
-        <eos-container header="Viewer">
-            <div style="padding: 0 10px 0 0;">
-                <label class="control-fb control--radio">Associated viewer <tooltip text="'The viewer who pressed this button/ran the command/etc.'"></tooltip>
-                    <input type="radio" ng-model="effect.viewerType" value="current"/>
-                    <div class="control__indicator"></div>
-                </label>
-                <label class="control-fb control--radio" style="margin-bottom: 10px;">Custom viewer
-                    <input type="radio" ng-model="effect.viewerType" value="custom"/>
-                    <div class="control__indicator"></div>
-                </label>
-                <div ng-show="effect.viewerType === 'custom'" style="padding-left: 30px;">
-                    <input class="form-control" type="text" ng-model="effect.customViewer" placeholder="Username" replace-variables></input>
-                </div>
-            </div>
-        </eos-container>
-
-        <eos-container header="Custom Role Actions" pad-top="true">
+    <eos-container header="Custom Role Actions" pad-top="true">
             <div>
-                <label class="control-fb control--checkbox"> Add to role</tooltip>
+                <label class="control-fb control--checkbox"> Add user to role</tooltip>
                     <input type="checkbox" ng-init="shouldAddRole = (effect.addRoleId != null && effect.addRoleId !== '')" ng-model="shouldAddRole" ng-click="effect.addRoleId = undefined">
                     <div class="control__indicator"></div>
                 </label>
@@ -64,7 +48,7 @@ const delay = {
             </div>
 
             <div style="margin-top:5px;">
-                <label class="control-fb control--checkbox"> Remove from role</tooltip>
+                <label class="control-fb control--checkbox"> Remove user from role</tooltip>
                     <input type="checkbox" ng-init="shouldRemoveRole = (effect.removeRoleId != null && effect.removeRoleId !== '')" ng-model="shouldRemoveRole" ng-click="effect.removeRoleId = undefined">
                     <div class="control__indicator"></div>
                 </label>
@@ -77,6 +61,39 @@ const delay = {
                             <li role="menuitem" ng-repeat="role in roles" ng-click="effect.removeRoleId = role.id"><a href>{{role.name}}</a></li>
                         </ul>
                     </div>
+                </div>
+            </div>
+
+            <div style="margin-top:5px;">
+                <label class="control-fb control--checkbox"> Remove all users from role</tooltip>
+                    <input type="checkbox" ng-init="shouldRemoveAllRole = (effect.removeAllRoleId != null && effect.removeAllRoleId !== '')" ng-model="shouldRemoveAllRole" ng-click="effect.removeAllRoleId = undefined">
+                    <div class="control__indicator"></div>
+                </label>
+                <div uib-collapse="!shouldRemoveAllRole" style="margin: 0 0 15px 15px;">
+                    <div class="btn-group" uib-dropdown>
+                        <button id="single-button" type="button" class="btn btn-default" uib-dropdown-toggle>
+                        {{getRoleName(effect.removeAllRoleId)}} <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
+                            <li role="menuitem" ng-repeat="role in roles" ng-click="effect.removeAllRoleId = role.id"><a href>{{role.name}}</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </eos-container>
+
+        <eos-container header="Viewer" ng-show="effect.removeRoleId != null || effect.addRoleId != null">
+            <div style="padding: 0 10px 0 0;">
+                <label class="control-fb control--radio">Associated viewer <tooltip text="'The viewer who pressed this button/ran the command/etc.'"></tooltip>
+                    <input type="radio" ng-model="effect.viewerType" value="current"/>
+                    <div class="control__indicator"></div>
+                </label>
+                <label class="control-fb control--radio" style="margin-bottom: 10px;">Custom viewer
+                    <input type="radio" ng-model="effect.viewerType" value="custom"/>
+                    <div class="control__indicator"></div>
+                </label>
+                <div ng-show="effect.viewerType === 'custom'" style="padding-left: 30px;">
+                    <input class="form-control" type="text" ng-model="effect.customViewer" placeholder="Username" replace-variables></input>
                 </div>
             </div>
         </eos-container>
@@ -124,6 +141,11 @@ const delay = {
         if (effect.removeRoleId) {
             customRolesManager.removeViewerFromRole(effect.removeRoleId, username);
         }
+
+        if (effect.removeAllRoleId) {
+            customRolesManager.removeAllViewersFromRole(effect.removeAllRoleId);
+        }
+
         return true;
     }
 };

--- a/backend/roles/custom-roles-manager.js
+++ b/backend/roles/custom-roles-manager.js
@@ -87,6 +87,17 @@ function addViewerToRole(roleId, username) {
     }
 }
 
+function removeAllViewersFromRole(roleId) {
+    let role = customRoles[roleId];
+    if (role) {
+        role.viewers = [];
+
+        saveCustomRole(role);
+
+        exports.triggerUiRefresh();
+    }
+}
+
 function removeViewerFromRole(roleId, username) {
     if (username == null || username.length < 1) return;
     let role = customRoles[roleId];
@@ -160,6 +171,7 @@ exports.addViewerToRole = addViewerToRole;
 
 exports.removeViewerFromRole = removeViewerFromRole;
 
+exports.removeAllViewersFromRole = removeAllViewersFromRole;
 
 
 


### PR DESCRIPTION
Implements #690 

Changes:
- Rearrange "update viewer roles" effect. You'll now choose the action before you choose a user.
- Add a "remove all from role" action to the effect.
- Implement backend, which just sets the viewers in said role to an empty array.

This will allow people to clear roles entirely for the purpose of resetting games, votes, or other things without needing to log everyone to a file and then loop through the file and remove people one by one.