### PR TITLE
Optional argument to get an active user in a custom role.

### DIFF
--- a/backend/variables/builtin/random-active-viewer.js
+++ b/backend/variables/builtin/random-active-viewer.js
@@ -2,23 +2,45 @@
 const util = require("../../utility");
 const logger = require("../../logwrapper");
 const activeViewerHandler = require('../../roles/role-managers/active-chatters');
+const customRoleManager = require('../../roles/custom-roles-manager');
 
 const { OutputDataType } = require("../../../shared/variable-contants");
 
 const model = {
     definition: {
         handle: "randomActiveViewer",
-        description: "Get a random active viewer in chat.",
+        usage: "randomActiveViewer[roleName]",
+        description: "Get a random active chatter. Optionally include a custom role name to get an active user in that role.",
         possibleDataOutput: [OutputDataType.TEXT]
     },
-    evaluator: async () => {
+    evaluator: async (_, roleName) => {
         logger.debug("Getting random active viewer...");
 
         let activeViewers = activeViewerHandler.getActiveChatters();
 
-        if (activeViewers && activeViewers.length > 0) {
+        if (activeViewers == null || activeViewers.length === 0) {
+            return "[Unable to get random active user]";
+        }
+
+        if (roleName == null) {
             let randIndex = util.getRandomInt(0, activeViewers.length - 1);
             return activeViewers[randIndex].username;
+        }
+
+        if (roleName != null) {
+            let customRole = customRoleManager.getRoleByName(roleName);
+            if (customRole == null) {
+                return "[Unable to get random active user]";
+            }
+
+            let customRoleUsers = customRole.viewers;
+            if (customRoleUsers.length === 0) {
+                return "[Unable to get random active user]";
+            }
+
+            let roleIntersection = activeViewers.filter(user => customRoleUsers.includes(user.username));
+            let randIndex = util.getRandomInt(0, roleIntersection.length - 1);
+            return roleIntersection[randIndex].username;
         }
 
         return "[Unable to get random active user]";

--- a/backend/variables/builtin/random-active-viewer.js
+++ b/backend/variables/builtin/random-active-viewer.js
@@ -9,7 +9,7 @@ const { OutputDataType } = require("../../../shared/variable-contants");
 const model = {
     definition: {
         handle: "randomActiveViewer",
-        usage: "randomActiveViewer[roleName]",
+        usage: "randomActiveViewer",
         description: "Get a random active chatter. Optionally include a custom role name to get an active user in that role.",
         possibleDataOutput: [OutputDataType.TEXT]
     },


### PR DESCRIPTION
Implements #685 

Usage:
$randomActiveViewer[Fun Group Name]

Changes:
- Implements an optional parameter for the randomActiveViewer variable that allows you to pass a role name.
- Backend to compare role user list against active user list and create a new array that contains only people in both.
- Pick one from the new list at random and output it.

Note:
We may look at a way to clarify which parameters are optional in the future in the variable picker. Right now we're just putting it in the descriptive text, but the actual variable usage shows the parameter.

![image](https://user-images.githubusercontent.com/17416635/75614568-b8b12980-5aff-11ea-8b64-12dfb3b3b044.png)
