### PR TITLE
Fix math cooldowns

### DIFF
--- a/backend/interactive/cooldown-manager.js
+++ b/backend/interactive/cooldown-manager.js
@@ -223,7 +223,7 @@ async function mathUpdate(updateData) {
             newCooldown = remainingCooldown - duration;
         }
 
-        await mixplay.updateCooldownForControls(controlIds, newCooldown);
+        await mixplay.updateCooldownForControls([controlId], newCooldown);
         updateCooldownForControlId(controlId, newCooldown / 1000);
     }
 }

--- a/backend/interactive/cooldown-manager.js
+++ b/backend/interactive/cooldown-manager.js
@@ -23,6 +23,11 @@ function cooldownIsExpired(controlId) {
 // Returns the amount of time remaining for a control id.
 function getRemainingCooldownTime(controlId) {
     let currentTtl = cooldownCache.getTtl(controlId) || 0;
+
+    if (currentTtl === 0) {
+        return 0;
+    }
+
     let diff = moment(currentTtl).diff(moment());
     if (diff < 0) {
         return 0;
@@ -219,9 +224,7 @@ async function mathUpdate(updateData) {
         }
 
         await mixplay.updateCooldownForControls(controlIds, newCooldown);
-        for (let controlId of controlIds) {
-            updateCooldownForControlId(controlId, newCooldown / 1000);
-        }
+        updateCooldownForControlId(controlId, newCooldown / 1000);
     }
 }
 


### PR DESCRIPTION
Should fix #701 

Changes:
- Remove an extra loop.
- Return ttl immediately if it's already 0, instead of comparing with moment.

For whatever reason I had decided in my old code to do an additional loop that wasn't needed. So, for each control ID I was looping through the control IDs again. I believe this was causing cooldowns to be applied twice and cause issues. This would have only affected the "add" and "subtract" cooldowns if updating a cooldown group with multiple buttons.