### PR TITLE
Follower restrictions

### DIFF
--- a/backend/common/user-access.js
+++ b/backend/common/user-access.js
@@ -5,11 +5,44 @@ const accountAccess = require("../common/account-access");
 const channelAccess = require("./channel-access");
 const mixerApi = require("../api-access");
 
+async function userFollowsUsers(userId, followCheckList) {
+    followCheckList.forEach(async (streamer) => {
+        let userFollowsUser = false;
+        if (streamer == null) {
+            return false;
+        }
+
+        if (isNaN(streamer)) {
+            let streamerData = await mixerApi.get(`channels/${streamer}?fields=id`, "v1", false, false);
+            if (streamerData != null) {
+                streamer = streamerData.id;
+            }
+
+            if (streamer == null) {
+                return false;
+            }
+        }
+
+        let userRelationshipData = await mixerApi.get(`channels/${userId}/relationship?user=${streamer}`, "v1", false, true);
+
+        if (!userRelationshipData) {
+            userFollowsUser = userRelationshipData.status && userRelationshipData.status.follows != null;
+        }
+
+        if (!userFollowsUser) {
+            return false;
+        }
+    });
+
+    return true;
+}
+
 async function getUserDetails(userId) {
 
     let mixerUserData = await mixerApi.get(`users/${userId}`, "v1", false, false);
 
     let streamerFollowsUser = false;
+    let userFollowsStreamer = false;
     if (mixerUserData) {
         const streamerData = accountAccess.getAccounts().streamer;
 
@@ -17,11 +50,8 @@ async function getUserDetails(userId) {
             "v1", false, true);
         mixerUserData.relationship = relationshipData ? relationshipData.status : null;
 
-        let streamerRelationshipData = await mixerApi
-            .get(`channels/${mixerUserData.channel.id}/relationship?user=${streamerData.userId}`, "v1", false, true);
-        if (streamerRelationshipData) {
-            streamerFollowsUser = streamerRelationshipData.status && streamerRelationshipData.status.follows != null;
-        }
+        streamerFollowsUser = userFollowsUsers(streamerData.userId, [mixerUserData.channel.id]);
+        userFollowsStreamer = userFollowsUsers(userId, [streamerData.userId]);
 
         let channelLevel = await channelAccess.getChannelProgressionForUser(userId);
         if (channelLevel) {
@@ -34,10 +64,12 @@ async function getUserDetails(userId) {
     const userDetails = {
         firebotData: firebotUserData || {},
         mixerData: mixerUserData,
-        streamerFollowsUser: streamerFollowsUser
+        streamerFollowsUser: streamerFollowsUser,
+        userFollowsStreamer: userFollowsStreamer
     };
 
     return userDetails;
 }
 
 exports.getUserDetails = getUserDetails;
+exports.userFollowsStreamers = userFollowsUsers;

--- a/backend/effects/builtin/conditional-effects/conditions/builtin-condition-loader.js
+++ b/backend/effects/builtin/conditional-effects/conditions/builtin-condition-loader.js
@@ -8,9 +8,11 @@ exports.registerConditionTypes = () => {
     let custom = require("./builtin/custom");
     let viewerRoles = require("./builtin/viewer-roles");
     let argsCount = require("./builtin/args-count");
+    let followCheck = require("./builtin/follow-check");
 
     conditionManager.registerConditionType(username);
     conditionManager.registerConditionType(custom);
     conditionManager.registerConditionType(viewerRoles);
     conditionManager.registerConditionType(argsCount);
+    conditionManager.registerConditionType(followCheck);
 };

--- a/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
+++ b/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const userAccess = require("../../../../../common/user-access");
+
+module.exports = {
+    id: "firebot:followcheck",
+    name: "Follow Check",
+    description: "Condition based on if user is following all people in a comma separated list.",
+    comparisonTypes: ["follows"],
+    leftSideValueType: "none",
+    rightSideValueType: "text",
+    predicate: async (conditionSettings, trigger) => {
+
+        let { rightSideValue } = conditionSettings;
+
+        // normalize usernames
+        let triggerUserId = trigger.metadata.userId ? trigger.metadata.userId : "";
+        let normalizeFollowList = rightSideValue ? rightSideValue.toLowerCase() : "";
+
+        if (normalizeFollowList === "" || triggerUserId === "") {
+            return false;
+        }
+
+        let followCheckList = normalizeFollowList.replace(new RegExp(' ', 'g'), "").split(',');
+
+        let followCheck = await userAccess.userFollowsUsers(triggerUserId, followCheckList);
+
+        console.log('Follow check returned ' + followCheck);
+
+        return followCheck;
+    }
+};

--- a/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
+++ b/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
@@ -19,7 +19,7 @@ module.exports = {
         }
 
         let followCheckList = normalizeFollowList.replace(new RegExp(' ', 'g'), "").split(',');
-        let followCheck = await userAccess.userFollowsUsers(triggerUserId, followCheckList);
+        let followCheck = await userAccess.userFollowsChannels(triggerUserId, followCheckList);
         return followCheck;
     }
 };

--- a/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
+++ b/backend/effects/builtin/conditional-effects/conditions/builtin/follow-check.js
@@ -10,10 +10,7 @@ module.exports = {
     leftSideValueType: "none",
     rightSideValueType: "text",
     predicate: async (conditionSettings, trigger) => {
-
         let { rightSideValue } = conditionSettings;
-
-        // normalize usernames
         let triggerUserId = trigger.metadata.userId ? trigger.metadata.userId : "";
         let normalizeFollowList = rightSideValue ? rightSideValue.toLowerCase() : "";
 
@@ -22,11 +19,7 @@ module.exports = {
         }
 
         let followCheckList = normalizeFollowList.replace(new RegExp(' ', 'g'), "").split(',');
-
         let followCheck = await userAccess.userFollowsUsers(triggerUserId, followCheckList);
-
-        console.log('Follow check returned ' + followCheck);
-
         return followCheck;
     }
 };

--- a/backend/restrictions/builtin-restrictions-loader.js
+++ b/backend/restrictions/builtin-restrictions-loader.js
@@ -11,6 +11,7 @@ exports.loadRestrictions = function() {
     const viewTime = require('./builtin/viewTimeRestriction');
     const mixplayInteractions = require('./builtin/mixplayInteractions');
     const chatMessages = require('./builtin/chatMessages');
+    const followCheck = require('./builtin/followCheck');
 
     restrictionsManager.registerRestriction(permissions);
     restrictionsManager.registerRestriction(channelProgression);
@@ -20,4 +21,5 @@ exports.loadRestrictions = function() {
     restrictionsManager.registerRestriction(viewTime);
     restrictionsManager.registerRestriction(mixplayInteractions);
     restrictionsManager.registerRestriction(chatMessages);
+    restrictionsManager.registerRestriction(followCheck);
 };

--- a/backend/restrictions/builtin/followCheck.js
+++ b/backend/restrictions/builtin/followCheck.js
@@ -41,7 +41,7 @@ const model = {
             }
 
             let followCheckList = normalizeFollowList.replace(new RegExp(' ', 'g'), "").split(',');
-            let followCheck = await userAccess.userFollowsUsers(triggerUserId, followCheckList);
+            let followCheck = await userAccess.userFollowsChannels(triggerUserId, followCheckList);
 
             if (followCheck) {
                 return resolve();

--- a/backend/restrictions/builtin/followCheck.js
+++ b/backend/restrictions/builtin/followCheck.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const model = {
+    definition: {
+        id: "firebot:followcheck",
+        name: "Follow Check",
+        description: "Restrict based on if user is following everyone in a comma separated list.",
+        triggers: []
+    },
+    optionsTemplate: `
+        <div>
+            <div id="userFollowList" class="mixplay-header" style="padding: 0 0 4px 0">
+                User follows
+            </div>
+            <input type="text" class="form-control" placeholder="Enter value" ng-model="restriction.value">
+        </div>
+    `,
+    optionsController: ($scope) => {
+
+    },
+    optionsValueDisplay: (restriction) => {
+        let value = restriction.value;
+
+        if (value == null) {
+            return "";
+        }
+
+        return value;
+    },
+    /*
+      function that resolves/rejects a promise based on if the restriction critera is met
+    */
+    predicate: async (trigger, restrictionData) => {
+        return new Promise(async (resolve, reject) => {
+            const userAccess = require("../../common/user-access");
+            let triggerUserId = trigger.metadata.userId ? trigger.metadata.userId : "";
+            let normalizeFollowList = restrictionData.value ? restrictionData.value.toLowerCase() : "";
+
+            if (normalizeFollowList === "" || triggerUserId === "") {
+                return reject("You are not following the correct people to use this.");
+            }
+
+            let followCheckList = normalizeFollowList.replace(new RegExp(' ', 'g'), "").split(',');
+            let followCheck = await userAccess.userFollowsUsers(triggerUserId, followCheckList);
+
+            if (followCheck) {
+                return resolve();
+            }
+
+            return reject("You must be following: " + restrictionData.value);
+        });
+    },
+    /*
+        called after all restrictions in a list are met. Do logic such as deducting currency here.
+    */
+    onSuccessful: (triggerData, restrictionData) => {
+
+    }
+
+};
+
+module.exports = model;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "firebotv5",
-    "version": "5.6.2",
+    "version": "5.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Implements #744 

Changes:
- New function in user-access that allows us to determine if a user is following certain streamers.
- Add follow check restriction.
- Add follow check conditional.

This will allow people to put buttons behind a list of required follows. This will be useful for people who want to cross promote other streamers by unlocking buttons and effects. It will also be useful in limiting your buttons to being follower only.

Downside:
This makes API calls. So, if a conditional or restriction is put onto something that is spammed a ton (like a chat message event) they could maybe hit the API call limit. This should cause firebot to return false on any other follow checks, but nothing should break.