### PR TITLE
Cleanup role conditional label.

### DIFF
--- a/backend/effects/builtin/conditional-effects/conditions/builtin/viewer-roles.js
+++ b/backend/effects/builtin/conditional-effects/conditions/builtin/viewer-roles.js
@@ -10,7 +10,7 @@ module.exports = {
     id: "firebot:viewerroles",
     name: "Viewer's Roles",
     description: "Condition based on a given viewer role",
-    comparisonTypes: ["include", "doesn't include"],
+    comparisonTypes: ["is in role", "isn't in role"],
     leftSideValueType: "text",
     rightSideValueType: "preset",
     getRightSidePresetValues: viewerRolesService => {
@@ -68,8 +68,10 @@ module.exports = {
 
         switch (comparisonType) {
         case "include":
+        case "is in role":
             return hasRole;
         case "doesn't include":
+        case "isn't in role":
             return !hasRole;
         default:
             return false;


### PR DESCRIPTION
Implements #742 

Changes:
- Update "include" to "is in role" and "doesn't include" to "isn't in role".
- Make sure we leave the "include" and "doesn't include" in as a fallback for previous versions.

Why?
This makes it easier to see what exactly this conditional is doing without needing to click in on it to edit it.

![image](https://user-images.githubusercontent.com/17416635/76173403-51355280-616d-11ea-87de-fcefc65cc702.png)
