### PR TITLE
#964 Create a clear option to clear command cooldowns.

### DIFF
--- a/backend/chat/commands/commandHandler.js
+++ b/backend/chat/commands/commandHandler.js
@@ -142,6 +142,29 @@ exports.manuallyCooldownCommand = (config) => {
     }
 };
 
+/**
+ *
+ * @param {object} config
+ * @param {string} config.commandId
+ * @param {string} config.username
+ * @param {object} config.cooldowns
+ * @param {boolean} [config.cooldowns.global]
+ * @param {boolean} [config.cooldowns.user]
+ */
+exports.manuallyClearCooldownCommand = (config) => {
+    if (config.commandId == null || config.cooldowns == null || (config.cooldowns.global == null && config.cooldowns.user == null)) return;
+    const globalCacheKey = `${config.commandId}`;
+    const userCacheKey = `${config.commandId}:${config.username}`;
+
+    if (cooldownCache.get(globalCacheKey) !== null && config.cooldowns.global === true) {
+        cooldownCache.del(globalCacheKey);
+    }
+
+    if (cooldownCache.get(userCacheKey) !== null && config.cooldowns.user === true) {
+        cooldownCache.del(userCacheKey);
+    }
+};
+
 function cooldownCommand(command, triggeredSubcmd, username) {
     let cooldown;
     if (triggeredSubcmd == null || triggeredSubcmd.cooldown == null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "firebotv5",
-    "version": "5.21.0",
+    "version": "5.23.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Implements #964 

This adds in a clear option for the command cooldowns effect. You can clear the global cooldown, a user specific cooldown, or both.

Changes:
- Add "action" option to clear command cooldown effects. It has "add" and "clear". 
- Add options to clear global and/or user specific cooldowns.