### PR TITLE
V5 Manual Highlight

### DIFF
--- a/backend/common/common-listeners.js
+++ b/backend/common/common-listeners.js
@@ -54,6 +54,11 @@ exports.setupCommonListeners = () => {
         return { path: path, id: uuid };
     });
 
+    frontendCommunicator.on("highlight-message", data => {
+        const eventsManager = require("../events/EventManager");
+        eventsManager.triggerEvent("firebot", "highlight-message", data);
+    });
+
     // Front old main
 
     // restarts the app

--- a/backend/events/builtin/firebotEventSource.js
+++ b/backend/events/builtin/firebotEventSource.js
@@ -50,6 +50,16 @@ const firebotEventSource = {
             name: "Custom Variable Created",
             description: "When a custom variable gets created",
             cached: false
+        },
+        {
+            id: "highlight-message",
+            name: "Chat Message Highlight",
+            description: "When you select to highlight a message on your overlay.",
+            cached: false,
+            manualMetadata: {
+                username: "Firebot",
+                messageText: "Test message"
+            }
         }
     ]
 };

--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -31,8 +31,7 @@ const model = {
 
         } else if (trigger.type === EffectTrigger.EVENT) {
             // if trigger is event, build chat message from chat event data
-            console.log(trigger);
-            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
+            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.chatMessage;
         }
 
         return chatMessage.trim();

--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -30,9 +30,9 @@ const model = {
             chatMessage = `${userCommand.trigger} ${userCommand.args.join(" ")}`;
 
         } else if (trigger.type === EffectTrigger.EVENT) {
-
             // if trigger is event, build chat message from chat event data
-            chatMessage = trigger.metadata.eventData.messageText;
+            console.log(trigger);
+            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
         }
 
         return chatMessage.trim();

--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -9,7 +9,7 @@ const { OutputDataType, VariableCategory } = require("../../../shared/variable-c
 let triggers = {};
 triggers[EffectTrigger.MANUAL] = true;
 triggers[EffectTrigger.COMMAND] = true;
-triggers[EffectTrigger.EVENT] = ["twitch:chat-message"];
+triggers[EffectTrigger.EVENT] = ["twitch:chat-message", "firebot:highlight-message"];
 
 const model = {
     definition: {

--- a/gui/app/directives/chat/chat-message.js
+++ b/gui/app/directives/chat/chat-message.js
@@ -104,6 +104,11 @@
                         });
 
                         actions.push({
+                            name: "Highlight This Message",
+                            icon: "fa-eye"
+                        });
+
+                        actions.push({
                             name: "Shoutout",
                             icon: "fa-megaphone"
                         });
@@ -177,6 +182,9 @@
                         break;
                     case "quote this message":
                         updateChatField(`!quote add @${userName} ${rawText}`);
+                        break;
+                    case "highlight this message":
+                        chatMessagesService.highlightMessage(userName, rawText);
                         break;
                     case "shoutout":
                         updateChatField(`!so @${userName}`);

--- a/gui/app/services/chatMessagesService.js
+++ b/gui/app/services/chatMessagesService.js
@@ -122,6 +122,16 @@
                 }
             };
 
+            service.highlightMessage = (username, rawText) => {
+                backendCommunicator.fireEvent("firebot:highlight-message", {
+                    action: "highlightMessage",
+                    meta: {
+                        username: username,
+                        messageText: rawText
+                    }
+                });
+            };
+
             // Chat Alert Message
             service.chatAlertMessage = function(message) {
 

--- a/gui/app/services/chatMessagesService.js
+++ b/gui/app/services/chatMessagesService.js
@@ -122,13 +122,10 @@
                 }
             };
 
-            service.highlightMessage = (username, rawText) => {
-                backendCommunicator.fireEvent("firebot:highlight-message", {
+            service.highlightMessage = (rawText) => {
+                backendCommunicator.fireEvent("highlight-message", {
                     action: "highlightMessage",
-                    meta: {
-                        username: username,
-                        messageText: rawText
-                    }
+                    messageText: rawText
                 });
             };
 

--- a/gui/app/services/chatMessagesService.js
+++ b/gui/app/services/chatMessagesService.js
@@ -122,10 +122,10 @@
                 }
             };
 
-            service.highlightMessage = (rawText) => {
+            service.highlightMessage = (username, rawText) => {
                 backendCommunicator.fireEvent("highlight-message", {
-                    action: "highlightMessage",
-                    messageText: rawText
+                    username: username,
+                    chatMessage: rawText
                 });
             };
 


### PR DESCRIPTION
### Description of the Change
This adds in an option to manually trigger a "message highlight" event from the Firebot chat window. The use case that inspired this was the ability to highlight a specific message in the overlay in order to bring more attention to it.

There is a "highlight message" channel points reward that I didn't think about until this was completed. Do you think the naming of this event may be confusing at all?


### Applicable Issues
N/A