### PR TITLE
Fix message event not triggering on streamer chatting in firebot chat.

### DIFF
--- a/backend/chat/twitch-chat.js
+++ b/backend/chat/twitch-chat.js
@@ -279,6 +279,9 @@ frontendCommunicator.on("send-chat-message", async sendData => {
     if (accountType === "Streamer") {
         let firebotMessage = await chatHelpers.buildFirebotChatMessageFromText(message);
         commandHandler.handleChatMessage(firebotMessage);
+
+        const chatMessageListener = require("../events/twitch-events/chat-message");
+        chatMessageListener.triggerChatMessage(firebotMessage);
     }
 
     twitchChat.sendChatMessage(message, null, accountType);


### PR DESCRIPTION
### Description of the Change
This makes it so that the chat message event will trigger when the user chats as the streamer account in Firebot's chat window.


### Applicable Issues
#1051 

### Testing
I tested by creating a !test command that had my streamer account reply with who chatted. I then typed !test into the firebot chat window and got the response that I chatted. This did not trigger the chat message event a second time, which is what I would expect.
