### PR TITLE
Show the enable-disable setting during event creation

### DIFF
--- a/gui/app/directives/modals/events/addOrEditEventModal.js
+++ b/gui/app/directives/modals/events/addOrEditEventModal.js
@@ -41,7 +41,7 @@
                     </div>
 
                     <div class="controls-fb-inline effect-setting-container">
-                        <label class="control-fb control--checkbox" ng-if="!$ctrl.isNewEvent">Enabled
+                        <label class="control-fb control--checkbox">Enabled
                             <input type="checkbox" ng-model="$ctrl.event.active" aria-label="..." checked>
                             <div class="control__indicator"></div>
                         </label>


### PR DESCRIPTION
### Description of the Change
Shows the enable-disable setting at event creation, instead of only displaying it after an event has been created.


### Applicable Issues
n/a
