### PR TITLE
Make Counter Manager Available to Custom Scripts

### DIFF
--- a/backend/common/handlers/custom-scripts/custom-script-helpers.js
+++ b/backend/common/handlers/custom-scripts/custom-script-helpers.js
@@ -113,6 +113,7 @@ function buildModules(scriptManifest) {
         userDb: require("../../../database/userDatabase"),
         quotesManager: require("../../../quotes/quotes-manager"),
         frontendCommunicator: require("../../frontend-communicator"),
+        counterManager: require("../../../counters/counter-manager"),
         mixplay: {},
         utils: require("../../../utility")
     };


### PR DESCRIPTION
### Description of the Change
Currency, custom variable, game, timer, … managers are already available to custom scripts. The counterManager was missing. This PR adds it.

Adding the counter-id in a custom script as parameter is not really nice, by adding the `counterManager` only the name has to be added, the script can then query the id from there.

### Applicable Issues
n/a