### PR TITLE
Fix $chatMessage variable parsing in message highlight event.

### DIFF
--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -31,7 +31,7 @@ const model = {
 
         } else if (trigger.type === EffectTrigger.EVENT) {
             // if trigger is event, build chat message from chat event data
-            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
+            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.chatMessage;
         }
 
         return chatMessage.trim();


### PR DESCRIPTION
### Description of the Change
This should fix an issue where the message highlight event can't parse $chatMessage.

### Applicable Issues
#1104 


### Testing
- Created a message highlight event.
- Added in $username and $chatMessage variables with a chat message effect.
- Highlighted a chat message.
- Confirmed that the output chat message contains the original username and text.