### PR TITLE
#1104 V5 chat message variable fix

### DIFF
--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -31,7 +31,6 @@ const model = {
 
         } else if (trigger.type === EffectTrigger.EVENT) {
             // if trigger is event, build chat message from chat event data
-            console.log(trigger.metadata.eventData);
             chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
         }
 

--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -31,7 +31,7 @@ const model = {
 
         } else if (trigger.type === EffectTrigger.EVENT) {
             // if trigger is event, build chat message from chat event data
-            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
+            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.chatMessage;
         }
 
         return chatMessage.trim();

--- a/backend/variables/builtin/chat-message.js
+++ b/backend/variables/builtin/chat-message.js
@@ -31,7 +31,8 @@ const model = {
 
         } else if (trigger.type === EffectTrigger.EVENT) {
             // if trigger is event, build chat message from chat event data
-            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.chatMessage;
+            console.log(trigger.metadata.eventData);
+            chatMessage = trigger.metadata.chatMessage || trigger.metadata.eventData.messageText;
         }
 
         return chatMessage.trim();

--- a/gui/app/services/chatMessagesService.js
+++ b/gui/app/services/chatMessagesService.js
@@ -113,7 +113,7 @@
             service.highlightMessage = (username, rawText) => {
                 backendCommunicator.fireEvent("highlight-message", {
                     username: username,
-                    chatMessage: rawText
+                    messageText: rawText
                 });
             };
 


### PR DESCRIPTION
### Description of the Change
From what I can tell, events seem to use messageText where other things tend to use chatMessage. We tried updating messageText to chatMessage for the release of manual highlighting, but it caused problems.

This changes chatMessage back to messageText which should fix the $chatMessage variable for events.


### Applicable Issues
#1104 


### Testing
1. Create a new highlight message or chat message event.
2. Have it output a chat message or overlay text.
3. Put in a $chatMessage variable in the effect.
4. Fire the event and confirm chatMessage gets parsed correctly.

Tested on message highlight and chat message events.

![image](https://user-images.githubusercontent.com/17416635/116252815-887e0e80-a735-11eb-90d1-005b4d17fde9.png)
