### PR TITLE
Fix bug where events controller keeps trying to find a deleted event set

### DIFF
--- a/gui/app/controllers/eventsController.js
+++ b/gui/app/controllers/eventsController.js
@@ -17,7 +17,7 @@
                 if (eventsService.getEventGroup(selectedTab) == null) {
                     return eventsService.getMainEvents();
                 }
-                
+
                 return eventsService.getEventGroup(selectedTab).events;
             };
 

--- a/gui/app/controllers/eventsController.js
+++ b/gui/app/controllers/eventsController.js
@@ -13,6 +13,10 @@
                 if (selectedTab === "mainevents") {
                     return eventsService.getMainEvents();
                 }
+
+                if (eventsService.getEventGroup(selectedTab) == null) {
+                    return eventsService.getMainEvents();
+                }
                 return eventsService.getEventGroup(selectedTab).events;
             };
 

--- a/gui/app/controllers/eventsController.js
+++ b/gui/app/controllers/eventsController.js
@@ -17,6 +17,7 @@
                 if (eventsService.getEventGroup(selectedTab) == null) {
                     return eventsService.getMainEvents();
                 }
+                
                 return eventsService.getEventGroup(selectedTab).events;
             };
 


### PR DESCRIPTION
### Description of the Change
The events controller keeps trying to find the event set you left the tab on, after deleting that particular event set through Remove Setup.


### Applicable Issues
Events tab keeps trying to find event set after removing setup https://github.com/crowbartools/Firebot/issues/1114


### Testing
Went to the evens tab, clicked on the event set that is going to be removed through Remove Setup. Removed setup, went back to events tab to make sure it defaulted to the main events.
