### PR TITLE
Split command import functionality from command saving functionality in command access

### DIFF
--- a/backend/chat/commands/command-access.js
+++ b/backend/chat/commands/command-access.js
@@ -82,25 +82,33 @@ function refreshCommandCache(retry = 1) {
     }
 }
 
-function saveNewCustomCommand(command) {
-    logger.debug("saving newcommand: " + command.trigger);
+function saveImportedCustomCommand(command) {
+    logger.debug("Saving imported command: " + command.trigger);
+
+    if (command.id == null || command.id === "") {
+        command.createdBy = "Imported";
+    } else {
+        command.lastEditBy = "Imported";
+    }
+    
+    saveCustomCommand(command);
+}
+
+function saveCustomCommand(command) {
+    let commandDb = getCommandsDb();
+
     if (command.id == null || command.id === "") {
         // generate id for new command
         const uuidv1 = require("uuid/v1");
         command.id = uuidv1();
-
-        command.createdBy = "Imported";
         command.createdAt = moment().format();
     } else {
-        command.lastEditBy = "Imported";
         command.lastEditAt = moment().format();
     }
 
     if (command.count == null) {
         command.count = 0;
     }
-
-    let commandDb = getCommandsDb();
 
     try {
         commandDb.push("/customCommands/" + command.id, command);
@@ -135,7 +143,7 @@ exports.refreshCommandCache = refreshCommandCache;
 exports.getSystemCommandOverrides = () => commandsCache.systemCommandOverrides;
 exports.saveSystemCommandOverride = saveSystemCommandOverride;
 exports.removeSystemCommandOverride = removeSystemCommandOverride;
-exports.saveNewCustomCommand = saveNewCustomCommand;
+exports.saveImportedCustomCommand = saveImportedCustomCommand;
 exports.deleteCustomCommand = deleteCustomCommand;
 exports.getCustomCommands = () => commandsCache.customCommands;
 exports.getCustomCommand = id =>

--- a/backend/chat/commands/command-access.js
+++ b/backend/chat/commands/command-access.js
@@ -82,18 +82,6 @@ function refreshCommandCache(retry = 1) {
     }
 }
 
-function saveImportedCustomCommand(command) {
-    logger.debug("Saving imported command: " + command.trigger);
-
-    if (command.id == null || command.id === "") {
-        command.createdBy = "Imported";
-    } else {
-        command.lastEditBy = "Imported";
-    }
-    
-    saveCustomCommand(command);
-}
-
 function saveCustomCommand(command) {
     let commandDb = getCommandsDb();
 
@@ -113,6 +101,18 @@ function saveCustomCommand(command) {
     try {
         commandDb.push("/customCommands/" + command.id, command);
     } catch (err) {} //eslint-disable-line no-empty
+}
+
+function saveImportedCustomCommand(command) {
+    logger.debug("Saving imported command: " + command.trigger);
+
+    if (command.id == null || command.id === "") {
+        command.createdBy = "Imported";
+    } else {
+        command.lastEditBy = "Imported";
+    }
+
+    saveCustomCommand(command);
 }
 
 function deleteCustomCommand(commandId) {

--- a/backend/import/setups/setup-importer.js
+++ b/backend/import/setups/setup-importer.js
@@ -85,7 +85,7 @@ function importSetup(setup, selectedCurrency) {
     // commands
     const commands = setup.components.commands || [];
     for (const command of commands) {
-        commandAccess.saveNewCustomCommand(command);
+        commandAccess.saveImportedCustomCommand(command);
     }
     commandAccess.triggerUiRefresh();
 

--- a/backend/import/v4/areas/v4-commands-importer.js
+++ b/backend/import/v4/areas/v4-commands-importer.js
@@ -37,7 +37,7 @@ function mapCommands(v4Commands, activeStatus = true, incompatibilityWarnings) {
         let restrictionData = permissionMapper.mapV4Permissions(v4Command.permissionType, v4Command.permissions);
         v5Command.restrictionData = restrictionData;
 
-        commandAccess.saveNewCustomCommand(v5Command);
+        commandAccess.saveImportedCustomCommand(v5Command);
     }
 
 }


### PR DESCRIPTION
### Description of the Change
This splits the importing and saving in `command-access.js`, so that the saving functionality can be reused (which is what I need for the toggle command effect feature). 


### Applicable Issues
Preparation for the toggle command effect feature: https://github.com/crowbartools/Firebot/issues/1068.


### Testing
Imported a new command, which was correctly saved. Then modified that command and imported the original one, which overrode the modified one correctly.