### PR TITLE
Add a button to the system commands list that toggles the active state of a command

### DIFF
--- a/gui/app/directives/misc/sysCommandRow.js
+++ b/gui/app/directives/misc/sysCommandRow.js
@@ -65,6 +65,7 @@
             </div>
             <div style="padding-top: 10px">
               <button class="btn btn-primary" ng-click="$ctrl.openEditSystemCommandModal()">Edit</button>
+              <button class="btn btn-default" type="button" ng-click="$ctrl.toggleCommandActiveState()">Toggle Enabled</button>
             </div>  
           </div>
         </div>
@@ -168,6 +169,11 @@
                     }
                 });
             };
+
+            $ctrl.toggleCommandActiveState = function() {
+                $ctrl.command.active = !$ctrl.command.active;
+                commandsService.saveSystemCommandOverride($ctrl.command);
+            }
 
             $ctrl.sysCommandMenuOptions = [
                 {

--- a/gui/app/directives/misc/sysCommandRow.js
+++ b/gui/app/directives/misc/sysCommandRow.js
@@ -173,7 +173,7 @@
             $ctrl.toggleCommandActiveState = function() {
                 $ctrl.command.active = !$ctrl.command.active;
                 commandsService.saveSystemCommandOverride($ctrl.command);
-            }
+            };
 
             $ctrl.sysCommandMenuOptions = [
                 {

--- a/gui/app/directives/misc/sysCommandRow.js
+++ b/gui/app/directives/misc/sysCommandRow.js
@@ -65,7 +65,7 @@
             </div>
             <div style="padding-top: 10px">
               <button class="btn btn-primary" ng-click="$ctrl.openEditSystemCommandModal()">Edit</button>
-              <button class="btn btn-default" type="button" ng-click="$ctrl.toggleCommandActiveState()">Toggle Enabled</button>
+              <button class="btn btn-default" ng-click="$ctrl.toggleCommandActiveState()">Toggle Enabled</button>
             </div>  
           </div>
         </div>


### PR DESCRIPTION
### Description of the Change
Adds a button to the system commands list that toggles the active state of a command, so that you don't have to open the modal first.

### Applicable Issues
n/a


### Testing
Clicked the button for both state, checked if in the edit modal if "Is Active" was in the right state.


### Screenshots
![image](https://user-images.githubusercontent.com/72231755/117027931-797ef980-acfd-11eb-8ac4-9452918f98f5.png)
