### PR TITLE
Fixes stream teams not working in the Viewers Roles condition + general clean up

### DIFF
--- a/backend/database/currencyDatabase.js
+++ b/backend/database/currencyDatabase.js
@@ -151,12 +151,19 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
 
         const onlineUsers = await userDatabase.getOnlineUsers();
 
+        /** @type{ Record<string, Array<{ id: string; name: string }>> } */
+        const teamRoles = {};
+        for (const user of onlineUsers) {
+            teamRoles[user.username] = await teamRolesManager
+                .getAllTeamRolesForViewer(user.username);
+        }
+
         const userIdsInRoles = onlineUsers
             .map(u => {
                 u.allRoles = [
                     ...u.twitchRoles.map(tr => twitchRolesManager.mapTwitchRole(tr)),
                     ...customRolesManager.getAllCustomRolesForViewer(u.username),
-                    ...teamRolesManager.getAllTeamRolesForViewer(u.username),
+                    ...teamRoles[u.username],
                     ...firebotRolesManager.getAllFirebotRolesForViewer(u.username)
                 ];
                 return u;

--- a/backend/events/filters/builtin/viewerRoles.js
+++ b/backend/events/filters/builtin/viewerRoles.js
@@ -67,19 +67,24 @@ module.exports = {
             return false;
         }
 
+        /** @type{string[]} */
         let twitchUserRoles = eventMeta.twitchUserRoles;
         if (twitchUserRoles == null) {
             twitchUserRoles = await twitchUsers.getUsersChatRoles(username);
         }
 
-        let userCustomRoles = customRolesManager.getAllCustomRolesForViewer(username) || [];
-        let userTeamRoles = teamRolesManager.getAllTeamRolesForViewer(username) || [];
-        let userTwitchRoles = (twitchUserRoles || [])
-            .map(r => twitchRolesManager.mapTwitchRole(r));
+        const userCustomRoles = customRolesManager.getAllCustomRolesForViewer(username) || [];
+        const userTeamRoles = await teamRolesManager.getAllTeamRolesForViewer(username) || [];
+        const userTwitchRoles = (twitchUserRoles || [])
+            .map(twitchRolesManager.mapTwitchRole);
 
-        let allRoles = userCustomRoles.concat(userTwitchRoles).concat(userTeamRoles);
+        const allRoles = [
+            ...userTwitchRoles,
+            ...userTeamRoles,
+            ...userCustomRoles
+        ];
 
-        let hasRole = allRoles.some(r => r.id === value);
+        const hasRole = allRoles.some(r => r.id === value);
 
         switch (comparisonType) {
         case "include":

--- a/backend/games/builtin/heist/heist-command.js
+++ b/backend/games/builtin/heist/heist-command.js
@@ -120,11 +120,15 @@ const heistCommand = {
 
         // get all user roles
         const userCustomRoles = customRolesManager.getAllCustomRolesForViewer(username) || [];
-        const userTeamRoles = teamRolesManager.getAllTeamRolesForViewer(username) || [];
+        const userTeamRoles = await teamRolesManager.getAllTeamRolesForViewer(username) || [];
         const userTwitchRoles = (userCommand.senderRoles || [])
             .map(r => twitchRolesManager.mapTwitchRole(r))
             .filter(r => !!r);
-        const allRoles = userCustomRoles.concat(userTwitchRoles).concat(userTeamRoles);
+        const allRoles = [
+            ...userTwitchRoles,
+            ...userTeamRoles,
+            ...userCustomRoles
+        ];
 
         // get the users success percentage
         let successChance = 50;

--- a/backend/games/builtin/slots/spin-command.js
+++ b/backend/games/builtin/slots/spin-command.js
@@ -124,11 +124,16 @@ const spinCommand = {
                     successChance = successChancesSettings.basePercent;
 
                     const userCustomRoles = customRolesManager.getAllCustomRolesForViewer(username) || [];
-                    const userTeamRoles = teamRolesManager.getAllTeamRolesForViewer(username) || [];
+                    const userTeamRoles = await teamRolesManager.getAllTeamRolesForViewer(username) || [];
                     const userTwitchRoles = (userCommand.senderRoles || [])
                         .map(r => twitchRolesManager.mapTwitchRole(r))
                         .filter(r => !!r);
-                    const allRoles = userCustomRoles.concat(userTwitchRoles).concat(userTeamRoles);
+
+                    const allRoles = [
+                        ...userTwitchRoles,
+                        ...userTeamRoles,
+                        ...userCustomRoles
+                    ];
 
                     for (let role of successChancesSettings.roles) {
                         if (allRoles.some(r => r.id === role.roleId)) {

--- a/backend/games/builtin/trivia/trivia-command.js
+++ b/backend/games/builtin/trivia/trivia-command.js
@@ -177,11 +177,16 @@ const triviaCommand = {
             }
 
             const userCustomRoles = customRolesManager.getAllCustomRolesForViewer(username) || [];
-            const userTeamRoles = teamRolesManager.getAllTeamRolesForViewer(username) || [];
+            const userTeamRoles = await teamRolesManager.getAllTeamRolesForViewer(username) || [];
             const userTwitchRoles = (userCommand.senderRoles || [])
                 .map(r => twitchRolesManager.mapTwitchRole(r))
                 .filter(r => !!r);
-            const allRoles = userCustomRoles.concat(userTwitchRoles).concat(userTeamRoles);
+
+            const allRoles = [
+                ...userTwitchRoles,
+                ...userTeamRoles,
+                ...userCustomRoles
+            ];
 
             // get the users winnings multiplier
             let winningsMultiplier = 1.25;

--- a/backend/roles/custom-roles-manager.js
+++ b/backend/roles/custom-roles-manager.js
@@ -5,6 +5,14 @@ const profileManager = require("../common/profile-manager");
 const frontendCommunicator = require("../common/frontend-communicator");
 const twitchRoleManager = require("../../shared/twitch-roles");
 
+/**
+ * @typedef CustomRole
+ * @property {string} id
+ * @property {string} name
+ * @property {string[]} viewers
+ */
+
+/** @type {Object.<string, CustomRole>} */
 let customRoles = {};
 
 const ROLES_FOLDER = "/roles/";

--- a/backend/roles/team-roles-manager.js
+++ b/backend/roles/team-roles-manager.js
@@ -3,6 +3,9 @@
 const twitchApi = require("../twitch-api/api");
 const frontendCommunicator = require("../common/frontend-communicator");
 
+/**
+ * @param {import('twitch/lib/API/Kraken/Team/Team').Team[]} teams
+ */
 function mapRoles(teams) {
     return teams
         .map(team => {

--- a/gui/app/services/viewerRolesService.js
+++ b/gui/app/services/viewerRolesService.js
@@ -98,9 +98,12 @@ const firebotRoleConstants = require("../../shared/firebot-roles");
                 return twitchRoles;
             };
 
-            service.getAllRoles = () => {
-                return service.getTwitchRoles().concat(service.getTeamRoles()).concat(service.getFirebotRoles()).concat(service.getCustomRoles());
-            };
+            service.getAllRoles = () => [
+                ...service.getTwitchRoles(),
+                ...service.getTeamRoles(),
+                ...service.getFirebotRoles(),
+                ...service.getCustomRoles()
+            ];
 
             service.getRoleById = function(id) {
                 let customRole = customRoles[id];

--- a/shared/twitch-roles.js
+++ b/shared/twitch-roles.js
@@ -45,6 +45,10 @@ function mapMixerRoleIdToTwitchRoleId(mixerRoleId) {
 }
 
 exports.getTwitchRoles = () => twitchRoles;
+/**
+ * @param {string} role
+ * @returns {{id: string; name: string}}
+ * */
 exports.mapTwitchRole = role => {
     if (role === "founder") {
         return twitchRoles.find(r => r.id === 'sub');


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
The stream team roles were not working in the Viewers Roles condition because `teamRolesManager.getAllTeamRolesForViewer` returns a Promise that we were not awaiting on. 

While I was at it I also did some general clean up of really old code + added some JSDocs.

@CaveMobster I am requesting a review from you as you worked in this recently and are the most familiar, so let me know if I forgot anything. I am also wondering if you would be willing pull down this branch and briefly test the Viewers Roles condition to confirm the fix. I am not in any stream teams so I cannot do so myself :( 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1130

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
