### PR TITLE
Add a variable for total bits cheered in the channel

### DIFF
--- a/backend/events/builtin/twitchEventSource.js
+++ b/backend/events/builtin/twitchEventSource.js
@@ -124,12 +124,13 @@ module.exports = {
             cached: false,
             manualMetadata: {
                 username: "Firebot",
-                totalBits: 100
+                bits: 100,
+                totalBits: 1200
             },
             activityFeed: {
                 icon: "fad fa-diamond",
                 getMessage: (eventData) => {
-                    return `**${eventData.username}** cheered **${eventData.totalBits}** bits`;
+                    return `**${eventData.username}** cheered **${eventData.bits}** bits. A total of **${eventData.totalBits}** were cheered by **${eventData.username}** in the channel.`;
                 }
             }
         },

--- a/backend/events/filters/builtin/cheer-bits-amount.js
+++ b/backend/events/filters/builtin/cheer-bits-amount.js
@@ -14,7 +14,7 @@ module.exports = {
         const { comparisonType, value } = filterSettings;
         const { eventMeta } = eventData;
 
-        const bitsAmount = eventMeta.totalBits || 0;
+        const bitsAmount = eventMeta.bits || 0;
 
 
         switch (comparisonType) {

--- a/backend/events/twitch-events/cheer.js
+++ b/backend/events/twitch-events/cheer.js
@@ -2,9 +2,10 @@
 
 const eventManager = require("../../events/EventManager");
 
-exports.triggerCheer = (username, totalBits, message = "") => {
+exports.triggerCheer = (username, bits, totalBits, message = "") => {
     eventManager.triggerEvent("twitch", "cheer", {
         username,
+        bits,
         totalBits,
         message
     });

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -75,7 +75,6 @@ async function createClient() {
     }
 
     try {
-
         const rewardRedemptionHandler =
         require("../../events/twitch-events/reward-redemption");
         const redemptionListener = await pubSubClient.onRedemption(streamer.userId,
@@ -84,6 +83,12 @@ async function createClient() {
             });
 
         listeners.push(redemptionListener);
+
+        const bitsListener = await pubSubClient.onBits(streamer.userId, (event) => {
+            const cheerListener = require("../../events/twitch-events/cheer");
+            cheerListener.triggerCheer(event.userName, event.bits, event.message);
+        });
+        listeners.push(bitsListener);
     } catch (err) {
         logger.error("Failed to connect to Twitch PubSub!", err);
         return;

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -86,7 +86,7 @@ async function createClient() {
 
         const bitsListener = await pubSubClient.onBits(streamer.userId, (event) => {
             const cheerListener = require("../../events/twitch-events/cheer");
-            cheerListener.triggerCheer(event.userName, event.bits, event.message);
+            cheerListener.triggerCheer(event.userName, event.bits, event.totalBits, event.message);
         });
         listeners.push(bitsListener);
     } catch (err) {

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -19,6 +19,7 @@ exports.loadReplaceVariables = () => {
         'bot',
         'chat-message',
         'chat-messages',
+        'cheer-bits',
         'cheer-message',
         'cheer-total-bits',
         'commafy',

--- a/backend/variables/builtin/cheer-bits.js
+++ b/backend/variables/builtin/cheer-bits.js
@@ -13,14 +13,14 @@ triggers[EffectTrigger.MANUAL] = true;
 const model = {
     definition: {
         handle: "cheerBitsAmount",
-        description: "The total amount of bits in the cheer.",
+        description: "The amount of bits in the cheer.",
         triggers: triggers,
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.NUMBER]
     },
     evaluator: (trigger) => {
-        let totalBits = trigger.metadata.eventData.totalBits || 0;
-        return totalBits;
+        let bits = trigger.metadata.eventData.bits || 0;
+        return bits;
     }
 };
 

--- a/backend/variables/builtin/cheer-total-bits.js
+++ b/backend/variables/builtin/cheer-total-bits.js
@@ -12,8 +12,8 @@ triggers[EffectTrigger.MANUAL] = true;
 
 const model = {
     definition: {
-        handle: "cheerBitsAmount",
-        description: "The total amount of bits in the cheer.",
+        handle: "cheerTotalBits",
+        description: "The total amount of bits cheered by a viewer in the channel.",
         triggers: triggers,
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.NUMBER]


### PR DESCRIPTION
### Description of the Change
This adds a variable to display the total amount of bits cheered in the channel by the associated user.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1127

### Testing
I tested with the test function, unfortunately no way to do live testing.