### PR TITLE
Add an event to catch whispers

### DIFF
--- a/backend/events/builtin/twitchEventSource.js
+++ b/backend/events/builtin/twitchEventSource.js
@@ -219,7 +219,7 @@ module.exports = {
             id: "whisper",
             name: "Whisper",
             description: "When someone sends you a whisper.",
-            cached: false,
+            cached: true,
             manualMetadata: {
                 username: "Firebot",
                 message: "Test whisper"

--- a/backend/events/builtin/twitchEventSource.js
+++ b/backend/events/builtin/twitchEventSource.js
@@ -214,6 +214,22 @@ module.exports = {
                     return `**${eventData.username}** redeemed **${eventData.rewardName}**${eventData.messageText && !!eventData.messageText.length ? `: *${eventData.messageText}*` : ''}`;
                 }
             }
+        },
+        {
+            id: "whisper",
+            name: "Whisper",
+            description: "When someone sends you a whisper.",
+            cached: false,
+            manualMetadata: {
+                username: "Firebot",
+                message: "Test whisper"
+            },
+            activityFeed: {
+                icon: "fad fa-comment-alt",
+                getMessage: (eventData) => {
+                    return `**${eventData.username}** sent you the following whisper: ${eventData.message}`;
+                }
+            }
         }
     ]
 };

--- a/backend/events/filters/builtin/username.js
+++ b/backend/events/filters/builtin/username.js
@@ -18,6 +18,7 @@ module.exports = {
         { eventSourceId: "twitch", eventId: "channel-reward-redemption" },
         { eventSourceId: "twitch", eventId: "viewer-arrived" },
         { eventSourceId: "twitch", eventId: "chat-message" },
+        { eventSourceId: "twitch", eventId: "whisper" },
         { eventSourceId: "streamloots", eventId: "purchase" },
         { eventSourceId: "streamloots", eventId: "redemption" },
         { eventSourceId: "streamlabs", eventId: "follow" }

--- a/backend/events/filters/builtin/viewerRoles.js
+++ b/backend/events/filters/builtin/viewerRoles.js
@@ -20,6 +20,7 @@ module.exports = {
         { eventSourceId: "twitch", eventId: "host" },
         { eventSourceId: "twitch", eventId: "viewer-arrived" },
         { eventSourceId: "twitch", eventId: "chat-message" },
+        { eventSourceId: "twitch", eventId: "whisper" },
         { eventSourceId: "streamloots", eventId: "purchase" },
         { eventSourceId: "streamloots", eventId: "redemption" },
         { eventSourceId: "firebot", eventId: "view-time-update" }

--- a/backend/events/twitch-events/whisper.js
+++ b/backend/events/twitch-events/whisper.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const eventManager = require("../../events/EventManager");
+
+exports.triggerWhisper = (username, message) => {
+    eventManager.triggerEvent("twitch", "whisper", {
+        username,
+        message
+    });
+};

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -86,9 +86,9 @@ async function createClient() {
         listeners.push(redemptionListener);
 
         const whisperListener = await pubSubClient.onWhisper(streamer.userId, (message) => {
-                const whisperListener = require("../../events/twitch-events/whisper");
-                whisperListener.triggerWhisper(message.senderName, message.text);
-            });
+            const whisperListener = require("../../events/twitch-events/whisper");
+            whisperListener.triggerWhisper(message.senderName, message.text);
+        });
         listeners.push(whisperListener);
 
     } catch (err) {

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -84,6 +84,13 @@ async function createClient() {
             });
 
         listeners.push(redemptionListener);
+
+        const whisperListener = await pubSubClient.onWhisper(streamer.userId, (message) => {
+                const whisperListener = require("../../events/twitch-events/whisper");
+                whisperListener.triggerWhisper(message.senderName, message.text);
+            });
+        listeners.push(whisperListener);
+
     } catch (err) {
         logger.error("Failed to connect to Twitch PubSub!", err);
         return;

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -115,7 +115,8 @@ exports.loadReplaceVariables = () => {
         'user',
         'username',
         'usernameArray',
-        'view-time'
+        'view-time',
+        'whisper-message'
     ].forEach(filename => {
         let definition = require(`./builtin/${filename}.js`);
         replaceVariableManager.registerReplaceVariable(definition);

--- a/backend/variables/builtin/whisper-message.js
+++ b/backend/variables/builtin/whisper-message.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const {
+    EffectTrigger
+} = require("../../effects/models/effectModels");
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+let triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:whisper"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model = {
+    definition: {
+        handle: "whisperMessage",
+        description: "The message included with the whisper.",
+        triggers: triggers,
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (trigger) => {
+        const whisperMessage = trigger.metadata.eventData.message || "";
+        return whisperMessage;
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
**Important:** Please look at https://github.com/crowbartools/Firebot/pull/1137 (total bits) first, as there are going to be conflicts.

### Description of the Change
This adds an event to catch whispers sent to the streamer.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1032

### Testing
I made an event with a chat alert effect that includes both username and the message, then whispered my streamer account from my bot account.
