### PR TITLE
Fix typos in the getPermissionType functions

### DIFF
--- a/gui/app/controllers/commandsController.js
+++ b/gui/app/controllers/commandsController.js
@@ -36,7 +36,7 @@
                 },
                 true);
 
-            $scope.getPermisisonType = command => {
+            $scope.getPermissionType = command => {
 
                 let permissions = command.restrictionData && command.restrictionData.restrictions &&
                     command.restrictionData.restrictions.find(r => r.type === "firebot:permissions");

--- a/gui/app/directives/misc/subcommandRow.js
+++ b/gui/app/directives/misc/subcommandRow.js
@@ -30,7 +30,7 @@
             </span>
           </div>
 
-          <div style="width: 25%"><span style="text-transform: capitalize;">{{$ctrl.getPermisisonType()}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip()"></tooltip></div>
+          <div style="width: 25%"><span style="text-transform: capitalize;">{{$ctrl.getPermissionType()}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip()"></tooltip></div>
 
           <div style="width: 25%">
             <div style="min-width: 75px">
@@ -192,7 +192,7 @@
                 $ctrl.subcommand.effects = effects;
             };
 
-            $ctrl.getPermisisonType = () => {
+            $ctrl.getPermissionType = () => {
                 let command = $ctrl.subcommand;
 
                 let permissions = command.restrictionData && command.restrictionData.restrictions &&

--- a/gui/app/directives/misc/sysCommandRow.js
+++ b/gui/app/directives/misc/sysCommandRow.js
@@ -18,7 +18,7 @@
                 <i class="far fa-user"></i> {{$ctrl.command.cooldown.user ? $ctrl.command.cooldown.user + "s" : "-" }}
             </span>
           </div>
-          <div style="width: 20%"><span style="text-transform: capitalize;">{{$ctrl.getPermisisonType($ctrl.command)}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip($ctrl.command)"></tooltip></div>
+          <div style="width: 20%"><span style="text-transform: capitalize;">{{$ctrl.getPermissionType($ctrl.command)}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip($ctrl.command)"></tooltip></div>
           <div style="width: 20%">
             <div style="min-width: 75px">
                 <span class="status-dot" ng-class="{'active': $ctrl.command.active, 'notactive': !$ctrl.command.active}"></span> {{$ctrl.command.active ? "Enabled" : "Disabled"}}
@@ -58,7 +58,7 @@
                     </div>
                     <div style="display: inline-block;">
                         <div><span class="muted" style="font-size: 10px;"><i class="fas fa-lock-alt"></i> PERMISSIONS</span></div>
-                        <div><span style="text-transform: capitalize;">{{$ctrl.getPermisisonType(subCmd, true)}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip(subCmd, true)"></tooltip></div>
+                        <div><span style="text-transform: capitalize;">{{$ctrl.getPermissionType(subCmd, true)}}</span> <tooltip type="info" text="$ctrl.getPermissionTooltip(subCmd, true)"></tooltip></div>
                     </div>
                 </div>-->                
               </div>
@@ -104,7 +104,7 @@
                 }
             };*/
 
-            $ctrl.getPermisisonType = (command, isSub) => {
+            $ctrl.getPermissionType = (command, isSub) => {
 
                 let permissions = command.restrictionData && command.restrictionData.restrictions &&
                   command.restrictionData.restrictions.find(r => r.type === "firebot:permissions");

--- a/gui/app/templates/chat/_commands.html
+++ b/gui/app/templates/chat/_commands.html
@@ -79,7 +79,7 @@
                                 </span>                           
                             </td>
                             <td>
-                                <span style="text-transform: capitalize;">{{getPermisisonType(command)}}</span> <tooltip type="info" text="getPermissionTooltip(command)"></tooltip>
+                                <span style="text-transform: capitalize;">{{getPermissionType(command)}}</span> <tooltip type="info" text="getPermissionTooltip(command)"></tooltip>
                             </td>
                             <td style="max-width: 135px;min-width: 100px;">
                                 <div style="display: flex; flex-wrap: wrap; width: 100%; overflow: auto;max-height: 45.25px;">


### PR DESCRIPTION
### Description of the Change
Fixes typos in the `getPermissionType` function name.


### Applicable Issues
n/a