### PR TITLE
Add a default value when cumulative months and streak are not defined

### DIFF
--- a/backend/events/twitch-events/sub.js
+++ b/backend/events/twitch-events/sub.js
@@ -17,14 +17,17 @@ function getSubType (subPlan) {
 
 exports.triggerSub = (subInfo) => {
     const subType = getSubType(subInfo.subPlan);
+    const totalMonths = subInfo.months ? subInfo.months : 1;
+    const streak = subInfo.streakMonths ? subInfo.streakMonths : 1;
+    const isPrime = subInfo.subPlan === "Prime";
 
     eventManager.triggerEvent("twitch", "sub", {
         username: subInfo.userDisplayName,
         subPlan: subInfo.subPlan,
         subType: subType,
-        totalMonths: subInfo.months,
-        streak: subInfo.streakMonths,
-        isPrime: subInfo.subPlan === "Prime",
+        totalMonths: totalMonths,
+        streak: streak,
+        isPrime: isPrime,
         isResub: subInfo.isResub
     });
 };


### PR DESCRIPTION
### Description of the Change
This fixes the situations where `totalMonths` and `streak` for subs are undefined, for example when someone subscribes on the channel for the first time.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1151


### Testing
I can't really test this other than firing a manual event. Unless there is another way to test it?
