### PR TITLE
Refactor the twitch events imports to use a general export module

### DIFF
--- a/backend/chat/twitch-chat.js
+++ b/backend/chat/twitch-chat.js
@@ -296,8 +296,8 @@ frontendCommunicator.on("send-chat-message", async sendData => {
         let firebotMessage = await chatHelpers.buildFirebotChatMessageFromText(message);
         commandHandler.handleChatMessage(firebotMessage);
 
-        const chatMessageListener = require("../events/twitch-events/chat-message");
-        chatMessageListener.triggerChatMessage(firebotMessage);
+        const twitchEventsHandler = require("../events/twitch-events");
+        twitchEventsHandler.chatMessage.triggerChatMessage(firebotMessage);
     }
 
     twitchChat.sendChatMessage(message, null, accountType);

--- a/backend/events/twitch-events.js
+++ b/backend/events/twitch-events.js
@@ -1,0 +1,14 @@
+"use strict";
+
+exports.chatMessage = require('./twitch-events/chat-message');
+exports.cheer = require('./twitch-events/cheer');
+exports.follow = require('./twitch-events/follow');
+exports.giftSub = require('./twitch-events/gift-sub');
+exports.host = require('./twitch-events/host');
+exports.raid = require('./twitch-events/raid');
+exports.rewardRedemption = require('./twitch-events/reward-redemption');
+exports.sub = require('./twitch-events/sub');
+exports.viewerArrived = require('./twitch-events/viewer-arrived');
+exports.viewerBanned = require('./twitch-events/viewer-banned');
+exports.viewerTimeout = require('./twitch-events/viewer-timeout');
+exports.whisper = require('./twitch-events/whisper');

--- a/backend/twitch-api/follow-poll.js
+++ b/backend/twitch-api/follow-poll.js
@@ -4,7 +4,7 @@ const accountAccess = require("../common/account-access");
 
 const twitchApi = require("./client");
 
-const followEvent = require("../events/twitch-events/follow");
+const twitchEventsHandler = require("../events/twitch-events");
 
 let followPollIntervalId;
 let lastUserId;
@@ -43,7 +43,7 @@ exports.startFollowPoll = () => {
                 }
 
                 if (follow.userId !== lastUserId) {
-                    followEvent.triggerFollow(follow.userDisplayName, follow.userId);
+                    twitchEventsHandler.follow.triggerFollow(follow.userDisplayName, follow.userId);
                 } else {
                     break;
                 }

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -75,31 +75,28 @@ async function createClient() {
     }
 
     try {
-        const rewardRedemptionHandler =
-        require("../../events/twitch-events/reward-redemption");
+        const twitchEventsHandler = require('../../events/twitch-events');
+
         const redemptionListener = await pubSubClient.onRedemption(streamer.userId,
             (message) => {
-                rewardRedemptionHandler.handleRewardRedemption(message);
+                twitchEventsHandler.rewardRedemption.handleRewardRedemption(message);
             });
 
         listeners.push(redemptionListener);
 
         const whisperListener = await pubSubClient.onWhisper(streamer.userId, (message) => {
-            const whisperListener = require("../../events/twitch-events/whisper");
-            whisperListener.triggerWhisper(message.senderName, message.text);
+            twitchEventsHandler.whisper.triggerWhisper(message.senderName, message.text);
         });
         listeners.push(whisperListener);
 
         const bitsListener = await pubSubClient.onBits(streamer.userId, (event) => {
-            const cheerListener = require("../../events/twitch-events/cheer");
-            cheerListener.triggerCheer(event.userName, event.isAnonymous, event.bits, event.totalBits, event.message);
+            twitchEventsHandler.cheer.triggerCheer(event.userName, event.isAnonymous, event.bits, event.totalBits, event.message);
         });
         listeners.push(bitsListener);
 
         const subsListener = await pubSubClient.onSubscription(streamer.userId, (subInfo) => {
             if (!subInfo.isGift) {
-                const subsHandler = require("../../events/twitch-events/sub");
-                subsHandler.triggerSub(subInfo);
+                twitchEventsHandler.sub.triggerSub(subInfo);
             }
         });
         listeners.push(subsListener);


### PR DESCRIPTION
### Description of the Change
This is refactor to group all of the twitch events, so that only one import is needed in `pubsub-client.js` and `twitch-chat-listeners.js`. 


### Applicable Issues
n/a


### Testing
Checked if the chat message and viewer events still worked as before.