### PR TITLE
Add a variable for sub messages

### DIFF
--- a/backend/events/twitch-events/sub.js
+++ b/backend/events/twitch-events/sub.js
@@ -29,6 +29,7 @@ exports.triggerSub = (subInfo) => {
         subPlan: subInfo.subPlan,
         subType: subType,
         totalMonths: totalMonths || 1,
+        subMessage: subInfo.message.message || "",
         streak: streak,
         isPrime: isPrime,
         isResub: subInfo.isResub

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -86,6 +86,7 @@ exports.loadReplaceVariables = () => {
         'stream-title',
         'streamer',
         'sub-count',
+        'sub-message',
         'sub-months',
         'sub-streak',
         'sub-type',

--- a/backend/variables/builtin/sub-message.js
+++ b/backend/variables/builtin/sub-message.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const {
+    EffectTrigger
+} = require("../../effects/models/effectModels");
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+let triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:sub"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model = {
+    definition: {
+        handle: "subMessage",
+        description: "The message included with a resubscription.",
+        triggers: triggers,
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData.message || "";
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
This adds a variable to the subscription event to display the resub message if it's available.


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1186


### Testing
I temporarily hardcoded the return value of the variable to test if the variable itself is working. Unfortunately there is no way to test an actual sub message.