### PR TITLE
Add a url moderation feature to the moderation tools

### DIFF
--- a/backend/chat/chat-listeners/listeners/chat-message-streamer-listener.js
+++ b/backend/chat/chat-listeners/listeners/chat-message-streamer-listener.js
@@ -14,7 +14,7 @@ module.exports = {
         const timerManager = require("../../../timers/timer-manager");
 
         //Send to chat moderation service
-        chatModerationManager.moderateMessage(data);
+        await chatModerationManager.moderateMessage(data);
 
         // Send to command router to see if we need to act on a command.
         commandHandler.handleChatEvent(data).catch(reason => {

--- a/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -28,7 +28,7 @@ exports.setupChatListeners = (streamerChatClient) => {
     streamerChatClient.onPrivmsg(async (_channel, user, messageText, msg) => {
         const firebotChatMessage = await chatHelpers.buildFirebotChatMessage(msg, messageText);
 
-        chatModerationManager.moderateMessage(firebotChatMessage);
+        await chatModerationManager.moderateMessage(firebotChatMessage);
 
         // send to the frontend
         if (firebotChatMessage.isHighlighted) {

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -23,7 +23,8 @@ let chatModerationSettings = {
         viewTime: {
             enabled: false,
             viewTimeInHours: 0
-        }
+        },
+        outputMessage: ""
     },
     exemptRoles: []
 };
@@ -142,6 +143,7 @@ async function moderateMessage(chatMessage) {
 
         if (chatModerationSettings.urlModeration.enabled) {
             const message = chatMessage.rawText;
+            let outputMessage = chatModerationSettings.urlModeration.outputMessage || "";
             const regex = new RegExp(/[\w][.][a-zA-Z]/, "gi");
 
             if (!regex.test(message)) return;
@@ -157,12 +159,19 @@ async function moderateMessage(chatMessage) {
 
                 if (viewerViewTime > minimumViewTime) return;
 
+                outputMessage = outputMessage.replace("{viewTime}", minimumViewTime.toString());
+
                 logger.debug("Url moderation: Not enough view time...");
             } else {
                 logger.debug("Url moderation: User does not have exempt role...");
             }
 
             chat.deleteMessage(chatMessage.id);
+
+            if (outputMessage) {
+                outputMessage = outputMessage.replace("{userName}", chatMessage.username);
+                chat.sendChatMessage(outputMessage);
+            }
         }
 
         const message = chatMessage.rawText;

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -19,8 +19,10 @@ let chatModerationSettings = {
     },
     urlModeration: {
         enabled: false,
-        viewTimeEnabled: false,
-        viewTime: 0
+        viewTime: {
+            enabled: false,
+            hours: 0
+        }
     },
     exemptRoles: []
 };
@@ -137,13 +139,13 @@ async function moderateMessage(chatMessage) {
         }
 
         if (chatModerationSettings.urlModeration.enabled) {
-            const viewerDB = require('../../database/userDatabase');
-            const viewer = await viewerDB.getUserByUsername(chatMessage.username);
-            
-            const viewerViewTime = viewer.minutesInChannel / 60;
-            const viewTime = chatModerationSettings.urlModeration.viewTime;
-            
-            if (chatModerationSettings.urlModeration.viewTimeEnabled) {
+            if (chatModerationSettings.urlModeration.viewTime.enabled) {
+                const viewerDB = require('../../database/userDatabase');
+                const viewer = await viewerDB.getUserByUsername(chatMessage.username);
+                
+                const viewerViewTime = viewer.minutesInChannel / 60;
+                const viewTime = chatModerationSettings.urlModeration.viewTime.hours;
+
                 if (viewerViewTime < viewTime) {
                     const chat = require("../twitch-chat");
                     chat.deleteMessage(chatMessage.id);

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -249,6 +249,10 @@ function load() {
             if (settings.emoteLimit == null) {
                 settings.emoteLimit = { enabled: false, max: 10 };
             }
+
+            if (settings.urlModeration.enabled) {
+                permitCommand.registerPermitCommand();
+            }
         }
 
         let words = getBannedWordsDb().getData("/");

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -17,6 +17,11 @@ let chatModerationSettings = {
         enabled: false,
         max: 10
     },
+    urlModeration: {
+        enabled: false,
+        viewTimeEnabled: false,
+        viewTime: 0
+    },
     exemptRoles: []
 };
 

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -143,19 +143,21 @@ async function moderateMessage(chatMessage) {
             if (permitCommand.hasTemporaryPermission(chatMessage.username)) return;
 
             const message = chatMessage.rawText;
-            let outputMessage = chatModerationSettings.urlModeration.outputMessage || "";
             const regex = new RegExp(/[\w][.][a-zA-Z]/, "gi");
 
             if (!regex.test(message)) return;
 
             logger.debug("Url moderation: Found url in message...");
 
-            if (chatModerationSettings.urlModeration.viewTime && chatModerationSettings.urlModeration.viewTime.enabled) {
+            const settings = chatModerationSettings.urlModeration;
+            let outputMessage = settings.outputMessage || "";
+
+            if (settings.viewTime && settings.viewTime.enabled) {
                 const viewerDB = require('../../database/userDatabase');
                 const viewer = await viewerDB.getUserByUsername(chatMessage.username);
 
                 const viewerViewTime = viewer.minutesInChannel / 60;
-                const minimumViewTime = chatModerationSettings.urlModeration.viewTime.viewTimeInHours;
+                const minimumViewTime = settings.viewTime.viewTimeInHours;
 
                 if (viewerViewTime > minimumViewTime) return;
 

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -19,6 +19,7 @@ let chatModerationSettings = {
     },
     urlModeration: {
         enabled: false,
+        permitDuration: 0,
         viewTime: {
             enabled: false,
             hours: 0

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -141,14 +141,23 @@ async function moderateMessage(chatMessage) {
         }
 
         if (chatModerationSettings.urlModeration.enabled) {
+            const message = chatMessage.rawText;
+            const urlRegex = /[\w][.][a-zA-Z]/;
+            const regex = new RegExp(urlRegex, "gi");
+
+            if (!regex.test(message)) return;
+
+            logger.debug("Url moderation: Found url in message...");
+
             if (chatModerationSettings.urlModeration.viewTime && chatModerationSettings.urlModeration.viewTime.enabled) {
                 const viewerDB = require('../../database/userDatabase');
                 const viewer = await viewerDB.getUserByUsername(chatMessage.username);
                 
                 const viewerViewTime = viewer.minutesInChannel / 60;
-                const viewTime = chatModerationSettings.urlModeration.viewTime.hours;
+                const viewTime = chatModerationSettings.urlModeration.viewTime.viewTimeInHours;
 
                 if (viewerViewTime < viewTime) {
+                    logger.debug("Url moderation: Not enough view time...");
                     chat.deleteMessage(chatMessage.id);
                     return;
                 }

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -20,7 +20,6 @@ let chatModerationSettings = {
     },
     urlModeration: {
         enabled: false,
-        permitDurationInSeconds: 0,
         viewTime: {
             enabled: false,
             viewTimeInHours: 0
@@ -142,7 +141,7 @@ async function moderateMessage(chatMessage) {
         }
 
         if (chatModerationSettings.urlModeration.enabled) {
-            if (chatModerationSettings.urlModeration.viewTime.enabled) {
+            if (chatModerationSettings.urlModeration.viewTime && chatModerationSettings.urlModeration.viewTime.enabled) {
                 const viewerDB = require('../../database/userDatabase');
                 const viewer = await viewerDB.getUserByUsername(chatMessage.username);
                 

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -19,10 +19,10 @@ let chatModerationSettings = {
     },
     urlModeration: {
         enabled: false,
-        permitDuration: 0,
+        permitDurationInSeconds: 0,
         viewTime: {
             enabled: false,
-            hours: 0
+            viewTimeInHours: 0
         }
     },
     exemptRoles: []
@@ -127,13 +127,14 @@ async function moderateMessage(chatMessage) {
     }
 
     if (moderateMessage) {
+        const chat = require("../twitch-chat");
+
         if (chatModerationSettings.emoteLimit.enabled && !!chatModerationSettings.emoteLimit.max) {
             const emoteCount = chatMessage.parts.filter(p => p.type === "emote").length;
             const emojiCount = chatMessage.parts
                 .filter(p => p.type === "text")
                 .reduce((acc, part) => acc + countEmojis(part.text), 0);
             if ((emoteCount + emojiCount) > chatModerationSettings.emoteLimit.max) {
-                const chat = require("../twitch-chat");
                 chat.deleteMessage(chatMessage.id);
                 return;
             }
@@ -148,7 +149,6 @@ async function moderateMessage(chatMessage) {
                 const viewTime = chatModerationSettings.urlModeration.viewTime.hours;
 
                 if (viewerViewTime < viewTime) {
-                    const chat = require("../twitch-chat");
                     chat.deleteMessage(chatMessage.id);
                     return;
                 }

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -158,6 +158,8 @@ async function moderateMessage(chatMessage) {
                 if (viewerViewTime > minimumViewTime) return;
 
                 logger.debug("Url moderation: Not enough view time...");
+            } else {
+                logger.debug("Url moderation: User does not have exempt role...");
             }
 
             chat.deleteMessage(chatMessage.id);

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -4,6 +4,7 @@ const profileManager = require("../../common/profile-manager");
 const { Worker } = require("worker_threads");
 const frontendCommunicator = require("../../common/frontend-communicator");
 const rolesManager = require("../../roles/custom-roles-manager");
+const permitCommand = require("./url-permit-command");
 
 let getChatModerationSettingsDb = () => profileManager.getJsonDbInProfile("/chat/moderation/chat-moderation-settings");
 let getBannedWordsDb = () => profileManager.getJsonDbInProfile("/chat/moderation/banned-words", false);
@@ -218,6 +219,14 @@ frontendCommunicator.on("getChatModerationData", () => {
         settings: chatModerationSettings,
         bannedWords: bannedWords.words
     };
+});
+
+frontendCommunicator.on("registerPermitCommand", () => {
+    permitCommand.registerPermitCommand();
+});
+
+frontendCommunicator.on("unregisterPermitCommand", () => {
+    permitCommand.unregisterPermitCommand();
 });
 
 function load() {

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -114,9 +114,7 @@ async function moderateMessage(chatMessage) {
         !chatModerationSettings.bannedWordList.enabled
         && !chatModerationSettings.emoteLimit.enabled
         && !chatModerationSettings.urlModeration.enabled
-    ) {
-        return;
-    }
+    ) return;
 
     let moderateMessage = false;
 
@@ -155,7 +153,7 @@ async function moderateMessage(chatMessage) {
             if (chatModerationSettings.urlModeration.viewTime && chatModerationSettings.urlModeration.viewTime.enabled) {
                 const viewerDB = require('../../database/userDatabase');
                 const viewer = await viewerDB.getUserByUsername(chatMessage.username);
-                
+
                 const viewerViewTime = viewer.minutesInChannel / 60;
                 const minimumViewTime = chatModerationSettings.urlModeration.viewTime.viewTimeInHours;
 
@@ -261,7 +259,7 @@ function load() {
                         viewTimeInHours: 0
                     },
                     outputMessage: ""
-                }
+                };
             }
 
             if (settings.urlModeration.enabled) {

--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -142,8 +142,7 @@ async function moderateMessage(chatMessage) {
 
         if (chatModerationSettings.urlModeration.enabled) {
             const message = chatMessage.rawText;
-            const urlRegex = /[\w][.][a-zA-Z]/;
-            const regex = new RegExp(urlRegex, "gi");
+            const regex = new RegExp(/[\w][.][a-zA-Z]/, "gi");
 
             if (!regex.test(message)) return;
 
@@ -154,14 +153,14 @@ async function moderateMessage(chatMessage) {
                 const viewer = await viewerDB.getUserByUsername(chatMessage.username);
                 
                 const viewerViewTime = viewer.minutesInChannel / 60;
-                const viewTime = chatModerationSettings.urlModeration.viewTime.viewTimeInHours;
+                const minimumViewTime = chatModerationSettings.urlModeration.viewTime.viewTimeInHours;
 
-                if (viewerViewTime < viewTime) {
-                    logger.debug("Url moderation: Not enough view time...");
-                    chat.deleteMessage(chatMessage.id);
-                    return;
-                }
+                if (viewerViewTime > minimumViewTime) return;
+
+                logger.debug("Url moderation: Not enough view time...");
             }
+
+            chat.deleteMessage(chatMessage.id);
         }
 
         const message = chatMessage.rawText;

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -18,6 +18,19 @@ const permitCommand = {
         autoDeleteTrigger: false,
         scanWholeMessage: false,
         hideCooldowns: true,
+        restrictionData: {
+            restrictions: [
+                {
+                    id: "sys-cmd-mods-only-perms",
+                    type: "firebot:permissions",
+                    mode: "roles",
+                    roleIds: [
+                        "broadcaster",
+                        "mod"
+                    ]
+                }
+            ]
+        },
         options: {
             permitDuration: {
                 type: "number",

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const util = require("../../utility");
-const twitchChat = require("../twitch-chat");
 const commandManager = require("../commands/CommandManager");
 
 const PERMIT_COMMAND_ID = "firebot:moderation:url:permit";
@@ -18,7 +16,7 @@ const permitCommand = {
         scanWholeMessage: false,
         hideCooldowns: true,
         options: {
-            permitDurationTemplate: {
+            permitDuration: {
                 type: "number",
                 title: "Duration in seconds",
                 description: "The amount of time the viewer has to post a link after the !permit command is used."
@@ -36,10 +34,9 @@ const permitCommand = {
     onTriggerEvent: async event => {
         const { commandOptions } = event;
         const target = event.userCommand.args[0];
-        const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDurationTemplate);
+        const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration);
 
-        console.log(event);
-
+        const twitchChat = require("../twitch-chat");
         twitchChat.sendChatMessage(message);
     }
 };

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -63,7 +63,7 @@ const permitCommand = {
 
         const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration);
 
-        if (message) {    
+        if (message) {
             twitchChat.sendChatMessage(message);
         }
 

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -5,7 +5,7 @@ const commandManager = require("../commands/CommandManager");
 const frontendCommunicator = require("../../common/frontend-communicator");
 
 const PERMIT_COMMAND_ID = "firebot:moderation:url:permit";
-let tempPermittedUser = "";
+let tempPermittedUsers = [];
 
 const permitCommand = {
     definition: {
@@ -58,7 +58,7 @@ const permitCommand = {
             return;
         }
 
-        tempPermittedUser = target;
+        tempPermittedUsers.push(target);
         logger.debug(`Url moderation: ${target} has been temporary permitted to post a url...`);
 
         const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration);
@@ -68,14 +68,14 @@ const permitCommand = {
         }
 
         setTimeout(() => {
-            tempPermittedUser = "";
+            tempPermittedUsers = tempPermittedUsers.filter(user => user !== target);
             logger.debug(`Url moderation: Temporary url permission for ${target} expired.`);
         }, commandOptions.permitDuration * 1000);
     }
 };
 
 function hasTemporaryPermission(username) {
-    return username === tempPermittedUser;
+    return tempPermittedUsers.includes(username);
 }
 
 function registerPermitCommand() {

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const util = require("../../utility");
+const twitchChat = require("../../chat/twitch-chat");
+const commandManager = require("../../chat/commands/CommandManager");
+
+const PERMIT_COMMAND_ID = "firebot:moderation:url:permit";
+
+const permitCommand = {
+    definition: {
+        id: PERMIT_COMMAND_ID,
+        name: "Permit",
+        active: true,
+        trigger: "!permit",
+        usage: "[target]",
+        description: "Permits a viewer to post a url for a set duration (see Moderation -> Url Moderation).",
+        autoDeleteTrigger: false,
+        scanWholeMessage: false,
+        hideCooldowns: true,
+        options: {
+            permitDisplayTemplate: {
+                type: "string",
+                title: "Output Template",
+                description: "How the permit message is formatted",
+                tip: "Variables: {target}, {duration}",
+                default: `{target}, you have {duration} seconds to post your url in the chat.`,
+                useTextArea: true
+            }
+        }
+    },
+    onTriggerEvent: async event => {
+        // To do
+    }
+};
+
+function registerPermitCommand() {
+    if (!commandManager.hasSystemCommand(PERMIT_COMMAND_ID)) {
+        commandManager.registerSystemCommand(permitCommand);
+    }
+}
+
+function unregisterPermitCommand() {
+    commandManager.unregisterSystemCommand(PERMIT_COMMAND_ID);
+}
+
+exports.registerPermitCommand = registerPermitCommand;
+exports.unregisterPermitCommand = unregisterPermitCommand;

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -49,15 +49,21 @@ const permitCommand = {
         }
     },
     onTriggerEvent: async event => {
+        const twitchChat = require("../twitch-chat");
         const { commandOptions } = event;
         const target = event.userCommand.args[0];
-        const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration);
+
+        if (!target) {
+            twitchChat.sendChatMessage("Please specify a user to permit.");
+            return;
+        }
 
         tempPermittedUser = target;
         logger.debug(`Url moderation: ${target} has been temporary permitted to post a url...`);
 
-        if (message) {
-            const twitchChat = require("../twitch-chat");
+        const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration);
+
+        if (message) {    
             twitchChat.sendChatMessage(message);
         }
 

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -28,7 +28,7 @@ const permitCommand = {
             permitDisplayTemplate: {
                 type: "string",
                 title: "Output Template",
-                description: "How the permit message is formatted",
+                description: "The chat message shown when the permit command is used (leave empty for no message).",
                 tip: "Variables: {target}, {duration}",
                 default: `{target}, you have {duration} seconds to post your url in the chat.`,
                 useTextArea: true
@@ -43,8 +43,10 @@ const permitCommand = {
         tempPermittedUser = target;
         logger.debug(`Url moderation: ${target} has been temporary permitted to post a url...`);
 
-        const twitchChat = require("../twitch-chat");
-        twitchChat.sendChatMessage(message);
+        if (message) {
+            const twitchChat = require("../twitch-chat");
+            twitchChat.sendChatMessage(message);
+        }
 
         setTimeout(() => {
             tempPermittedUser = "";

--- a/backend/chat/moderation/url-permit-command.js
+++ b/backend/chat/moderation/url-permit-command.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const util = require("../../utility");
-const twitchChat = require("../../chat/twitch-chat");
-const commandManager = require("../../chat/commands/CommandManager");
+const twitchChat = require("../twitch-chat");
+const commandManager = require("../commands/CommandManager");
 
 const PERMIT_COMMAND_ID = "firebot:moderation:url:permit";
 
@@ -18,6 +18,11 @@ const permitCommand = {
         scanWholeMessage: false,
         hideCooldowns: true,
         options: {
+            permitDurationTemplate: {
+                type: "number",
+                title: "Duration in seconds",
+                description: "The amount of time the viewer has to post a link after the !permit command is used."
+            },
             permitDisplayTemplate: {
                 type: "string",
                 title: "Output Template",
@@ -29,7 +34,13 @@ const permitCommand = {
         }
     },
     onTriggerEvent: async event => {
-        // To do
+        const { commandOptions } = event;
+        const target = event.userCommand.args[0];
+        const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDurationTemplate);
+
+        console.log(event);
+
+        twitchChat.sendChatMessage(message);
     }
 };
 

--- a/gui/app/controllers/moderation.controller.js
+++ b/gui/app/controllers/moderation.controller.js
@@ -79,7 +79,7 @@
                     chatModerationService.chatModerationData.settings.urlModeration.enabled = false;
                     chatModerationService.unregisterPermitCommand();
                 }
-                    
+
                 chatModerationService.saveChatModerationSettings();
             };
 

--- a/gui/app/controllers/moderation.controller.js
+++ b/gui/app/controllers/moderation.controller.js
@@ -29,7 +29,8 @@
             $scope.getExemptRoles = () => {
                 return [
                     ...viewerRolesService.getTwitchRoles(),
-                    ...viewerRolesService.getCustomRoles()
+                    ...viewerRolesService.getCustomRoles(),
+                    ...viewerRolesService.getTeamRoles()
                 ].filter(r => chatModerationService.chatModerationData.settings.exemptRoles.includes(r.id));
             };
 
@@ -38,7 +39,8 @@
                 const options =
                     [
                         ...viewerRolesService.getTwitchRoles(),
-                        ...viewerRolesService.getCustomRoles()
+                        ...viewerRolesService.getCustomRoles(),
+                        ...viewerRolesService.getTeamRoles()
                     ]
                         .filter(r =>
                             !chatModerationService.chatModerationData.settings.exemptRoles.includes(r.id))
@@ -68,12 +70,6 @@
             };
 
             $scope.cms = chatModerationService;
-
-            $scope.toggleBannedWordsFeature = () => {
-                chatModerationService.chatModerationData.settings.bannedWordList.enabled =
-                    !chatModerationService.chatModerationData.settings.bannedWordList.enabled;
-                chatModerationService.saveChatModerationSettings();
-            };
 
             $scope.showEditBannedWordsModal = () => {
                 utilityService.showModal({

--- a/gui/app/controllers/moderation.controller.js
+++ b/gui/app/controllers/moderation.controller.js
@@ -73,11 +73,11 @@
 
             $scope.toggleUrlModerationFeature = () => {
                 if (!chatModerationService.chatModerationData.settings.urlModeration.enabled) {
-                    chatModerationService.chatModerationData.settings.urlModeration.enabled = false;
-                    chatModerationService.unregisterPermitCommand();
-                } else {
                     chatModerationService.chatModerationData.settings.urlModeration.enabled = true;
                     chatModerationService.registerPermitCommand();
+                } else {
+                    chatModerationService.chatModerationData.settings.urlModeration.enabled = false;
+                    chatModerationService.unregisterPermitCommand();
                 }
                     
                 chatModerationService.saveChatModerationSettings();

--- a/gui/app/controllers/moderation.controller.js
+++ b/gui/app/controllers/moderation.controller.js
@@ -71,6 +71,18 @@
 
             $scope.cms = chatModerationService;
 
+            $scope.toggleUrlModerationFeature = () => {
+                if (!chatModerationService.chatModerationData.settings.urlModeration.enabled) {
+                    chatModerationService.chatModerationData.settings.urlModeration.enabled = false;
+                    chatModerationService.unregisterPermitCommand();
+                } else {
+                    chatModerationService.chatModerationData.settings.urlModeration.enabled = true;
+                    chatModerationService.registerPermitCommand();
+                }
+                    
+                chatModerationService.saveChatModerationSettings();
+            };
+
             $scope.showEditBannedWordsModal = () => {
                 utilityService.showModal({
                     component: "editBannedWordsModal",

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -19,7 +19,9 @@
                         max: 10
                     },
                     urlModeration: {
-                        enabled: false
+                        enabled: false,
+                        viewTimeEnabled: false,
+                        viewTime: 0
                     },
                     exemptRoles: []
                 },

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -20,10 +20,10 @@
                     },
                     urlModeration: {
                         enabled: false,
-                        permitDuration: 0,
+                        permitDurationInSeconds: 0,
                         viewTime: {
                             enabled: false,
-                            hours: 0
+                            viewTimeInHours: 0
                         }
                     },
                     exemptRoles: []

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -20,7 +20,6 @@
                     },
                     urlModeration: {
                         enabled: false,
-                        permitDurationInSeconds: 0,
                         viewTime: {
                             enabled: false,
                             viewTimeInHours: 0

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -20,8 +20,10 @@
                     },
                     urlModeration: {
                         enabled: false,
-                        viewTimeEnabled: false,
-                        viewTime: 0
+                        viewTime: {
+                            enabled: false,
+                            hours: 0
+                        }
                     },
                     exemptRoles: []
                 },

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -18,6 +18,9 @@
                         enabled: false,
                         max: 10
                     },
+                    urlModeration: {
+                        enabled: false
+                    },
                     exemptRoles: []
                 },
                 bannedWords: []

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -20,6 +20,7 @@
                     },
                     urlModeration: {
                         enabled: false,
+                        permitDuration: 0,
                         viewTime: {
                             enabled: false,
                             hours: 0

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -23,7 +23,8 @@
                         viewTime: {
                             enabled: false,
                             viewTimeInHours: 0
-                        }
+                        },
+                        outputMessage: ""
                     },
                     exemptRoles: []
                 },

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -89,6 +89,14 @@
                 backendCommunicator.fireEvent("removeAllBannedWords");
             };
 
+            service.registerPermitCommand = () => {
+                backendCommunicator.fireEvent("registerPermitCommand");
+            };
+
+            service.unregisterPermitCommand = () => {
+                backendCommunicator.fireEvent("unregisterPermitCommand");
+            };
+
             return service;
         });
 }());

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -16,75 +16,79 @@
     <div style="padding: 15px;">
         <div ng-show="activeTab === 0">
 
-          <div class="content-block" style="width: 50%;">
+          <div class="content-block moderation-feature-block">
             <div class="content-block-body">
               <div style="font-weight: 600;font-size: 20px;">Exempt Roles <tooltip text="'These roles are exempt from all Moderation features.'" /></div>
 
               <div style="margin-top: 15px">
                 <div class="role-bar" ng-repeat="role in getExemptRoles() track by role.id">
-                    <span>{{role.name}}</span>
-                    <span class="clickable" style="padding-left: 10px;" ng-click="removeExemptRole(role.id)" uib-tooltip="Remove role" tooltip-append-to-body="true">
-                        <i class="far fa-times"></i>
-                    </span>
+                  <span>{{role.name}}</span>
+                  <span class="clickable" style="padding-left: 10px;" ng-click="removeExemptRole(role.id)" uib-tooltip="Remove role" tooltip-append-to-body="true">
+                    <i class="far fa-times"></i>
+                  </span>
                 </div>
                 <div class="role-bar clickable" ng-click="openAddExemptRoleModal()" uib-tooltip="Add role" tooltip-append-to-body="true">
-                    <i class="far fa-plus"></i> 
+                  <i class="far fa-plus"></i> 
                 </div> 
               </div>
             </div>
           </div>
 
 
-            <div class="content-block" style="width: 50%; margin-top: 15px;">
-                <div class="content-block-body">
-                  <div style="display: flex;align-items: center;justify-content: space-between;">
-                      <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.bannedWordList.enabled }">Banned Word List</div>
-                      <div style="width: 150px; flex-shrink: 0;text-align: right;">
-                          <toggle-button toggle-model="cms.chatModerationData.settings.bannedWordList.enabled" 
-                          on-toggle="toggleBannedWordsFeature()" font-size="40"></toggle-button>
-                      </div> 
-                  </div> 
-
-                  <div style="margin-top: 15px" ng-show="cms.chatModerationData.settings.bannedWordList.enabled">
-                    <div id="roles" class="mixplay-header" style="padding: 0 0 4px 0">
-                        Words
-                    </div>
-                    <button ng-click="showEditBannedWordsModal()" class="btn btn-default">Edit Word List</button>
-                  </div>         
-                </div>
-            </div>
-
-            <div class="content-block" style="width: 50%; margin-top: 15px;">
-                <div class="content-block-body">
-                  <div style="display: flex;align-items: center;justify-content: space-between;">
-                      <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.emoteLimit.enabled }">Emote/Emoji Limit</div>
-                      <div style="width: 150px; flex-shrink: 0;text-align: right;">
-                          <toggle-button 
-                            toggle-model="cms.chatModerationData.settings.emoteLimit.enabled"
-                            auto-update-value="true"
-                            on-toggle="cms.saveChatModerationSettings()" 
-                            font-size="40" />
-                      </div> 
-                  </div> 
-
-                  <div style="margin-top: 15px" ng-show="cms.chatModerationData.settings.emoteLimit.enabled">
-                    <firebot-input
-                      input-title="Max Per Message" 
-                      placeholder-text="Enter number" 
-                      input-type="number" 
-                      disable-variables="true" 
-                      model="cms.chatModerationData.settings.emoteLimit.max"
-                      on-input-update="cms.saveChatModerationSettings()"
-                    />
-                  </div>         
-                </div>
-            </div>
-
-            <div class="content-block" style="width: 50%; margin-top: 15px;">
+            <div class="content-block moderation-feature-block">
               <div class="content-block-body">
-                <div style="display: flex;align-items: center;justify-content: space-between;">
-                  <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url Moderation</div>
-                  <div style="width: 150px; flex-shrink: 0;text-align: right;">
+                <div class="title-toggle-button-container">
+                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.bannedWordList.enabled }">Banned Word List</div>
+                  <div class="toggle-button-container">
+                    <toggle-button 
+                      toggle-model="cms.chatModerationData.settings.bannedWordList.enabled"
+                      on-toggle="toggleBannedWordsFeature()"
+                      font-size="40"
+                    />
+                  </div> 
+                </div> 
+
+                <div style="margin-top: 15px" ng-show="cms.chatModerationData.settings.bannedWordList.enabled">
+                  <div id="roles" class="mixplay-header" style="padding: 0 0 4px 0">
+                      Words
+                  </div>
+                  <button ng-click="showEditBannedWordsModal()" class="btn btn-default">Edit Word List</button>
+                </div>         
+              </div>
+            </div>
+
+            <div class="content-block moderation-feature-block">
+              <div class="content-block-body">
+                <div class="title-toggle-button-container">
+                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.emoteLimit.enabled }">Emote/Emoji Limit</div>
+                  <div class="toggle-button-container">
+                    <toggle-button 
+                      toggle-model="cms.chatModerationData.settings.emoteLimit.enabled"
+                      auto-update-value="true"
+                      on-toggle="cms.saveChatModerationSettings()" 
+                      font-size="40"
+                    />
+                  </div> 
+                </div> 
+
+                <div style="margin-top: 15px" ng-show="cms.chatModerationData.settings.emoteLimit.enabled">
+                  <firebot-input
+                    input-title="Max Per Message" 
+                    placeholder-text="Enter number" 
+                    input-type="number" 
+                    disable-variables="true" 
+                    model="cms.chatModerationData.settings.emoteLimit.max"
+                    on-input-update="cms.saveChatModerationSettings()"
+                  />
+                </div>         
+              </div>
+            </div>
+
+            <div class="content-block moderation-feature-block">
+              <div class="content-block-body">
+                <div class="title-toggle-button-container">
+                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url Moderation</div>
+                  <div class="toggle-button-container">
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
                       on-toggle="cms.saveChatModerationSettings()"
@@ -94,11 +98,12 @@
                 </div>
 
                 <div 
-                  style="margin-top: 15px; margin-left: 15px; display: flex; align-items: center; justify-content: space-between;" 
+                  style="margin-top: 15px; margin-left: 15px;"
+                  class="title-toggle-button-container"
                   ng-show="cms.chatModerationData.settings.urlModeration.enabled"
                 >
-                  <div style="font-weight: 600; font-size: 16px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTimeEnabled }">View Time</div>
-                  <div style="width: 150px; flex-shrink: 0; text-align: right;">
+                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTimeEnabled }">View Time</div>
+                  <div class="toggle-button-container">
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
                       on-toggle="cms.saveChatModerationSettings()"

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -81,18 +81,47 @@
             </div>
 
             <div class="content-block" style="width: 50%; margin-top: 15px;">
-                <div class="content-block-body">
-                  <div style="display: flex;align-items: center;justify-content: space-between;">
-                      <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url moderation</div>
-                      <div style="width: 150px; flex-shrink: 0;text-align: right;">
-                          <toggle-button
-                            toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
-                            on-toggle="cms.saveChatModerationSettings()"
-                            auto-update-value="true"
-                            font-size="40" />
-                      </div> 
-                  </div>        
+              <div class="content-block-body">
+                <div style="display: flex;align-items: center;justify-content: space-between;">
+                  <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url Moderation</div>
+                  <div style="width: 150px; flex-shrink: 0;text-align: right;">
+                    <toggle-button
+                      toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
+                      on-toggle="cms.saveChatModerationSettings()"
+                      auto-update-value="true"
+                      font-size="40" />
+                  </div>
                 </div>
+
+                <div 
+                  style="margin-top: 15px; margin-left: 15px; display: flex; align-items: center; justify-content: space-between;" 
+                  ng-show="cms.chatModerationData.settings.urlModeration.enabled"
+                >
+                  <div style="font-weight: 600; font-size: 16px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTimeEnabled }">View Time</div>
+                  <div style="width: 150px; flex-shrink: 0; text-align: right;">
+                    <toggle-button
+                      toggle-model="cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
+                      on-toggle="cms.saveChatModerationSettings()"
+                      auto-update-value="true"
+                      font-size="32"
+                    />
+                  </div>
+                </div>
+                <div
+                  style="margin-top: 15px; margin-left: 15px;"
+                  ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
+                >
+                  <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
+                  <firebot-input
+                    input-title="View time"
+                    placeholder-text="Enter amount of hours"
+                    input-type="number"
+                    disable-variables="true"
+                    model="cms.chatModerationData.settings.urlModeration.viewTime"
+                    on-input-update="cms.saveChatModerationSettings()"
+                  />
+                </div>
+              </div>
             </div>
             
         </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -135,7 +135,7 @@
                     style="margin-top: 20px; width: 100%;"
                     ng-show="cms.chatModerationData.settings.urlModeration.enabled"
                   >
-                  <div class="muted">The chat message shown when a url is moderated.</div>
+                  <div class="muted">The chat message shown when message containing a url is moderated.</div>
                     <div class="muted" style="margin-bottom: 10px; font-weight: 800;">
                       Variables: {userName}<span ng-show="cms.chatModerationData.settings.urlModeration.viewTime.enabled">, {viewTime}</span>
                     </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -93,7 +93,8 @@
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
                       on-toggle="toggleUrlModerationFeature()"
-                      font-size="40" />
+                      font-size="40"
+                    />
                   </div>
                 </div>
                 <div class="muted" style="margin-bottom: 15px;">
@@ -143,6 +144,7 @@
                       input-type="string"
                       disable-variables="true"
                       use-text-area="true"
+                      placeholder-text="Enter text"
                       model="cms.chatModerationData.settings.urlModeration.outputMessage"
                       on-input-update="cms.saveChatModerationSettings()"
                     />

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -103,7 +103,7 @@
                   class="title-toggle-button-container"
                   ng-show="cms.chatModerationData.settings.urlModeration.enabled"
                 >
-                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTime.enabled }">View Time</div>
+                  <div class="moderation-feature-subtitle" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTime.enabled }">View Time</div>
                   <div class="toggle-button-container">
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.viewTime.enabled"
@@ -124,6 +124,30 @@
                       input-type="number"
                       disable-variables="true"
                       model="cms.chatModerationData.settings.urlModeration.viewTime.hours"
+                      on-input-update="cms.saveChatModerationSettings()"
+                    />
+                  </div>
+                </div>
+
+                <div 
+                  style="margin-top: 25px; margin-left: 15px;"
+                  class="title-toggle-button-container"
+                  ng-show="cms.chatModerationData.settings.urlModeration.enabled"
+                >
+                  <div class="moderation-feature-subtitle">Permit duration</div>
+                  <div
+                    style="margin-top: 15px; width: 100%;"
+                    ng-show="cms.chatModerationData.settings.urlModeration.enabled"
+                  >
+                    <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">
+                      The amount of time the viewer has to post a link after the !permit command is used (found in system commands).
+                    </div>
+                    <firebot-input
+                      input-title="Duration in seconds"
+                      placeholder-text="Enter amount of seconds"
+                      input-type="number"
+                      disable-variables="true"
+                      model="cms.chatModerationData.settings.urlModeration.permitDuration"
                       on-input-update="cms.saveChatModerationSettings()"
                     />
                   </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -42,7 +42,8 @@
                   <div class="toggle-button-container">
                     <toggle-button 
                       toggle-model="cms.chatModerationData.settings.bannedWordList.enabled"
-                      on-toggle="toggleBannedWordsFeature()"
+                      auto-update-value="true"
+                      on-toggle="cms.saveChatModerationSettings()"
                       font-size="40"
                     />
                   </div> 

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -135,7 +135,7 @@
                     style="margin-top: 20px; width: 100%;"
                     ng-show="cms.chatModerationData.settings.urlModeration.enabled"
                   >
-                  <div class="muted">The chat message shown when message containing a url is moderated.</div>
+                  <div class="muted">The chat message shown when a message containing a url is moderated (leave empty for no message).</div>
                     <div class="muted" style="margin-bottom: 10px; font-weight: 800;">
                       Variables: {userName}<span ng-show="cms.chatModerationData.settings.urlModeration.viewTime.enabled">, {viewTime}</span>
                     </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -119,7 +119,7 @@
                     style="margin-top: 15px; width: 100%;"
                     ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTime.enabled"
                   >
-                    <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
+                    <div class="muted" style="margin-bottom: 10px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
                     <firebot-input
                       input-title="View time in hours"
                       placeholder-text="Enter amount of hours"
@@ -130,6 +130,23 @@
                     />
                   </div>
                 </div>
+
+                <div
+                    style="margin-top: 20px; width: 100%;"
+                    ng-show="cms.chatModerationData.settings.urlModeration.enabled"
+                  >
+                  <div class="muted">The chat message shown when a url is moderated.</div>
+                    <div class="muted" style="margin-bottom: 10px; font-weight: 800;">
+                      Variables: {userName}<span ng-show="cms.chatModerationData.settings.urlModeration.viewTime.enabled">, {viewTime}</span>
+                    </div>
+                    <firebot-input
+                      input-type="string"
+                      disable-variables="true"
+                      use-text-area="true"
+                      model="cms.chatModerationData.settings.urlModeration.outputMessage"
+                      on-input-update="cms.saveChatModerationSettings()"
+                    />
+                  </div>
               </div>
             </div>
             

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -92,7 +92,7 @@
                   <div class="toggle-button-container">
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
-                      on-toggle="cms.saveChatModerationSettings()"
+                      on-toggle="toggleUrlModerationFeature()"
                       auto-update-value="true"
                       font-size="40" />
                   </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -119,7 +119,7 @@
                   >
                     <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
                     <firebot-input
-                      input-title="View time"
+                      input-title="View time in hours"
                       placeholder-text="Enter amount of hours"
                       input-type="number"
                       disable-variables="true"

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -97,6 +97,9 @@
                       font-size="40" />
                   </div>
                 </div>
+                <div class="muted" style="margin-bottom: 15px;">
+                  A !permit command is automatically added to System Commands.
+                </div>
 
                 <div 
                   style="margin-top: 15px; margin-left: 15px;"
@@ -124,30 +127,6 @@
                       input-type="number"
                       disable-variables="true"
                       model="cms.chatModerationData.settings.urlModeration.viewTime.viewTimeInHours"
-                      on-input-update="cms.saveChatModerationSettings()"
-                    />
-                  </div>
-                </div>
-
-                <div 
-                  style="margin-top: 25px; margin-left: 15px;"
-                  class="title-toggle-button-container"
-                  ng-show="cms.chatModerationData.settings.urlModeration.enabled"
-                >
-                  <div class="moderation-feature-subtitle">Permit duration</div>
-                  <div
-                    style="margin-top: 15px; width: 100%;"
-                    ng-show="cms.chatModerationData.settings.urlModeration.enabled"
-                  >
-                    <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">
-                      The amount of time the viewer has to post a link after the !permit command is used (found in system commands).
-                    </div>
-                    <firebot-input
-                      input-title="Duration in seconds"
-                      placeholder-text="Enter amount of seconds"
-                      input-type="number"
-                      disable-variables="true"
-                      model="cms.chatModerationData.settings.urlModeration.permitDurationInSeconds"
                       on-input-update="cms.saveChatModerationSettings()"
                     />
                   </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -103,10 +103,10 @@
                   class="title-toggle-button-container"
                   ng-show="cms.chatModerationData.settings.urlModeration.enabled"
                 >
-                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTimeEnabled }">View Time</div>
+                  <div class="moderation-feature-title" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.viewTime.enabled }">View Time</div>
                   <div class="toggle-button-container">
                     <toggle-button
-                      toggle-model="cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
+                      toggle-model="cms.chatModerationData.settings.urlModeration.viewTime.enabled"
                       on-toggle="cms.saveChatModerationSettings()"
                       auto-update-value="true"
                       font-size="32"
@@ -115,7 +115,7 @@
 
                   <div
                     style="margin-top: 15px; width: 100%;"
-                    ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
+                    ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTime.enabled"
                   >
                     <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
                     <firebot-input
@@ -123,7 +123,7 @@
                       placeholder-text="Enter amount of hours"
                       input-type="number"
                       disable-variables="true"
-                      model="cms.chatModerationData.settings.urlModeration.viewTime"
+                      model="cms.chatModerationData.settings.urlModeration.viewTime.hours"
                       on-input-update="cms.saveChatModerationSettings()"
                     />
                   </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -79,6 +79,18 @@
                   </div>         
                 </div>
             </div>
+
+            <div class="content-block" style="width: 50%; margin-top: 15px;">
+                <div class="content-block-body">
+                  <div style="display: flex;align-items: center;justify-content: space-between;">
+                      <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url moderation</div>
+                      <div style="width: 150px; flex-shrink: 0;text-align: right;">
+                          <toggle-button toggle-model="cms.chatModerationData.settings.urlModeration.enabled" 
+                          on-toggle="toggleUrlModerationFeature()" font-size="40"></toggle-button>
+                      </div> 
+                  </div>        
+                </div>
+            </div>
             
         </div>
         <div ng-show="activeTab === 1">

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -93,7 +93,6 @@
                     <toggle-button
                       toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
                       on-toggle="toggleUrlModerationFeature()"
-                      auto-update-value="true"
                       font-size="40" />
                   </div>
                 </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -85,8 +85,11 @@
                   <div style="display: flex;align-items: center;justify-content: space-between;">
                       <div style="font-weight: 600;font-size: 20px;" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url moderation</div>
                       <div style="width: 150px; flex-shrink: 0;text-align: right;">
-                          <toggle-button toggle-model="cms.chatModerationData.settings.urlModeration.enabled" 
-                          on-toggle="toggleUrlModerationFeature()" font-size="40"></toggle-button>
+                          <toggle-button
+                            toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
+                            on-toggle="cms.saveChatModerationSettings()"
+                            auto-update-value="true"
+                            font-size="40" />
                       </div> 
                   </div>        
                 </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -112,20 +112,21 @@
                       font-size="32"
                     />
                   </div>
-                </div>
-                <div
-                  style="margin-top: 15px; margin-left: 15px;"
-                  ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
-                >
-                  <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
-                  <firebot-input
-                    input-title="View time"
-                    placeholder-text="Enter amount of hours"
-                    input-type="number"
-                    disable-variables="true"
-                    model="cms.chatModerationData.settings.urlModeration.viewTime"
-                    on-input-update="cms.saveChatModerationSettings()"
-                  />
+
+                  <div
+                    style="margin-top: 15px; width: 100%;"
+                    ng-show="cms.chatModerationData.settings.urlModeration.enabled && cms.chatModerationData.settings.urlModeration.viewTimeEnabled"
+                  >
+                    <div class="muted" style="margin-bottom: 15px; margin-left: 15px;">All viewers with a higher view time will be exempt from url moderation.</div>
+                    <firebot-input
+                      input-title="View time"
+                      placeholder-text="Enter amount of hours"
+                      input-type="number"
+                      disable-variables="true"
+                      model="cms.chatModerationData.settings.urlModeration.viewTime"
+                      on-input-update="cms.saveChatModerationSettings()"
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -123,7 +123,7 @@
                       placeholder-text="Enter amount of hours"
                       input-type="number"
                       disable-variables="true"
-                      model="cms.chatModerationData.settings.urlModeration.viewTime.hours"
+                      model="cms.chatModerationData.settings.urlModeration.viewTime.viewTimeInHours"
                       on-input-update="cms.saveChatModerationSettings()"
                     />
                   </div>
@@ -147,7 +147,7 @@
                       placeholder-text="Enter amount of seconds"
                       input-type="number"
                       disable-variables="true"
-                      model="cms.chatModerationData.settings.urlModeration.permitDuration"
+                      model="cms.chatModerationData.settings.urlModeration.permitDurationInSeconds"
                       on-input-update="cms.saveChatModerationSettings()"
                     />
                   </div>

--- a/gui/scss/core/_moderation.scss
+++ b/gui/scss/core/_moderation.scss
@@ -26,3 +26,29 @@
         padding:0px;
     }
 }
+
+.moderation-feature-block {
+    width: 50%;
+
+    &:not(:first-child) {
+        margin-top: 15px;
+    }
+
+    .title-toggle-button-container {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        .moderation-feature-title {
+            font-weight: 600; 
+            font-size: 16px;
+        }
+    
+        .toggle-button-container {
+            width: 150px; 
+            flex-shrink: 0;
+            text-align: right;
+        }
+    }
+}
+

--- a/gui/scss/core/_moderation.scss
+++ b/gui/scss/core/_moderation.scss
@@ -42,6 +42,11 @@
 
         .moderation-feature-title {
             font-weight: 600; 
+            font-size: 20px;
+        }
+
+        .moderation-feature-subtitle {
+            font-weight: 600; 
             font-size: 16px;
         }
     

--- a/gui/scss/core/_moderation.scss
+++ b/gui/scss/core/_moderation.scss
@@ -38,6 +38,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        flex-wrap: wrap;
 
         .moderation-feature-title {
             font-weight: 600; 


### PR DESCRIPTION
### Description of the Change
This adds a url moderation feature to the moderation tools. When view time is enabled, it will check for both exempt roles and view time, otherwise it will only check for exempt roles. 

It also automatically adds a !permit system command with which viewers can be temporarily be permitted to post urls, the default duration (30 seconds) of that permit can be adjusted by the user.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1167

### Testing
The following cases were tested:
- Viewer time disabled with and without message and variables
- Viewer time enabled with and without message and variables
- Exempt roles active with and without viewer time enabled
- Permit command with and without message and variables
- Permit command with different permit durations
- Permit command with multiple users


### Screenshots
![image](https://user-images.githubusercontent.com/72231755/119364097-da6f7100-bcae-11eb-9678-d00eed27b0e4.png)
![image](https://user-images.githubusercontent.com/72231755/119370592-bcf1d580-bcb5-11eb-905d-26d481144546.png)


