### PR TITLE
Add an event to fire when the stream category is edited through the dashboard

### DIFF
--- a/backend/common/common-listeners.js
+++ b/backend/common/common-listeners.js
@@ -68,6 +68,11 @@ exports.setupCommonListeners = () => {
         eventsManager.triggerEvent("firebot", "highlight-message", data);
     });
 
+    frontendCommunicator.on("category-changed", category => {
+        const eventsManager = require("../events/EventManager");
+        eventsManager.triggerEvent("firebot", "category-changed", {category: category});
+    });
+
     // Front old main
 
     // restarts the app

--- a/backend/events/builtin/firebotEventSource.js
+++ b/backend/events/builtin/firebotEventSource.js
@@ -60,6 +60,15 @@ const firebotEventSource = {
                 username: "Firebot",
                 messageText: "Test message"
             }
+        },
+        {
+            id: "category-changed",
+            name: "Category Changed",
+            description: "When you change the stream category in the dashboard.",
+            cached: false,
+            manualMetadata: {
+                category: "Just Chatting"
+            }
         }
     ]
 };

--- a/backend/events/filters/builtin-filter-loader.js
+++ b/backend/events/filters/builtin-filter-loader.js
@@ -13,6 +13,8 @@ exports.loadFilters = () => {
     const previousViewTime = require("./builtin/previous-view-time");
     const newViewTime = require("./builtin/new-view-time");
 
+    const streamCategory = require("./builtin/stream-category");
+
     const subType = require("./builtin/sub-type");
     const subKind = require("./builtin/sub-kind");
     const giftCount = require("./builtin/gift-count");
@@ -39,6 +41,8 @@ exports.loadFilters = () => {
 
     filterManager.registerFilter(previousViewTime);
     filterManager.registerFilter(newViewTime);
+
+    filterManager.registerFilter(streamCategory);
 
     filterManager.registerFilter(subType);
     filterManager.registerFilter(subKind);

--- a/backend/events/filters/builtin/stream-category.js
+++ b/backend/events/filters/builtin/stream-category.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const { ComparisonType } = require("../../../../shared/filter-constants");
+const twitchApi = require("../../../twitch-api/api");
+
+module.exports = {
+    id: "firebot:category-changed",
+    name: "Category",
+    description: "The category that is currently selected to stream to.",
+    events: [
+        { eventSourceId: "firebot", eventId: "category-changed" }
+    ],
+    comparisonTypes: [ComparisonType.IS, ComparisonType.IS_NOT, ComparisonType.CONTAINS, ComparisonType.MATCHES_REGEX],
+    valueType: "text",
+    predicate: (filterSettings, eventData) => {
+        let { comparisonType, value } = filterSettings;
+        let { eventMeta } = eventData;
+
+        let eventCategory = eventMeta.category ? eventMeta.category.toLowerCase() : "";
+        let filterCategory = value ? value.toLowerCase() : "";
+
+        switch (comparisonType) {
+        case ComparisonType.IS:
+            return eventCategory === filterCategory;
+        case ComparisonType.IS_NOT:
+            return eventCategory !== filterCategory;
+            case ComparisonType.CONTAINS:
+            return eventCategory.includes(filterCategory);
+        case ComparisonType.MATCHES_REGEX: {
+            let regex = new RegExp(filterCategory, "gi");
+            return regex.test(eventCategory);
+        }
+        default:
+            return false;
+        }
+    }
+}

--- a/backend/events/filters/builtin/stream-category.js
+++ b/backend/events/filters/builtin/stream-category.js
@@ -24,7 +24,7 @@ module.exports = {
             return eventCategory === filterCategory;
         case ComparisonType.IS_NOT:
             return eventCategory !== filterCategory;
-            case ComparisonType.CONTAINS:
+        case ComparisonType.CONTAINS:
             return eventCategory.includes(filterCategory);
         case ComparisonType.MATCHES_REGEX: {
             let regex = new RegExp(filterCategory, "gi");

--- a/backend/events/filters/builtin/stream-category.js
+++ b/backend/events/filters/builtin/stream-category.js
@@ -34,4 +34,4 @@ module.exports = {
             return false;
         }
     }
-}
+};

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -71,7 +71,8 @@
 
                 $ctrl.streamInfo = {
                     title: "",
-                    gameId: 0
+                    gameId: 0,
+                    gameName: ""
                 };
 
                 $ctrl.selectedGame = null;
@@ -109,11 +110,13 @@
                 $ctrl.gameSelected = function(game) {
                     if (game != null) {
                         $ctrl.streamInfo.gameId = game.id;
+                        $ctrl.streamInfo.gameName = game.name;
                     }
                 };
 
                 $ctrl.save = () => {
                     backendCommunicator.fireEventAsync("set-channel-info", $ctrl.streamInfo);
+                    backendCommunicator.fireEvent("category-changed", $ctrl.streamInfo.gameName);
                     ngToast.create({
                         className: 'success',
                         content: "Updated stream info!"


### PR DESCRIPTION
### Description of the Change
This adds an event to fire when the category is changed. Useful when you want certain commands and events (and timers soon) to toggle when you are streaming to a specific category.


### Applicable Issues
n/a

### Testing
I tested multiple categories through both the filter and the conditional effect with the `$game` variable as the condition.


### Screenshots
![image](https://user-images.githubusercontent.com/72231755/119798268-47674e80-bedb-11eb-91ef-a348aad8e8e8.png)
