### PR TITLE
Fix the exact minimum view time not being included in the condition

### DIFF
--- a/backend/chat/moderation/chat-moderation-manager.js
+++ b/backend/chat/moderation/chat-moderation-manager.js
@@ -159,7 +159,7 @@ async function moderateMessage(chatMessage) {
                 const viewerViewTime = viewer.minutesInChannel / 60;
                 const minimumViewTime = settings.viewTime.viewTimeInHours;
 
-                if (viewerViewTime > minimumViewTime) return;
+                if (viewerViewTime >= minimumViewTime) return;
 
                 outputMessage = outputMessage.replace("{viewTime}", minimumViewTime.toString());
 


### PR DESCRIPTION
### Description of the Change
When 2 hours is the minimum view time in the url moderation feature, manually setting a viewer to 2 hours of view time would still cause their message to get deleted. This fixes that issue.

### Applicable Issues
n/a
