### PR TITLE
Add a workaround to return the correct username for multi month gift subs

### DIFF
--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -41,10 +41,23 @@ exports.triggerSubGift = (subInfo) => {
     eventManager.triggerEvent("twitch", "subs-gifted", {
         username: subInfo.userDisplayName,
         giftSubMonths: subInfo._data["cumulative_months"] || 1,
-        gifteeUsername: subInfo.userDisplayName,
+        gifteeUsername: getGifteeDisplayName(subInfo),
         gifterUsername: subInfo.gifterDisplayName,
         subPlan: subInfo.subPlan,
         isAnonymous: subInfo.isAnonymous,
         giftDuration: subInfo.giftDuration
     });
 };
+
+// Workaround since the package only checks for the subgift context
+function getGifteeDisplayName(subInfo) {
+    switch (subInfo._data["context"]) {
+    case "subgift":
+    case "resubgift":
+    case "anonsubgift":
+    case "anonresubgift":
+        return subInfo._data["recipient_display_name"];
+    default:
+        return subInfo._data["display_name"];
+    }
+}

--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -41,7 +41,7 @@ exports.triggerSubGift = (subInfo) => {
     eventManager.triggerEvent("twitch", "subs-gifted", {
         username: subInfo.userDisplayName,
         giftSubMonths: subInfo._data["cumulative_months"] || 1,
-        gifteeUsername: subInfo._data["recipient_display_name"],
+        gifteeUsername: subInfo._data["recipient_display_name"] || subInfo.userDisplayName,
         gifterUsername: subInfo.gifterDisplayName,
         subPlan: subInfo.subPlan,
         isAnonymous: subInfo.isAnonymous,

--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -41,23 +41,10 @@ exports.triggerSubGift = (subInfo) => {
     eventManager.triggerEvent("twitch", "subs-gifted", {
         username: subInfo.userDisplayName,
         giftSubMonths: subInfo._data["cumulative_months"] || 1,
-        gifteeUsername: getGifteeDisplayName(subInfo),
+        gifteeUsername: subInfo._data["recipient_display_name"],
         gifterUsername: subInfo.gifterDisplayName,
         subPlan: subInfo.subPlan,
         isAnonymous: subInfo.isAnonymous,
         giftDuration: subInfo.giftDuration
     });
 };
-
-// Workaround since the package only checks for the subgift context
-function getGifteeDisplayName(subInfo) {
-    switch (subInfo._data["context"]) {
-    case "subgift":
-    case "resubgift":
-    case "anonsubgift":
-    case "anonresubgift":
-        return subInfo._data["recipient_display_name"];
-    default:
-        return subInfo._data["display_name"];
-    }
-}

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -101,7 +101,7 @@ async function createClient() {
         listeners.push(bitsListener);
 
         const subsListener = await pubSubClient.onSubscription(streamer.userId, (subInfo) => {
-            if (!subInfo.isGift) {
+            if (subInfo._data["context"] === "sub" || subInfo._data["context"] === "resub") {
                 twitchEventsHandler.sub.triggerSub(subInfo);
             } else {
                 twitchEventsHandler.giftSub.triggerSubGift(subInfo);


### PR DESCRIPTION
### Description of the Change
This workaround takes care of two things:
1. It checks for the right context in the pubsub listener, since `isGift` only checks for `subgift`, and not for `resubgift`, `anonsubgift` and `anonresubgift`.
2. Since the package's `userDisplayName` also only checks for the `subgift` context, it now tries to access `recipient_display_name` straight from the data, and falls back to `userDisplayName` if it can't find it.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1241