### PR TITLE
Forgot a typo in the run-program effect

### DIFF
--- a/backend/effects/builtin/run-program.js
+++ b/backend/effects/builtin/run-program.js
@@ -108,7 +108,7 @@ const model = {
             }
 
             child.on('error', function(err) {
-                logger.warning(`spawned program error:`, err);
+                logger.warn(`spawned program error:`, err);
                 child.kill();
                 return resolve();
             });


### PR DESCRIPTION
### Description of the Change
Missed a `logger.warning` typo in the run program effect, changed it to `logger.warn` so that it doesn't fail due to wrong function call when running a program through the run program effect.