### PR TITLE
Update the chat connect to include cheer and follower emotes

### DIFF
--- a/backend/common/handlers/chatProcessor.js
+++ b/backend/common/handlers/chatProcessor.js
@@ -342,7 +342,7 @@ async function uiChatMessage(data) {
 
                     if (emoteData) {
                         for (let channelEmote of emoteData.channelEmotes) {
-                            if (channelEmote.code === word) {
+                            if (channelEmote.name === word) {
                                 emote = channelEmote;
                                 foundEmote = true;
                                 break;

--- a/gui/app/directives/chat/chat-autocomplete-menu.component.js
+++ b/gui/app/directives/chat/chat-autocomplete-menu.component.js
@@ -159,8 +159,8 @@
 
                     function buildEmoteItems() {
                         return chatMessagesService.allEmotes.map(emote => ({
-                            display: emote.code,
-                            text: emote.code,
+                            display: emote.name,
+                            text: emote.name,
                             url: emote.url
                         }));
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebotv5",
-  "version": "5.39.2",
+  "version": "5.40.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Description of the Change
This PR changes the chat connect chat to use the Helix API so that cheer emotes and follower emotes will be displayed when sent from the dashboard chat.


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1261


### Testing
Tested all emote types (sub, cheer, follower) from dashboard chat to Twitch chat and the other way around.