### PR TITLE
Fix the eventData key name for the sub message variable

### DIFF
--- a/backend/variables/builtin/sub-message.js
+++ b/backend/variables/builtin/sub-message.js
@@ -19,7 +19,7 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: (trigger) => {
-        return trigger.metadata.eventData.message || "";
+        return trigger.metadata.eventData.subMessage || "";
     }
 };
 


### PR DESCRIPTION
### Description of the Change
The sub message variable currently doesn't work to it using the wrong key name for the event data. This PR fixes that.


### Applicable Issues
n/a


### Testing
n/a
