### PR TITLE
Overlay sound effect fix - related to #1272

### DIFF
--- a/backend/effects/builtin/playSound.js
+++ b/backend/effects/builtin/playSound.js
@@ -137,7 +137,8 @@ const playSound = {
 
         let data = {
             filepath: effect.filepath,
-            volume: effect.volume
+            volume: effect.volume,
+            overlayInstance: effect.overlayInstance
         };
 
         // Get random sound


### PR DESCRIPTION
### Description of the Change
Added `effect.overlayInstance` to the data sent from Firebot to the overlay so the overlay can route the sound effect to the correct overlay instance instead of defaulting it to the default overlay.


### Applicable Issues
#1272 


### Testing
✔️ - Tested with both OBS and Chrome to see that the sound effect actually plays in the correct overlay instance.