### PR TITLE
Fix the gifter username returning null in case of a multimonth gift sub

### DIFF
--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -42,7 +42,7 @@ exports.triggerSubGift = (subInfo) => {
         username: subInfo.userDisplayName,
         giftSubMonths: subInfo._data["cumulative_months"] || 1,
         gifteeUsername: subInfo._data["recipient_display_name"] || subInfo.userDisplayName,
-        gifterUsername: subInfo.gifterDisplayName,
+        gifterUsername: subInfo.gifterDisplayName || subInfo.userDisplayName,
         subPlan: subInfo.subPlan,
         isAnonymous: subInfo.isAnonymous,
         giftDuration: subInfo.giftDuration


### PR DESCRIPTION
### Description of the Change
This fixes the gifter username from returning null/UnknownUser when it's a multimonth gift sub.


### Applicable Issues
n/a


### Testing
n/a :(