### PR TITLE
Add the option to toggle the paused status of a channel reward

### DIFF
--- a/gui/app/controllers/channel-rewards.controller.js
+++ b/gui/app/controllers/channel-rewards.controller.js
@@ -42,6 +42,10 @@
                     icon: "fa-coin",
                     cellTemplate: `{{data.twitchData.cost}}`,
                     cellController: () => {}
+                },
+                {
+                    cellTemplate: `<span class="paused-dot" style="margin-right: 5px" ng-class="{'paused': data.twitchData.isPaused, 'unpaused': !data.twitchData.isPaused}"></span>{{data.twitchData.isPaused ? 'Paused' : 'Unpaused' }}`,
+                    cellController: () => {}
                 }
             ];
 
@@ -58,6 +62,15 @@
                         html: `<a href uib-tooltip="This reward was created outside of Firebot, it's enabled status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Enabled</a>`,
                         click: function () {
                             item.twitchData.isEnabled = !item.twitchData.isEnabled;
+                            channelRewardsService.saveChannelReward(item);
+                        },
+                        compile: true,
+                        enabled: item.manageable
+                    },
+                    {
+                        html: `<a href uib-tooltip="This reward was created outside of Firebot, it's paused status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Paused</a>`,
+                        click: function () {
+                            item.twitchData.isPaused = !item.twitchData.isPaused;
                             channelRewardsService.saveChannelReward(item);
                         },
                         compile: true,

--- a/gui/app/controllers/channel-rewards.controller.js
+++ b/gui/app/controllers/channel-rewards.controller.js
@@ -59,7 +59,7 @@
                         }
                     },
                     {
-                        html: `<a href uib-tooltip="This reward was created outside of Firebot, it's enabled status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Enabled</a>`,
+                        html: `<a href uib-tooltip="This reward was created outside of Firebot, its enabled status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Enabled</a>`,
                         click: function () {
                             item.twitchData.isEnabled = !item.twitchData.isEnabled;
                             channelRewardsService.saveChannelReward(item);
@@ -68,7 +68,7 @@
                         enabled: item.manageable
                     },
                     {
-                        html: `<a href uib-tooltip="This reward was created outside of Firebot, it's paused status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Paused</a>`,
+                        html: `<a href uib-tooltip="This reward was created outside of Firebot, its paused status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> Toggle Paused</a>`,
                         click: function () {
                             item.twitchData.isPaused = !item.twitchData.isPaused;
                             channelRewardsService.saveChannelReward(item);

--- a/gui/scss/core/_controls.scss
+++ b/gui/scss/core/_controls.scss
@@ -568,6 +568,22 @@ table.fb-table-alt {
     align-items: center;
 }
 
+.paused-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 10px;
+    display: inline-block;
+    &.unpaused {
+        background: lightgreen;
+    }
+    &.paused {
+        background: orange;
+    }
+    &.hidden {
+        opacity: 0;
+    }
+}
+
 .status-dot {
     width: 10px;
     height: 10px;

--- a/gui/scss/core/_controls.scss
+++ b/gui/scss/core/_controls.scss
@@ -579,9 +579,6 @@ table.fb-table-alt {
     &.paused {
         background: orange;
     }
-    &.hidden {
-        opacity: 0;
-    }
 }
 
 .status-dot {


### PR DESCRIPTION
### Description of the Change
Add the option to toggle the paused status of a channel reward. Particularly useful since Twitch doesn't provide a clear overview and option for this, especially when a reward is set to skip the reward queue.


### Applicable Issues
n/a


### Testing
Tested the status view in the table, tested if the reward actually gets paused on Twitch.


### Screenshots
![image](https://user-images.githubusercontent.com/72231755/129476960-49cfa835-504f-4a30-be04-0dea4100823f.png)

