### PR TITLE
feat: added $encodeForHtml for safe variable use in HTML templates

### DIFF
--- a/backend/effects/builtin/html.js
+++ b/backend/effects/builtin/html.js
@@ -73,6 +73,8 @@ const html = {
             This effect requires the Firebot overlay to be loaded in your broadcasting software. <a href ng-click="showOverlayInfoModal()" style="text-decoration:underline">Learn more</a>
             <br /><br />
             Please be aware that this effect is <i>extremely</i> prone to errors due to it's open-ended nature.
+            <br /><br />
+            When using variables that are derived from user provided content, it is recommended to escape the value using <code>$encodeForHtml[$variable]</code>.
         </div>
     </eos-container>
     `,

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -99,6 +99,7 @@ exports.loadReplaceVariables = () => {
         'text-uppercase',
         'text-capitalize',
         'text-contains',
+        'text-encode-for-html',
         'text-encode-for-url',
         'text-split',
         'text-substring',

--- a/backend/variables/builtin/text-encode-for-html.js
+++ b/backend/variables/builtin/text-encode-for-html.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
-const he = require('he')
+const he = require('he');
 
 const model = {
     definition: {

--- a/backend/variables/builtin/text-encode-for-html.js
+++ b/backend/variables/builtin/text-encode-for-html.js
@@ -1,0 +1,21 @@
+// Migration: done
+
+"use strict";
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+const he = require('he')
+
+const model = {
+    definition: {
+        handle: "encodeForHtml",
+        description: "Encodes input text for safe use within HTML templates",
+        usage: "encodeForHtml[text]",
+        categories: [VariableCategory.TEXT],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (_, text) => {
+        return text ? he.encode(text) : "";
+    }
+};
+
+module.exports = model;

--- a/gui/app/templates/interactive/effect-options/html.html
+++ b/gui/app/templates/interactive/effect-options/html.html
@@ -27,5 +27,7 @@
         This effect requires the Firebot overlay to be loaded in your broadcasting software. <a href ng-click="showOverlayInfoModal()" style="text-decoration:underline">Learn more</a>
         <br /><br />
         Please be aware that this effect is <i>extremely</i> prone to errors due to it's open-ended nature.
+        <br /><br />
+        When using variables that are derived from user provided content, it is recommended to escape the value using <code>$encodeForHtml[$variable]</code>.
     </div>
 </eos-container>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebotv5",
-  "version": "5.39.2",
+  "version": "5.40.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4012,6 +4012,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "express": "^4.17.1",
     "fs-extra": "^7.0.1",
     "fuse.js": "^3.4.6",
+    "he": "^1.2.0",
     "howler": "https://github.com/ebiggz/howler.js/tarball/master",
     "js-convert-case": "^4.1.1",
     "kbm-robot": "https://github.com/Skriglitz/kbm-robot/tarball/master",


### PR DESCRIPTION
### Description of the Change
Added the built-in variable $encodeForHtml which properly escapes HTML entities.
This allows the safe use of $variables within HTML templates for the HTML effect.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
- Built local version
- Tested the variable within an HTML template
- Tested injection scenarios to make sure they are not possible (cheerMessage: `hello <strong>world</strong>`)

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
#### New built-in variable in the `$vars` picker:
![image](https://user-images.githubusercontent.com/203591/129484429-f5e145be-d4b4-4dec-9281-601c312f8e06.png)

#### Extended warning at the bottom of the HTML effect
![image](https://user-images.githubusercontent.com/203591/129484545-779e5710-e232-48fd-a693-4cea8c291679.png)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
