### PR TITLE
fix: subMessage not populated

### DIFF
--- a/backend/events/builtin/twitchEventSource.js
+++ b/backend/events/builtin/twitchEventSource.js
@@ -64,6 +64,7 @@ module.exports = {
             manualMetadata: {
                 username: "Firebot",
                 subPlan: "1000",
+                subMessage: "Test message",
                 totalMonths: 10,
                 streak: 8,
                 isPrime: false,
@@ -124,7 +125,8 @@ module.exports = {
                 username: "Firebot",
                 isAnonymous: false,
                 bits: 100,
-                totalBits: 1200
+                totalBits: 1200,
+                cheerMessage: "cheer100 Test message"
             },
             activityFeed: {
                 icon: "fad fa-diamond",

--- a/backend/events/twitch-events/cheer.js
+++ b/backend/events/twitch-events/cheer.js
@@ -2,12 +2,12 @@
 
 const eventManager = require("../../events/EventManager");
 
-exports.triggerCheer = (username, isAnonymous, bits, totalBits, message = "") => {
+exports.triggerCheer = (username, isAnonymous, bits, totalBits, cheerMessage = "") => {
     eventManager.triggerEvent("twitch", "cheer", {
         username,
         isAnonymous,
         bits,
         totalBits,
-        message
+        cheerMessage
     });
 };

--- a/backend/variables/builtin/cheer-message.js
+++ b/backend/variables/builtin/cheer-message.js
@@ -19,7 +19,7 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: (trigger) => {
-        const cheerMessage = trigger.metadata.eventData.message || "";
+        const cheerMessage = trigger.metadata.eventData.cheerMessage || "";
         return cheerMessage
             .replace(/( |\b)[a-zA-Z]+\d+( |\b)/g, "")
             .trim();

--- a/backend/variables/builtin/sub-message.js
+++ b/backend/variables/builtin/sub-message.js
@@ -19,7 +19,7 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: (trigger) => {
-        return trigger.metadata.eventData.message || "";
+        return trigger.metadata.eventData.subMessage || "";
     }
 };
 


### PR DESCRIPTION
### Description of the Change
The subscription message is not being populated at the moment due to a difference between what the event data provides(`subMessage`) and what the built-in expects (`message`).

This PR implements the following:
- Use `subMessage` in the built-in variable evaluation to return the actual message.
- Populate `subMessage` when triggering an event manually for testing.
- Normalize `cheer` event so that is uses `cheerMessage` instead of `message` (all the other event uses distinct names for their message property [ie.: `subMessage`, `chatMessage`, etc....])


### Applicable Issues
N/A - Didn't open an issue for this bug.

### Testing
Tested receiving subs via Twitch + test triggers.

### Screenshots
No UI change applicable.
