### PR TITLE
fix: settings not restoring in run effect-list/preset

### DIFF
--- a/gui/app/services/preset-effect-lists.service.js
+++ b/gui/app/services/preset-effect-lists.service.js
@@ -39,7 +39,7 @@
             };
 
             service.getPresetEffectList = function(presetEffectListId) {
-                return service.presetEffectLists[presetEffectListId];
+                return service.presetEffectLists.find(pel => pel.id === presetEffectListId);
             };
 
             service.savePresetEffectList = function(presetEffectList) {


### PR DESCRIPTION
### Description of the Change
Corrected bug that prevented the effect list effect from properly restoring setting when reopening.

### Applicable Issues
Fix for #1286 


### Testing
1. Created an effect list effect
2. Used a preset effect list
3. Saved
4. Reopened the dialog

### Screenshots
N/A


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
