### PR TITLE
fix: trigger being mutated in effectGroup causing issues for effects …

### DIFF
--- a/backend/effects/builtin/effectGroup.js
+++ b/backend/effects/builtin/effectGroup.js
@@ -144,11 +144,15 @@ const effectGroup = {
                     return resolve(true);
                 }
 
-                trigger.type = EffectTrigger.PRESET_LIST;
-                trigger.metadata.presetListArgs = effect.presetListArgs;
+                // The original trigger may be in use down the chain of events,
+                // we must therefore deepclone it in order to prevent mutations
+                const newTrigger = JSON.parse(JSON.stringify(trigger));
+
+                newTrigger.type = EffectTrigger.PRESET_LIST;
+                newTrigger.metadata.presetListArgs = effect.presetListArgs;
 
                 processEffectsRequest = {
-                    trigger: trigger,
+                    trigger: newTrigger,
                     effects: presetList.effects
                 };
             } else {


### PR DESCRIPTION
…down the chain

### Description of the Change
The "Run Effect List" (effectGroup) effect was incorrectly causing a mutation which was preventing subsequent effects in the chain from being able to evaluate event variables.

### Applicable Issues
#1288  (self-reported)

### Testing
Simulated events to ensure that effects after a preset group are able to resolve variables.

