### PR TITLE
fix: Amazon Polly playing in wrong overlay instance (#1303)

### DIFF
--- a/backend/effects/builtin/playSound.js
+++ b/backend/effects/builtin/playSound.js
@@ -186,7 +186,7 @@ const playSound = {
         if (effect.waitForSound) {
             try {
                 const duration = await frontendCommunicator.fireEventAsync("getSoundDuration", {
-                    path: effect.filepath
+                    path: data.filepath
                 });
                 const durationInMils = (Math.round(duration) || 0) * 1000;
                 await wait(durationInMils);

--- a/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
+++ b/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
@@ -455,7 +455,8 @@ const playSound = {
 
         let data = {
             filepath: mp3Path,
-            volume: effect.volume
+            volume: effect.volume,
+            overlayInstance: effect.overlayInstance
         };
 
         // Set output device.

--- a/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
+++ b/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
@@ -77,8 +77,8 @@ const playSound = {
    */
     definition: {
         id: "aws:polly",
-        name: "Text-To-Speech (AWS Polly)",
-        description: "Have Firebot read out some text using AWS Polly.",
+        name: "Text-To-Speech (Amazon Polly)",
+        description: "Have Firebot read out some text using Amazon Polly.",
         icon: "fad fa-microphone-alt",
         categories: [EffectCategory.FUN],
         dependencies: [],
@@ -409,7 +409,7 @@ const playSound = {
         if (!awsIntegration || !awsIntegration.userSettings ||
             !awsIntegration.userSettings.iamCredentials.accessKeyId ||
             !awsIntegration.userSettings.iamCredentials.secretAccessKey) {
-            logger.error('AWS integration has not been configured. Unable to execute AWS Polly effect.');
+            logger.error('AWS integration has not been configured. Unable to execute Amazon Polly effect.');
             return false;
         }
 
@@ -433,7 +433,7 @@ const playSound = {
         try {
             synthSpeedResponse = await polly.send(synthSpeechCommand);
         } catch (err) {
-            logger.error("Unable to synthesize speech using AWS Polly", err);
+            logger.error("Unable to synthesize speech using Amazon Polly", err);
             return false;
         }
 


### PR DESCRIPTION
### Description of the Change
- Fixed Amazon Polly playing in the wrong overlay instance (#1303)
- Amazon Polly was being wrongly referred to as "AWS Polly", this has been corrected
- Fixed Play Sound effect "Wait for Sound" not working when playing a sound from a folder. ( #1309)

### Applicable Issues
#1303,  #1309

### Testing
- Tested playing polly in a custom overlay instance
- Tested playing a sound from a folder and see if it waited properly