### PR TITLE
#1280 stream info tags

### DIFF
--- a/backend/twitch-api/api.js
+++ b/backend/twitch-api/api.js
@@ -9,3 +9,4 @@ exports.channelRewards = require("./resource/channel-rewards");
 exports.users = require("./resource/users");
 exports.teams = require("./resource/teams");
 exports.categories = require("./resource/categories");
+exports.streamTags = require("./resource/stream-tags");

--- a/backend/twitch-api/frontend-twitch-listeners.js
+++ b/backend/twitch-api/frontend-twitch-listeners.js
@@ -18,7 +18,7 @@ exports.setupListeners = () => {
     });
 
     frontendCommunicator.onAsync("get-all-stream-tags", () => {
-        return twitchApi.streamTags.getAllStreamTags();
+        return twitchApi.streamTags.getAllStreamTagsPaginated();
     });
 
     frontendCommunicator.onAsync("get-channel-info", async () => {

--- a/backend/twitch-api/frontend-twitch-listeners.js
+++ b/backend/twitch-api/frontend-twitch-listeners.js
@@ -42,6 +42,15 @@ exports.setupListeners = () => {
         }
     });
 
+    frontendCommunicator.onAsync("set-stream-tags", async (tagIds) => {
+        try {
+            await twitchApi.streamTags.updateChannelStreamTags(tagIds);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    });
+
     frontendCommunicator.onAsync("get-channel-rewards", async () => {
         const rewards = await twitchApi.channelRewards.getCustomChannelRewards();
         return rewards || [];

--- a/backend/twitch-api/frontend-twitch-listeners.js
+++ b/backend/twitch-api/frontend-twitch-listeners.js
@@ -1,23 +1,25 @@
 "use strict";
 
-const twitchCategories = require("./resource/categories");
-const channelRewards = require("./resource/channel-rewards");
-const channels = require("./resource/channels");
+const twitchApi = require("./api");
 const frontendCommunicator = require("../common/frontend-communicator");
 
 exports.setupListeners = () => {
 
     frontendCommunicator.onAsync("search-twitch-games", query => {
-        return twitchCategories.searchCategories(query);
+        return twitchApi.categories.searchCategories(query);
     });
 
     frontendCommunicator.onAsync("get-twitch-game", gameId => {
-        return twitchCategories.getCategoryById(gameId);
+        return twitchApi.categories.getCategoryById(gameId);
+    });
+
+    frontendCommunicator.onAsync("get-channel-stream-tags", () => {
+        return twitchApi.streamTags.getChannelStreamTags();
     });
 
     frontendCommunicator.onAsync("get-channel-info", async () => {
         try {
-            const channelInfo = await channels.getChannelInformation();
+            const channelInfo = await twitchApi.channels.getChannelInformation();
             return {
                 title: channelInfo.title,
                 gameId: channelInfo.game_id
@@ -29,7 +31,7 @@ exports.setupListeners = () => {
 
     frontendCommunicator.onAsync("set-channel-info", async ({ title, gameId }) => {
         try {
-            await channels.updateChannelInformation(title, gameId);
+            await twitchApi.channels.updateChannelInformation(title, gameId);
             return true;
         } catch (error) {
             return false;
@@ -37,7 +39,7 @@ exports.setupListeners = () => {
     });
 
     frontendCommunicator.onAsync("get-channel-rewards", async () => {
-        const rewards = await channelRewards.getCustomChannelRewards();
+        const rewards = await twitchApi.channelRewards.getCustomChannelRewards();
         return rewards || [];
     });
 

--- a/backend/twitch-api/frontend-twitch-listeners.js
+++ b/backend/twitch-api/frontend-twitch-listeners.js
@@ -17,6 +17,10 @@ exports.setupListeners = () => {
         return twitchApi.streamTags.getChannelStreamTags();
     });
 
+    frontendCommunicator.onAsync("get-all-stream-tags", () => {
+        return twitchApi.streamTags.getAllStreamTags();
+    });
+
     frontendCommunicator.onAsync("get-channel-info", async () => {
         try {
             const channelInfo = await twitchApi.channels.getChannelInformation();

--- a/backend/twitch-api/resource/stream-tags.js
+++ b/backend/twitch-api/resource/stream-tags.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const twitchApi = require("../client");
+const { TwitchAPICallType } = require('twitch/lib');
+const accountAccess = require("../../common/account-access");
+const logger = require('../../logwrapper');
+
+/**
+ * @typedef TwitchStreamTag
+ * @property {string} tag_id - The ID of this tag
+ * @property {boolean} is_auto - Whether this tag is automatically applied for a category
+ * @property {object} name - A dictionary that contains the localized names of the tag
+ * @property {object} description - A dictionary that contains the localized descriptions of the tag
+ */
+
+function mapTwitchTag(tag) {
+	return {
+		id: tag.tag_id,
+		isAuto: tag.is_auto,
+		name: tag.localization_names["en-us"],
+		description: tag.localization_descriptions["en-us"]
+	}
+}
+
+async function getAllStreamTags() {
+	const client = twitchApi.getClient();
+
+	try {
+		const response = await client.callApi({
+            type: TwitchAPICallType.Helix,
+            url: "tags/streams"
+        });
+
+		if (response == null || response.data == null || response.data.length < 1) {
+            return null;
+        }
+
+		/**@type {TwitchStreamTag[]} */
+        return response.data.map(tag => mapTwitchTag(tag));
+	} catch (err) {
+		logger.error("Failed to get all stream tags", error);
+        return null;
+	}
+}
+
+async function getChannelStreamTags() {
+	const client = twitchApi.getClient();
+
+	try {
+		const response = await client.callApi({
+			type: TwitchAPICallType.Helix,
+			url: "streams/tags",
+			method: "GET",
+			query: {
+				"broadcaster_id": accountAccess.getAccounts().streamer.userId
+			}
+		});
+
+		if (response == null || response.data == null || response.data.length < 1) {
+            return null;
+        }
+
+		/**@type {TwitchStreamTag[]} */
+		return response.data.map(tag => mapTwitchTag(tag));
+	} catch (err) {
+		logger.error("Failed to get channel stream tags", err);
+        return null;
+	}
+}
+
+function updateChannelStreamTags(tagIds) {
+	const client = twitchApi.getClient();
+    try {
+        await client.callApi({
+            type: TwitchAPICallType.Helix,
+            url: "streams/tags",
+            method: "PUT",
+            query: {
+                "broadcaster_id": accountAccess.getAccounts().streamer.userId
+            },
+            body: { tag_ids: tagIds }
+        });
+        return true;
+    } catch (err) {
+        logger.error("Failed to update channel stream tags", err);
+        return false;
+    }
+}
+
+exports.getAllStreamTags = getAllStreamTags;
+exports.getChannelStreamTags = getChannelStreamTags;
+exports.updateChannelStreamTags = updateChannelStreamTags;

--- a/backend/twitch-api/resource/stream-tags.js
+++ b/backend/twitch-api/resource/stream-tags.js
@@ -8,7 +8,7 @@ const logger = require('../../logwrapper');
 /**
  * @typedef TwitchStreamTag
  * @property {string} tag_id - The ID of this tag
- * @property {boolean} is_auto - Whether this tag is automatically applied for a category
+ * @property {boolean} is_auto - Whether this tag is automatically applied to the channel
  * @property {object} name - A dictionary that contains the localized names of the tag
  * @property {object} description - A dictionary that contains the localized descriptions of the tag
  */

--- a/backend/twitch-api/resource/stream-tags.js
+++ b/backend/twitch-api/resource/stream-tags.js
@@ -7,10 +7,10 @@ const logger = require('../../logwrapper');
 
 /**
  * @typedef TwitchStreamTag
- * @property {string} tag_id - The ID of this tag
- * @property {boolean} is_auto - Whether this tag is automatically applied to the channel
- * @property {object} name - A dictionary that contains the localized names of the tag
- * @property {object} description - A dictionary that contains the localized descriptions of the tag
+ * @property {string} id - The ID of this tag
+ * @property {boolean} isAuto - Whether this tag is automatically applied to the channel
+ * @property {string} name - A dictionary that contains the localized names of the tag
+ * @property {string} description - A dictionary that contains the localized descriptions of the tag
  */
 
 function mapTwitchTag(tag) {
@@ -65,8 +65,6 @@ async function getAllStreamTagsPaginated() {
 		response = await getAllStreamTags(cursor);
 		streamTags = streamTags.concat(response.data.filter(tag => !tag.is_auto));
 	}
-
-	logger.info(streamTags.length);
 
 	/**@type {TwitchStreamTag[]} */
 	return streamTags.map(tag => mapTwitchTag(tag));

--- a/backend/twitch-api/resource/stream-tags.js
+++ b/backend/twitch-api/resource/stream-tags.js
@@ -68,7 +68,7 @@ async function getChannelStreamTags() {
 	}
 }
 
-function updateChannelStreamTags(tagIds) {
+async function updateChannelStreamTags(tagIds) {
 	const client = twitchApi.getClient();
     try {
         await client.callApi({

--- a/gui/app/app-main.js
+++ b/gui/app/app-main.js
@@ -110,7 +110,8 @@
         effectQueuesService,
         timerService,
         channelRewardsService,
-        sortTagsService
+        sortTagsService,
+        streamTagsService
     ) {
         // 'chatMessagesService' is included so its instantiated on app start
 
@@ -144,6 +145,8 @@
         channelRewardsService.loadChannelRewards();
 
         sortTagsService.loadSortTags();
+
+        streamTagsService.loadAllStreamTags();
 
         //start notification check
         $timeout(() => {

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -122,7 +122,6 @@
                                             .then((tags) => {
                                                 if (tags != null) {
                                                     $ctrl.streamTags = tags;
-                                                    console.log(tags);
                                                 }
                                                 $ctrl.dataLoaded = true;
                                             });

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -182,6 +182,7 @@
 
                 $ctrl.save = () => {
                     backendCommunicator.fireEventAsync("set-channel-info", $ctrl.streamInfo);
+                    backendCommunicator.fireEventAsync("set-stream-tags", $ctrl.streamTags.map(tag => tag.id));
                     backendCommunicator.fireEvent("category-changed", $ctrl.streamInfo.gameName);
                     ngToast.create({
                         className: 'success',

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -141,6 +141,7 @@
                             label: "Add Stream Tag",
                             options: $ctrl.streamTagsService.allStreamTags,
                             saveText: "Add",
+                            selectPlaceholder: "Select a tag...",
                             validationText: "Please select a tag."
     
                         },

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -70,13 +70,13 @@
                                 <div 
                                     class="role-bar clickable"
                                     ng-show="$ctrl.streamTags.length < 5"
-                                    ng-class="{'disabled': !$ctrl.allStreamTags.length > 0}"
-                                    aria-disabled="{{!$ctrl.allStreamTags.length > 0}}"
+                                    ng-class="{'disabled': !$ctrl.streamTagsService.allStreamTags.length > 0}"
+                                    aria-disabled="{{!$ctrl.streamTagsService.allStreamTags.length > 0}}"
                                     role="button" 
-                                    aria-label="{{$ctrl.allStreamTags.length > 0 ? 'Add tag' : 'Loading tags...'}}"
-                                    uib-tooltip="{{$ctrl.allStreamTags.length > 0 ? 'Add tag' : 'Loading tags...'}}" 
+                                    aria-label="{{$ctrl.streamTagsService.allStreamTags.length > 0 ? 'Add tag' : 'Loading tags...'}}"
+                                    uib-tooltip="{{$ctrl.streamTagsService.allStreamTags.length > 0 ? 'Add tag' : 'Loading tags...'}}" 
                                     tooltip-append-to-body="true" 
-                                    ng-click="$ctrl.openAddStreamTagsModal()"
+                                    ng-click="!$ctrl.streamTagsService.allStreamTags.length > 0 ? $event.stopPropagation() : $ctrl.openAddStreamTagsModal();"
                                 >
                                     <i class="far fa-plus"></i> 
                                 </div>
@@ -95,7 +95,7 @@
                 close: "&",
                 dismiss: "&"
             },
-            controller: function($scope, ngToast, utilityService, backendCommunicator) {
+            controller: function($scope, ngToast, utilityService, streamTagsService, backendCommunicator) {
                 const $ctrl = this;
 
                 $ctrl.dataLoaded = false;
@@ -108,8 +108,8 @@
                     gameName: ""
                 };
 
+                $ctrl.streamTagsService = streamTagsService;
                 $ctrl.streamTags = [];
-                $ctrl.allStreamTags = [];
 
                 $ctrl.selectedGame = null;
 
@@ -119,15 +119,6 @@
                 };
 
                 $ctrl.$onInit = async () => {
-                    $ctrl.loadStreamInfo();
-                    $ctrl.loadAllStreamTags();
-                };
-
-                $ctrl.loadAllStreamTags = async () => {
-                    $ctrl.allStreamTags = await backendCommunicator.fireEventAsync("get-all-stream-tags");
-                };
-
-                $ctrl.loadStreamInfo = async () => {
                     $ctrl.streamTags = await backendCommunicator.fireEventAsync("get-channel-stream-tags");
                     $ctrl.streamInfo = await backendCommunicator.fireEventAsync("get-channel-info");
 
@@ -139,7 +130,7 @@
                         }
                     }
 
-                    if ($ctrl.selectedGame && $ctrl.streamTags) {
+                    if ($ctrl.selectedGame) {
                         $ctrl.dataLoaded = true;
                     }
                 };
@@ -148,14 +139,16 @@
                     utilityService.openSelectModal(
                         {
                             label: "Add Stream Tag",
-                            options: $ctrl.allStreamTags,
+                            options: $ctrl.streamTagsService.allStreamTags,
                             saveText: "Add",
                             validationText: "Please select a tag."
     
                         },
                         (tagId) => {
                             if (!tagId) return;
-                            $ctrl.streamTags.push($ctrl.allStreamTags.find(tag => tag.id === tagId));
+                            if (!$ctrl.streamTags.find(tag => tag.id === tagId)) {
+                                $ctrl.streamTags.push($ctrl.streamTagsService.allStreamTags.find(tag => tag.id === tagId));
+                            }
                         });
                 }
 

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -32,7 +32,7 @@
                             />
                         </div>
 
-                        <div class="form-group" style="margin-bottom:0;">
+                        <div class="form-group">
                             <label for="game" class="control-label">Category</label>
                             <ui-select ng-model="$ctrl.selectedGame" required input-id="game" theme="bootstrap" spinner-enabled="true" on-select="$ctrl.gameSelected($item)">
                                 <ui-select-match placeholder="Search for category...">
@@ -48,6 +48,30 @@
                                     </div>                                  
                                 </ui-select-choices>
                             </ui-select>
+                        </div>
+
+                        <div class="form-group" style="margin-bottom: 0;">
+                            <label for="tags" class="control-label">Stream Tags</label>
+                            <div style="display: block" role="list">
+                                <div class="role-bar" id="streamTags" ng-repeat="tag in $ctrl.streamTags track by tag.id" role="listitem">
+                                    <span>{{tag.name}}</span>
+                                    <span 
+                                        role="button" 
+                                        class="clickable" 
+                                        style="padding-left: 10px;" 
+                                        aria-label="Remove {{tag.name}} tag" 
+                                        uib-tooltip="Remove tag" 
+                                        tooltip-append-to-body="true"
+                                        ng-click="$ctrl.removeStreamTag(tag.id)"
+                                        ng-if="!tag.isAuto"
+                                    >
+                                        <i class="far fa-times"></i>
+                                    </span>
+                                </div>
+                                <div class="role-bar clickable" role="button" aria-label="Add tag" uib-tooltip="Add tag" tooltip-append-to-body="true">
+                                    <i class="far fa-plus"></i> 
+                                </div>
+                            </div>
                         </div>
                         
                     </form>
@@ -122,6 +146,10 @@
                         $ctrl.streamInfo.gameName = game.name;
                     }
                 };
+
+                $ctrl.removeStreamTag = function(id) {
+                    $ctrl.streamTags = $ctrl.streamTags.filter(tag => tag.id !== id);
+                }
 
                 $ctrl.save = () => {
                     backendCommunicator.fireEventAsync("set-channel-info", $ctrl.streamInfo);

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -54,7 +54,7 @@
                             <label for="tags" class="control-label">Stream Tags</label>
                             <div style="display: block" role="list">
                                 <div class="role-bar" id="streamTags" ng-repeat="tag in $ctrl.streamTags track by tag.id" role="listitem">
-                                    <span>{{tag.name}}</span>
+                                    <span uib-tooltip="{{tag.description}}">{{tag.name}}</span>
                                     <span 
                                         role="button" 
                                         class="clickable" 
@@ -63,7 +63,6 @@
                                         uib-tooltip="Remove tag" 
                                         tooltip-append-to-body="true"
                                         ng-click="$ctrl.removeStreamTag(tag.id)"
-                                        ng-if="!tag.isAuto"
                                     >
                                         <i class="far fa-times"></i>
                                     </span>

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -143,7 +143,7 @@
                             saveText: "Add",
                             selectPlaceholder: "Select a tag...",
                             validationText: "Please select a tag."
-    
+
                         },
                         (tagId) => {
                             if (!tagId) return;
@@ -151,7 +151,7 @@
                                 $ctrl.streamTags.push($ctrl.streamTagsService.allStreamTags.find(tag => tag.id === tagId));
                             }
                         });
-                }
+                };
 
                 $ctrl.searchGames = function(gameQuery) {
                     backendCommunicator.fireEventAsync("search-twitch-games", gameQuery)
@@ -171,11 +171,11 @@
 
                 $ctrl.removeStreamTag = function(id) {
                     $ctrl.streamTags = $ctrl.streamTags.filter(tag => tag.id !== id);
-                }
+                };
 
                 $ctrl.save = () => {
                     backendCommunicator.fireEventAsync("set-channel-info", $ctrl.streamInfo);
-                    backendCommunicator.fireEventAsync("set-stream-tags", $ctrl.streamTags.map(tag => tag.id));
+                    backendCommunicator.fireEventAsync("set-stream-tags", { tagIds: $ctrl.streamTags.map(tag => tag.id) });
                     backendCommunicator.fireEvent("category-changed", $ctrl.streamInfo.gameName);
                     ngToast.create({
                         className: 'success',

--- a/gui/app/directives/modals/misc/edit-stream-info-modal.js
+++ b/gui/app/directives/modals/misc/edit-stream-info-modal.js
@@ -75,6 +75,8 @@
                     gameName: ""
                 };
 
+                $ctrl.streamTags = [];
+
                 $ctrl.selectedGame = null;
 
                 $ctrl.formFieldHasError = (fieldName) => {
@@ -92,7 +94,14 @@
                                         if (game != null) {
                                             $ctrl.selectedGame = game;
                                         }
-                                        $ctrl.dataLoaded = true;
+                                        backendCommunicator.fireEventAsync("get-channel-stream-tags")
+                                            .then((tags) => {
+                                                if (tags != null) {
+                                                    $ctrl.streamTags = tags;
+                                                    console.log(tags);
+                                                }
+                                                $ctrl.dataLoaded = true;
+                                            });
                                     });
                             }
                         });

--- a/gui/app/index.html
+++ b/gui/app/index.html
@@ -149,6 +149,7 @@
     <script type="text/javascript" src="./services/sound.service.js"></script>
     <script type="text/javascript" src="./services/startup-scripts.service.js"></script>
     <script type="text/javascript" src="./services/stream-info.service.js"></script>
+    <script type="text/javascript" src="./services/stream-tags.service.js"></script>
     <script type="text/javascript" src="./services/timer.service.js"></script>
     <script type="text/javascript" src="./services/tts.service.js"></script>
     <script type="text/javascript" src="./services/updates.service.js"></script>

--- a/gui/app/services/stream-tags.service.js
+++ b/gui/app/services/stream-tags.service.js
@@ -6,16 +6,16 @@
         .factory("streamTagsService", function(backendCommunicator) {
             let service = {};
 
-			service.allStreamTags = [];
+            service.allStreamTags = [];
 
-			service.loadAllStreamTags = async () => {
+            service.loadAllStreamTags = async () => {
                 const streamTags = await backendCommunicator.fireEventAsync("get-all-stream-tags");
 
-				if (streamTags) {
-					service.allStreamTags = streamTags;
-				}
+                if (streamTags) {
+                    service.allStreamTags = streamTags;
+                }
             };
 
-			return service;
+            return service;
         });
 }());

--- a/gui/app/services/stream-tags.service.js
+++ b/gui/app/services/stream-tags.service.js
@@ -1,0 +1,21 @@
+"use strict";
+(function() {
+
+    angular
+        .module("firebotApp")
+        .factory("streamTagsService", function(backendCommunicator) {
+            let service = {};
+
+			service.allStreamTags = [];
+
+			service.loadAllStreamTags = async () => {
+                const streamTags = await backendCommunicator.fireEventAsync("get-all-stream-tags");
+
+				if (streamTags) {
+					service.allStreamTags = streamTags;
+				}
+            };
+
+			return service;
+        });
+}());

--- a/gui/scss/core/_global.scss
+++ b/gui/scss/core/_global.scss
@@ -1695,6 +1695,10 @@ thead th{
   margin-right: 4px;
   margin-bottom: 4px;
   justify-content: space-between;
+  &.disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 }
 
 .effect-bar {


### PR DESCRIPTION
### Description of the Change
This adds an option in the stream info modal to add and remove tags for the channel. 


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1280


### Testing
- Added tags to the max of 5, and removing them to see if the UI behaves correctly
- Tried adding double tags to verify that they don't get added
- Saved an empty tag list and a populated tag list
- Clicked the Add Tag button before the tags were loaded to make sure it doesn't open the select modal
- Checked accessibility (as much as possible with the current components)

### Screenshots
5 tags (the maximum that Twitch allows)
![image](https://user-images.githubusercontent.com/72231755/129961179-a6f66650-5e3b-4889-9765-c2e9edf1990e.png)

Less than 5 tags
![image](https://user-images.githubusercontent.com/72231755/129961219-bfdd1719-efcb-4b63-bae0-45f001f184f5.png)

Tag selecter
![image](https://user-images.githubusercontent.com/72231755/129961313-2951196e-2da5-4732-8194-ea03d834dfc6.png)
