### PR TITLE
#1260 update currency viewer roles

### DIFF
--- a/backend/effects/builtin/currency.js
+++ b/backend/effects/builtin/currency.js
@@ -80,12 +80,12 @@ const currency = {
 
             <eos-container header="Target" pad-top="true">
 
-                <div class="permission-type controls-fb-inline">
+                <div class="permission-type controls-fb">
                     <label class="control-fb control--radio">Single User
                         <input type="radio" ng-model="effect.target" value="individual"/>
                         <div class="control__indicator"></div>
                     </label>
-                    <label class="control-fb control--radio">Role
+                    <label class="control-fb control--radio">Online Users in Role
                         <input type="radio" ng-model="effect.target" value="group"/>
                         <div class="control__indicator"></div>
                     </label>

--- a/backend/effects/builtin/currency.js
+++ b/backend/effects/builtin/currency.js
@@ -115,11 +115,13 @@ const currency = {
                                 <div class="control__indicator"></div>
                             </label>
                         </div>
-                        <div style="font-size: 16px;font-weight: 900;color: #b9b9b9;font-family: 'Quicksand';margin-bottom: 5px;">Mixer</div>
-                        <label ng-repeat="mixerRole in getMixerRoles()" class="control-fb control--checkbox">{{mixerRole.name}}
-                            <input type="checkbox" ng-click="toggleRole(mixerRole)" ng-checked="isRoleChecked(mixerRole)"  aria-label="..." >
-                            <div class="control__indicator"></div>
-                        </label>
+                        <div>
+                            <div style="font-size: 16px;font-weight: 900;color: #b9b9b9;font-family: 'Quicksand';margin-bottom: 5px;">Teams</div>
+                            <label ng-repeat="teamRole in getTeamRoles()" class="control-fb control--checkbox">{{teamRole.name}}
+                                <input type="checkbox" ng-click="toggleRole(teamRole)" ng-checked="isRoleChecked(teamRole)"  aria-label="..." >
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
                     </div>
                     <div ng-if="effect.target === 'individual'" class="input-group">
                         <span class="input-group-addon" id="basic-addon3">Username</span>
@@ -189,7 +191,6 @@ const currency = {
         $scope.getCustomRoles = viewerRolesService.getCustomRoles;
         $scope.getFirebotRoles = viewerRolesService.getFirebotRoles;
         $scope.getTeamRoles = viewerRolesService.getTeamRoles;
-        $scope.getMixerRoles = viewerRolesService.getMixerRoles;
 
         $scope.isRoleChecked = function(role) {
             return $scope.effect.roleIds.includes(role.id);

--- a/backend/effects/builtin/currency.js
+++ b/backend/effects/builtin/currency.js
@@ -122,6 +122,13 @@ const currency = {
                                 <div class="control__indicator"></div>
                             </label>
                         </div>
+                        <div>
+                            <div style="font-size: 16px;font-weight: 900;color: #b9b9b9;font-family: 'Quicksand';margin-bottom: 5px;">Twitch</div>
+                            <label ng-repeat="twitchRole in getTwitchRoles()" class="control-fb control--checkbox">{{twitchRole.name}}
+                                <input type="checkbox" ng-click="toggleRole(twitchRole)" ng-checked="isRoleChecked(twitchRole)"  aria-label="..." >
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
                     </div>
                     <div ng-if="effect.target === 'individual'" class="input-group">
                         <span class="input-group-addon" id="basic-addon3">Username</span>
@@ -190,6 +197,7 @@ const currency = {
         $scope.hasCustomRoles = viewerRolesService.getCustomRoles().length > 0;
         $scope.getCustomRoles = viewerRolesService.getCustomRoles;
         $scope.getFirebotRoles = viewerRolesService.getFirebotRoles;
+        $scope.getTwitchRoles = viewerRolesService.getTwitchRoles;
         $scope.getTeamRoles = viewerRolesService.getTeamRoles;
 
         $scope.isRoleChecked = function(role) {

--- a/gui/app/services/viewer-roles.service.js
+++ b/gui/app/services/viewer-roles.service.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const mixerRoleConstants = require("../../shared/mixer-roles");
 const twitchRoleConstants = require("../../shared/twitch-roles");
 const firebotRoleConstants = require("../../shared/firebot-roles");
 

--- a/gui/app/services/viewer-roles.service.js
+++ b/gui/app/services/viewer-roles.service.js
@@ -88,11 +88,6 @@ const firebotRoleConstants = require("../../shared/firebot-roles");
                 return firebotRoles;
             };
 
-            const mixerRoles = mixerRoleConstants.getMixerRoles();
-            service.getMixerRoles = function() {
-                return mixerRoles;
-            };
-
             const twitchRoles = twitchRoleConstants.getTwitchRoles();
             service.getTwitchRoles = function() {
                 return twitchRoles;

--- a/shared/mixer-roles.js
+++ b/shared/mixer-roles.js
@@ -1,5 +1,36 @@
 "use strict";
 
+const mixerRoles = [
+    {
+        id: "Pro",
+        name: "Pro Users"
+    },
+    {
+        id: "Subscriber",
+        name: "Subscribers"
+    },
+    {
+        id: "Partner",
+        name: "Partners"
+    },
+    {
+        id: "Mod",
+        name: "Moderators"
+    },
+    {
+        id: "ChannelEditor",
+        name: "Channel Editors"
+    },
+    {
+        id: "Staff",
+        name: "Staff"
+    },
+    {
+        id: "Owner",
+        name: "Streamer"
+    }
+];
+
 // get a firebot mixer role object baed on the raw role id from mixers api
 function mapMixerRole(rawRole) {
     let mappedRole;

--- a/shared/mixer-roles.js
+++ b/shared/mixer-roles.js
@@ -1,36 +1,5 @@
 "use strict";
 
-const mixerRoles = [
-    {
-        id: "Pro",
-        name: "Pro Users"
-    },
-    {
-        id: "Subscriber",
-        name: "Subscribers"
-    },
-    {
-        id: "Partner",
-        name: "Partners"
-    },
-    {
-        id: "Mod",
-        name: "Moderators"
-    },
-    {
-        id: "ChannelEditor",
-        name: "Channel Editors"
-    },
-    {
-        id: "Staff",
-        name: "Staff"
-    },
-    {
-        id: "Owner",
-        name: "Streamer"
-    }
-];
-
 // get a firebot mixer role object baed on the raw role id from mixers api
 function mapMixerRole(rawRole) {
     let mappedRole;
@@ -51,7 +20,6 @@ function mapMixerRole(rawRole) {
     return mixerRoles.find(r => r.id === mappedRole);
 }
 
-exports.getMixerRoles = () => mixerRoles;
 exports.mapMixerRole = mapMixerRole;
 
 


### PR DESCRIPTION
### Description of the Change
The Update Currency effect still had Mixer roles (RIP) instead of Twitch roles. This PR fixes that, and I also added clarification that the currency update for roles is for online role users. I will add an option to update a currency for offline roles in a separate PR.


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1260 and https://github.com/crowbartools/Firebot/issues/1270


### Testing
Couldn't do any online fixing at the moment, but I did test if all roles showed up correctly.