### PR TITLE
Add a check in case the cache only consists of unique messages

### DIFF
--- a/backend/chat/moderation/raid-message-checker.js
+++ b/backend/chat/moderation/raid-message-checker.js
@@ -56,8 +56,14 @@ function getRaidMessage() {
         return allMessages;
     }, {});
 
-    const highest = Math.max(...Object.values(raidMessages));
-    const index = Object.values(raidMessages).findIndex(message => message === highest);
+    const counts = Object.values(raidMessages);
+
+    const highest = Math.max(...counts);
+    if (highest < 2) {
+        return "";
+    }
+
+    const index = counts.findIndex(count => count === highest);
 
     return Object.keys(raidMessages)[index];
 }
@@ -72,6 +78,12 @@ function checkPreviousMessages() {
 
 function enable(shouldBan, shouldBlock) {
     raidMessage = getRaidMessage();
+
+    if (!raidMessage) {
+        logger.debug("No raid message detected");
+        return;
+    }
+
     settings.shouldBan = shouldBan;
     settings.shouldBlock = shouldBlock;
 


### PR DESCRIPTION
### Description of the Change
Currently when using the spam raid command with the ban/block option on a chat that solely consists of unique messages, it will ban and block the account of the first message it encounters and takes that as the raid message. This PR adds a minimum check of 2, so that other accounts don't get accidentally banned in case it's used incorrectly.


### Testing
Tested double and unique messages.