### PR TITLE
Spam raid protection subcommands

### DIFF
--- a/backend/chat/commands/builtin/spam-raid-protection.js
+++ b/backend/chat/commands/builtin/spam-raid-protection.js
@@ -10,7 +10,7 @@ const spamRaidProtection = {
         active: true,
         hidden: false,
         trigger: "!spamraidprotection",
-        description: "Toggles protective measures such as follow-only mode, slow mode, etc.",
+        description: "Toggles protective measures like chat clearing, follow only, sub only, emote only and slow mode, as well as whether spam raiders should be banned and/or blocked or not.",
         autoDeleteTrigger: false,
         scanWholeMessage: false,
         cooldown: {
@@ -98,6 +98,132 @@ const spamRaidProtection = {
                 arg: "off",
                 usage: "off",
                 description: "Turn off the protection command.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "followonly",
+                usage: "followonly",
+                description: "Toggles the follow-only mode setting.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "subonly",
+                usage: "subonly",
+                description: "Toggles the subscriber-only mode setting.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "emoteonly",
+                usage: "emoteonly",
+                description: "Toggles the emote-only mode setting.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "slow",
+                usage: "slow",
+                description: "Toggles the slow mode setting.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "chatclear",
+                usage: "chatclear",
+                description: "Toggles the setting to clear chat.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "ban",
+                usage: "ban",
+                description: "Toggles the setting to ban spam raiders.",
+                restrictionData: {
+                    restrictions: [
+                        {
+                            id: "sys-cmd-mods-only-perms",
+                            type: "firebot:permissions",
+                            mode: "roles",
+                            roleIds: [
+                                "broadcaster",
+                                "mod"
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                arg: "block",
+                usage: "block",
+                description: "Toggles the setting to block spam raiders.",
                 restrictionData: {
                     restrictions: [
                         {

--- a/backend/chat/commands/builtin/spam-raid-protection.js
+++ b/backend/chat/commands/builtin/spam-raid-protection.js
@@ -194,6 +194,7 @@ const spamRaidProtection = {
 
         if (args.length === 0) {
             activateProtectionOptions(commandOptions);
+            return;
         }
 
         let option = "";

--- a/backend/chat/commands/builtin/spam-raid-protection.js
+++ b/backend/chat/commands/builtin/spam-raid-protection.js
@@ -30,10 +30,8 @@ const activateProtectionOptions = async (commandOptions) => {
         chatModerationManager.enableSpamRaidProtection(commandOptions.banRaiders, commandOptions.blockRaiders);
     }
 
-    setTimeout(function() {
-        (function(commandOptions) {
-            chat.sendChatMessage(commandOptions.displayTemplate);
-        }(commandOptions));
+    setTimeout(() => {
+        chat.sendChatMessage(commandOptions.displayTemplate);
     }, 2000);
 };
 

--- a/backend/chat/commands/builtin/spam-raid-protection.js
+++ b/backend/chat/commands/builtin/spam-raid-protection.js
@@ -2,7 +2,7 @@
 
 const chat = require("../../twitch-chat");
 const chatModerationManager = require("../../moderation/chat-moderation-manager");
-const commandAccess = require("../command-access");
+const commandManager = require("../CommandManager");
 const frontendCommunicator = require("../../../common/frontend-communicator");
 
 const activateProtectionOptions = async (commandOptions) => {
@@ -38,8 +38,8 @@ const activateProtectionOptions = async (commandOptions) => {
 };
 
 const toggleSetting = (option, setting) => {
-    const systemCommands = commandAccess.getSystemCommandOverrides();
-    let command = systemCommands["firebot:spamRaidProtection"];
+    const systemCommands = commandManager.getAllSystemCommandDefinitions();
+    let command = systemCommands.find(sc => sc.id === "firebot:spamRaidProtection");
 
     if (command == null) return;
 
@@ -51,8 +51,8 @@ const toggleSetting = (option, setting) => {
         command.options[option].value = !command.options[option].value;
     }
 
-    commandAccess.saveSystemCommandOverride(command);
-    frontendCommunicator.send("systemCommandsUpdated");
+    commandManager.saveSystemCommandOverride(command);
+    frontendCommunicator.send("custom-commands-updated");
 };
 
 const spamRaidProtection = {
@@ -149,152 +149,45 @@ const spamRaidProtection = {
             {
                 arg: "off",
                 usage: "off",
-                description: "Turn off the protection command.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Turn off the protection command."
             },
             {
                 arg: "followeronly",
                 usage: "followeronly [on/off]",
-                description: "Toggles the follower-only mode setting.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether follower-only mode should be turned on when the protection command is used."
             },
             {
                 arg: "subsonly",
                 usage: "subsonly [on/off]",
-                description: "Toggles the subscriber-only mode setting.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether subs-only mode should be turned on when the protection command is used."
             },
             {
                 arg: "emoteonly",
                 usage: "emoteonly [on/off]",
-                description: "Toggles the emote-only mode setting.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether emote-only mode should be turned on when the protection command is used."
             },
             {
                 arg: "slow",
                 usage: "slow [on/off]",
-                description: "Toggles the slow mode setting.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether slow mode should be turned on when the protection command is used."
             },
             {
                 arg: "clearchat",
                 usage: "clearchat [on/off]",
-                description: "Toggles the setting to clear chat.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether chat should be cleared when the protection command is used."
             },
             {
                 arg: "banraiders",
                 usage: "banraiders [on/off]",
-                description: "Toggles the setting to ban spam raiders.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether spam raiders should be banned when the protection command is used."
             },
             {
                 arg: "blockraiders",
                 usage: "blockraiders [on/off]",
-                description: "Toggles the setting to block spam raiders.",
-                restrictionData: {
-                    restrictions: [
-                        {
-                            id: "sys-cmd-mods-only-perms",
-                            type: "firebot:permissions",
-                            mode: "roles",
-                            roleIds: [
-                                "broadcaster",
-                                "mod"
-                            ]
-                        }
-                    ]
-                }
+                description: "Whether spam raiders should be blocked when the protection command is used."
             }
         ]
     },
-    /**
-     * When the command is triggered
-     */
     onTriggerEvent: async event => {
         const { commandOptions } = event;
         const args = event.userCommand.args;


### PR DESCRIPTION
### Description of the Change
This adds subcommands to toggle the settings for spam raid protection command.


### Testing
Tested the command with all subcommands as well as without.