### PR TITLE
Fix a bug that caused the chat to fail to reconnect

### DIFF
--- a/backend/chat/twitch-chat.js
+++ b/backend/chat/twitch-chat.js
@@ -95,10 +95,7 @@ class TwitchChat extends EventEmitter {
             });
 
             this._streamerChatClient.onDisconnect((manual, reason) => {
-                if (!manual) {
-                    logger.error("Chat not disconnected", manual, reason);
-                    this.disconnect();
-                }
+                if (!manual) logger.error("Chat disconnected unexpectedly", reason);
             });
 
             await this._streamerChatClient.connect();


### PR DESCRIPTION
### Description of the Change
This fixes a bug that caused the chat to disconnect but not reconnect. When the client is not disconnected manually it tries to automatically reconnect, but since we disconnected the client after that but didn't remove the listeners, it got stuck. Disconnecting is not needed, so I removed that line.


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1350


### Testing
Tested this by disconnecting my internet (causing error 1006) and reconnecting.
