### PR TITLE
Time Range Restriction

### DIFF
--- a/backend/restrictions/builtin-restrictions-loader.js
+++ b/backend/restrictions/builtin-restrictions-loader.js
@@ -11,6 +11,7 @@ exports.loadRestrictions = () => {
         'custom-variable',
         'follow-check',
         'permissions',
+        'time-range',
         'view-time',
         'viewer-count'
     ].forEach(filename => {

--- a/backend/restrictions/builtin/time-range.js
+++ b/backend/restrictions/builtin/time-range.js
@@ -34,12 +34,11 @@ const model = {
             hours = hours % 12;
             hours = hours ? hours : 12; // the hour '0' should be '12'
             minutes = minutes < 10 ? '0' + minutes : minutes;
-            let strTime = hours + ':' + minutes + ' ' + ampm;
-            return strTime;
+            return hours + ':' + minutes + ' ' + ampm;
         }
 
-        let startTime = formatAMPM(restriction.startTime);
-        let endTime = formatAMPM(restriction.endTime);
+        const startTime = formatAMPM(restriction.startTime);
+        const endTime = formatAMPM(restriction.endTime);
 
         return "Between " + startTime + " - " + endTime;
     },
@@ -48,10 +47,10 @@ const model = {
     */
     predicate: async (trigger, restrictionData) => {
         return new Promise(async (resolve, reject) => {
+            const time = moment(),
+                startTime = moment(restrictionData.startTime);
 
-            let time = moment(),
-                startTime = moment(restrictionData.startTime),
-                endTime = moment(restrictionData.endTime);
+            let endTime = moment(restrictionData.endTime);
 
             if (endTime.isSameOrBefore(startTime)) {
                 endTime = endTime.add(1, 'days');
@@ -60,7 +59,7 @@ const model = {
             if (time.isBetween(startTime, endTime)) {
                 resolve();
             } else {
-                reject('Time must be between ' + moment(restrictionData.startTime).utc().format('HH:mm:ss') + ' and ' + moment(restrictionData.endTime).utc().format('HH:mm:ss') + '.');
+                reject('Time must be between ' + moment(restrictionData.startTime).format('hh:mm A') + ' and ' + moment(restrictionData.endTime).format('hh:mm A') + '.');
             }
         });
     },

--- a/backend/restrictions/builtin/time-range.js
+++ b/backend/restrictions/builtin/time-range.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const moment = require("moment");
+
+const model = {
+    definition: {
+        id: "firebot:timeRange",
+        name: "Time Range",
+        description: "Restrict usage to a specific local time.",
+        triggers: []
+    },
+    optionsTemplate: `
+        <div>
+            <div id="startTime" class="modal-subheader" style="padding: 0 0 4px 0">
+                Start Time
+            </div>
+            <div uib-timepicker ng-model="restriction.startTime" show-spinners="false"></div>
+
+            <div id="endTime" class="modal-subheader" style="padding: 1em 0 4px 0">
+                End Time
+            </div>
+            <div uib-timepicker ng-model="restriction.endTime" show-spinners="false"></div>
+        </div>
+    `,
+    optionsController: ($scope) => {
+
+    },
+    optionsValueDisplay: (restriction) => {
+        function formatAMPM(date) {
+            date = new Date(date);
+            let hours = date.getHours();
+            let minutes = date.getMinutes();
+            let ampm = hours >= 12 ? 'pm' : 'am';
+            hours = hours % 12;
+            hours = hours ? hours : 12; // the hour '0' should be '12'
+            minutes = minutes < 10 ? '0' + minutes : minutes;
+            let strTime = hours + ':' + minutes + ' ' + ampm;
+            return strTime;
+        }
+
+        let startTime = formatAMPM(restriction.startTime);
+        let endTime = formatAMPM(restriction.endTime);
+
+        return "Between " + startTime + " - " + endTime;
+    },
+    /*
+      function that resolves/rejects a promise based on if the restriction critera is met
+    */
+    predicate: async (trigger, restrictionData) => {
+        return new Promise(async (resolve, reject) => {
+
+            let time = moment(),
+                startTime = moment(restrictionData.startTime),
+                endTime = moment(restrictionData.endTime);
+
+            if (endTime.isSameOrBefore(startTime)) {
+                endTime = endTime.add(1, 'days');
+            }
+
+            if (time.isBetween(startTime, endTime)) {
+                resolve();
+            } else {
+                reject('Time must be between ' + moment(restrictionData.startTime).utc().format('HH:mm:ss') + ' and ' + moment(restrictionData.endTime).utc().format('HH:mm:ss') + '.');
+            }
+        });
+    },
+    /*
+        called after all restrictions in a list are met. Do logic such as deducting currency here.
+    */
+    onSuccessful: (triggerData, restrictionData) => {
+
+    }
+
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
This implements a "Time Range" restriction so that people can setup things to only run during certain times of the day. Example use case is a "sing me a song" command that you dont want to run after 10pm.

### Applicable Issues
#902 

### Testing
- Apply restriction to a command and run command while in time range.
- Apply restriction to a command and run command while outside of the time range.
- Set a time range that crosses over midnight to make sure that day overlapping works.
- Set a time range where the end time is before the start time (app assumes that you meant that time the following day)

### Notes
This is meant to be a daily time range. Any longer length of time we can probably expect the user to turn the command on or off manually.