### PR TITLE
Create a json db manager class

### DIFF
--- a/backend/app-management/electron/events/when-ready.js
+++ b/backend/app-management/electron/events/when-ready.js
@@ -88,10 +88,10 @@ exports.whenReady = async () => {
     customRolesManager.loadCustomRoles();
 
     const effectQueueManager = require("../../../effects/queues/effect-queue-manager");
-    effectQueueManager.loadEffectQueues();
+    effectQueueManager.loadItems();
 
     const presetEffectListManager = require("../../../effects/preset-lists/preset-effect-list-manager");
-    presetEffectListManager.loadPresetEffectLists();
+    presetEffectListManager.loadItems();
 
     const startupScriptsManager = require("../../../common/handlers/custom-scripts/startup-scripts-manager");
     startupScriptsManager.loadStartupConfig();

--- a/backend/common/effect-runner.js
+++ b/backend/common/effect-runner.js
@@ -151,7 +151,7 @@ async function processEffects(processEffectsRequest) {
     runEffectsContext.effects = JSON.parse(JSON.stringify(runEffectsContext.effects));
 
     const queueId = processEffectsRequest.effects.queue;
-    const queue = effectQueueManager.getEffectQueue(queueId);
+    const queue = effectQueueManager.getItem(queueId);
     if (queue != null) {
         logger.debug(`Sending effects for list ${processEffectsRequest.effects.id} to queue ${queueId}...`);
         effectQueueRunner.addEffectsToQueue(queue, runEffectsContext,

--- a/backend/database/json-db-manager.js
+++ b/backend/database/json-db-manager.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const profileManager = require("../common/profile-manager");
+const logger = require("../logwrapper");
+const uuidv1 = require("uuid/v1");
+
+/** @template T */
+class JsonDbManager {
+    /**
+     * @param {string} type - The type of data in the json file
+     * @param {string} path - The path to the json file
+     */
+    constructor(type, path) {
+        this.type = type;
+        this._items = {};
+        this.db = profileManager.getJsonDbInProfile(path);
+    }
+
+    /**
+     * @returns {Promise.<void>}
+     */
+    async loadItems() {
+        logger.debug(`Attempting to load ${this.type}s...`);
+
+        try {
+            const data = this.db.getData("/");
+
+            if (data) {
+                this._items = data;
+            }
+
+            logger.debug(`Loaded ${this.type}s.`);
+        } catch (err) {
+            logger.warn(`There was an error reading ${this.type} file.`, err);
+        }
+    }
+
+    /**
+     * @param {string} itemId
+     * @returns {T}
+     */
+    getItem(itemId) {
+        if (itemId == null) {
+            return null;
+        }
+        return this._items[itemId];
+    }
+
+    /**
+     * @returns {T[]}
+     */
+    getAllItems() {
+        if (this._items == null) {
+            return null;
+        }
+
+        return this._items;
+    }
+
+    /**
+     * @param {T} item
+     * @returns {Promise.<T>}
+     */
+    async saveItem(item) {
+        if (item == null) {
+            return;
+        }
+
+        if (item.id != null) {
+            this._items[item.id] = item;
+        } else {
+            item.id = uuidv1();
+            this._items[item.id] = item;
+        }
+
+        try {
+            this.db.push("/" + item.id, item);
+
+            logger.debug(`Saved ${this.type} with id ${item.id} to file.`);
+
+            return item;
+        } catch (err) {
+            logger.warn(`There was an error saving ${this.type}.`, err);
+            return null;
+        }
+    }
+
+    /**
+     * @param {T[]} allItems
+     * @returns {Promise.<void>}
+     */
+    async saveAllItems(allItems) {
+        const itemsObject = allItems.reduce((acc, current) => {
+            acc[current.id] = current;
+            return acc;
+        }, {});
+
+        this._items = itemsObject;
+
+        try {
+            this.db.push("/", this._items);
+
+            logger.debug(`Saved all ${this.type} to file.`);
+
+        } catch (err) {
+            logger.warn(`There was an error saving all ${this.type}s.`, err);
+            return null;
+        }
+    }
+
+    /**
+     * @param {string} itemId
+     * @returns {Promise.<void>}
+     */
+    async deleteItem(itemId) {
+        if (itemId == null) {
+            return;
+        }
+
+        delete this._items[itemId];
+
+        try {
+            this.db.delete("/" + itemId);
+
+            logger.debug(`Deleted ${this.type}: ${itemId}`);
+
+        } catch (err) {
+            logger.warn(`There was an error deleting ${this.type}.`, err);
+        }
+    }
+}
+
+module.exports = JsonDbManager;

--- a/backend/database/json-db-manager.js
+++ b/backend/database/json-db-manager.js
@@ -12,7 +12,7 @@ class JsonDbManager {
      */
     constructor(type, path) {
         this.type = type;
-        this._items = {};
+        this.items = {};
         this.db = profileManager.getJsonDbInProfile(path);
     }
 
@@ -26,7 +26,7 @@ class JsonDbManager {
             const data = this.db.getData("/");
 
             if (data) {
-                this._items = data;
+                this.items = data;
             }
 
             logger.debug(`Loaded ${this.type}s.`);
@@ -43,18 +43,18 @@ class JsonDbManager {
         if (itemId == null) {
             return null;
         }
-        return this._items[itemId];
+        return this.items[itemId];
     }
 
     /**
      * @returns {T[]}
      */
     getAllItems() {
-        if (this._items == null) {
+        if (this.items == null) {
             return null;
         }
 
-        return this._items;
+        return this.items;
     }
 
     /**
@@ -67,10 +67,10 @@ class JsonDbManager {
         }
 
         if (item.id != null) {
-            this._items[item.id] = item;
+            this.items[item.id] = item;
         } else {
             item.id = uuidv1();
-            this._items[item.id] = item;
+            this.items[item.id] = item;
         }
 
         try {
@@ -95,10 +95,10 @@ class JsonDbManager {
             return acc;
         }, {});
 
-        this._items = itemsObject;
+        this.items = itemsObject;
 
         try {
-            this.db.push("/", this._items);
+            this.db.push("/", this.items);
 
             logger.debug(`Saved all ${this.type} to file.`);
 
@@ -117,7 +117,7 @@ class JsonDbManager {
             return;
         }
 
-        delete this._items[itemId];
+        delete this.items[itemId];
 
         try {
             this.db.delete("/" + itemId);

--- a/backend/effects/builtin/effectGroup.js
+++ b/backend/effects/builtin/effectGroup.js
@@ -130,7 +130,7 @@ const effectGroup = {
             let processEffectsRequest = {};
 
             if (effect.listType === "preset") {
-                const presetList = presetEffectListManager.getPresetEffectList(effect.presetListId);
+                const presetList = presetEffectListManager.getItem(effect.presetListId);
                 if (presetList == null) {
                     // preset list doesnt exist anymore
                     return resolve(true);

--- a/backend/effects/preset-lists/preset-effect-list-manager.js
+++ b/backend/effects/preset-lists/preset-effect-list-manager.js
@@ -1,150 +1,48 @@
 "use strict";
 
-const logger = require("../../logwrapper");
-const profileManager = require("../../common/profile-manager");
 const frontendCommunicator = require("../../common/frontend-communicator");
+const JsonDbManager = require("../../database/json-db-manager");
 
 /**
  * @typedef SavedPresetEffectList
- * @property {string} id - the id of the preset effect list
- * @property {name} name - the name of the effect list
- * @property {object} effects - the saved effects in the list
- * @property {string} effects.id - the effect list root id
- * @property {any[]} effects.list - the array of effects objects
+ * @property {string} id - the id of the effect list
+ * @property {string} name - the name of the effect list
+ * @prop {object[]} args - the arguments if the effect list
+ * @prop {object} effects - the saved effects in the list
+ * @prop {string} effects.id - the effect list root id
+ * @prop {any[]} effects.list - the array of effects objects
+ * @property {string[]} sortTags - the sort tags for the effect list
  */
 
 /**
- * @type {Object.<string, SavedPresetEffectList>}
+ * @extends {JsonDbManager<SavedPresetEffectList>}
  */
-let presetEffectLists = {};
+class PresetEffectListManager extends JsonDbManager {
+    constructor() {
+        super("Preset Effect List", "/effects/preset-effect-lists");
+    }
 
-const EFFECTS_FOLDER = "/effects/";
-function getPresetEffectListDb() {
-    return profileManager
-        .getJsonDbInProfile(EFFECTS_FOLDER + "preset-effect-lists");
-}
-
-function loadPresetEffectLists() {
-    logger.debug(`Attempting to load preset effect lists...`);
-
-    const presetEffectListDb = getPresetEffectListDb();
-
-    try {
-        const presetEffectListData = presetEffectListDb.getData("/");
-
-        if (presetEffectListData) {
-            presetEffectLists = presetEffectListData;
-        }
-
-        logger.debug(`Loaded preset effect lists.`);
-    } catch (err) {
-        logger.warn(`There was an error reading preset effect lists file.`, err);
+    /**
+     * @emits
+     * @returns {void}
+     */
+    triggerUiRefresh() {
+        frontendCommunicator.send("all-preset-lists", this.getAllItems());
     }
 }
 
-/**
- * @param {SavedPresetEffectList} presetEffectList
- */
-async function savePresetEffectList(presetEffectList) {
-    if (presetEffectList == null) {
-        return;
-    }
+const presetEffectListManager = new PresetEffectListManager();
 
-    if (presetEffectList.id != null) {
-        presetEffectLists[presetEffectList.id] = presetEffectList;
-    } else {
-        const uuidv1 = require("uuid/v1");
-        presetEffectList.id = uuidv1();
-        presetEffectLists[presetEffectList.id] = presetEffectList;
-    }
-
-    try {
-        const presetEffectListDb = getPresetEffectListDb();
-
-        presetEffectListDb.push("/" + presetEffectList.id, presetEffectList);
-
-        logger.debug(`Saved preset effect list ${presetEffectList.id} to file.`);
-
-        return presetEffectList;
-    } catch (err) {
-        logger.warn(`There was an error saving a preset effect list.`, err);
-        return null;
-    }
-}
-
-/**
- *
- * @param {SavedPresetEffectList[]} allPresetEffectLists
- */
-async function saveAllPresetEffectLists(allPresetEffectLists) {
-    /** @type {Record<string,SavedPresetEffectList>} */
-    const presetEffectListsObject = allPresetEffectLists.reduce((acc, current) => {
-        acc[current.id] = current;
-        return acc;
-    }, {});
-
-    presetEffectLists = presetEffectListsObject;
-
-    try {
-        const presetEffectListDb = getPresetEffectListDb();
-
-        presetEffectListDb.push("/", presetEffectLists);
-
-        logger.debug(`Saved all preset effect lists to file.`);
-
-    } catch (err) {
-        logger.warn(`There was an error saving all preset effect lists.`, err);
-        return null;
-    }
-}
-
-function deletePresetEffectList(presetEffectListId) {
-    if (presetEffectListId == null) {
-        return;
-    }
-
-    delete presetEffectLists[presetEffectListId];
-
-    try {
-        const presetEffectListDb = getPresetEffectListDb();
-
-        presetEffectListDb.delete("/" + presetEffectListId);
-
-        logger.debug(`Deleted preset effect list: ${presetEffectListId}`);
-
-    } catch (err) {
-        logger.warn(`There was an error deleting a preset effect list.`, err);
-    }
-}
-
-function getPresetEffectList(presetEffectListId) {
-    if (presetEffectListId == null) {
-        return null;
-    }
-    return presetEffectLists[presetEffectListId];
-}
-
-function triggerUiRefresh() {
-    frontendCommunicator.send("all-preset-lists", presetEffectLists);
-}
-
-frontendCommunicator.onAsync("getPresetEffectLists", async () => presetEffectLists);
+frontendCommunicator.onAsync("getPresetEffectLists",
+    async () => presetEffectListManager.getAllItems());
 
 frontendCommunicator.onAsync("savePresetEffectList",
-    (/** @type {SavedPresetEffectList} */ presetEffectList) => savePresetEffectList(presetEffectList));
+    async (/** @type {SavedPresetEffectList} */ presetEffectList) => await presetEffectListManager.saveItem(presetEffectList));
 
 frontendCommunicator.onAsync("saveAllPresetEffectLists",
-    async (/** @type {SavedPresetEffectList[]} */ allPresetEffectLists) => {
-        saveAllPresetEffectLists(allPresetEffectLists);
-    }
-);
+    async (/** @type {SavedPresetEffectList[]} */ allPresetEffectLists) => await presetEffectListManager.saveAllItems(allPresetEffectLists));
 
-frontendCommunicator.on("deletePresetEffectList", (presetEffectListId) => {
-    deletePresetEffectList(presetEffectListId);
-});
+frontendCommunicator.on("deletePresetEffectList",
+    (/** @type {string} */presetEffectListId) => presetEffectListManager.deleteItem(presetEffectListId));
 
-exports.loadPresetEffectLists = loadPresetEffectLists;
-exports.getPresetEffectList = getPresetEffectList;
-exports.savePresetEffectList = savePresetEffectList;
-exports.deletePresetEffectList = deletePresetEffectList;
-exports.triggerUiRefresh = triggerUiRefresh;
+module.exports = presetEffectListManager;

--- a/backend/effects/preset-lists/preset-effect-list-manager.js
+++ b/backend/effects/preset-lists/preset-effect-list-manager.js
@@ -4,7 +4,7 @@ const frontendCommunicator = require("../../common/frontend-communicator");
 const JsonDbManager = require("../../database/json-db-manager");
 
 /**
- * @typedef SavedPresetEffectList
+ * @typedef PresetEffectList
  * @property {string} id - the id of the effect list
  * @property {string} name - the name of the effect list
  * @prop {object[]} args - the arguments if the effect list
@@ -15,7 +15,7 @@ const JsonDbManager = require("../../database/json-db-manager");
  */
 
 /**
- * @extends {JsonDbManager<SavedPresetEffectList>}
+ * @extends {JsonDbManager<PresetEffectList>}
  */
 class PresetEffectListManager extends JsonDbManager {
     constructor() {
@@ -37,10 +37,10 @@ frontendCommunicator.onAsync("getPresetEffectLists",
     async () => presetEffectListManager.getAllItems());
 
 frontendCommunicator.onAsync("savePresetEffectList",
-    async (/** @type {SavedPresetEffectList} */ presetEffectList) => await presetEffectListManager.saveItem(presetEffectList));
+    async (/** @type {PresetEffectList} */ presetEffectList) => await presetEffectListManager.saveItem(presetEffectList));
 
 frontendCommunicator.onAsync("saveAllPresetEffectLists",
-    async (/** @type {SavedPresetEffectList[]} */ allPresetEffectLists) => await presetEffectListManager.saveAllItems(allPresetEffectLists));
+    async (/** @type {PresetEffectList[]} */ allPresetEffectLists) => await presetEffectListManager.saveAllItems(allPresetEffectLists));
 
 frontendCommunicator.on("deletePresetEffectList",
     (/** @type {string} */presetEffectListId) => presetEffectListManager.deleteItem(presetEffectListId));

--- a/backend/effects/queues/effect-queue-manager.js
+++ b/backend/effects/queues/effect-queue-manager.js
@@ -1,155 +1,46 @@
 "use strict";
 
-const logger = require("../../logwrapper");
-const profileManager = require("../../common/profile-manager");
 const frontendCommunicator = require("../../common/frontend-communicator");
-let effectQueueRunner = require("./effect-queue-runner");
+const JsonDbManager = require("../../database/json-db-manager");
 
 /**
  * @typedef SavedEffectQueue
  * @property {string} id - the id of the effect queue
  * @property {string} name - the name of the effect queue
  * @property {string} mode - the mode of the effect queue
+ * @property {number} [interval] - the interval set for the interval mode
+ * @property {string[]} sortTags - the sort tags for the effect queue
  */
-
 
 /**
- * @type {Object.<string, SavedEffectQueue>}
+ * @extends {JsonDbManager<SavedPresetEffectList>}
  */
-let effectQueues = {};
-
-const EFFECTS_FOLDER = "/effects/";
-const getEffectQueuesDb = () => {
-    return profileManager.getJsonDbInProfile(EFFECTS_FOLDER + "effectqueues");
-};
-
-const loadEffectQueues = () => {
-    logger.debug(`Attempting to load effect queues...`);
-
-    const queuesDb = getEffectQueuesDb();
-
-    try {
-        let effectQueueData = queuesDb.getData("/");
-
-        if (effectQueueData) {
-            effectQueues = effectQueueData;
-        }
-
-        logger.debug(`Loaded effect queues.`);
-
-    } catch (err) {
-        logger.warn(`There was an error reading effect queues file.`, err);
-    }
-};
-
-/**
- * @param {SavedEffectQueue} effectQueue
- */
-const saveEffectQueue = async (effectQueue) => {
-    if (effectQueue == null) {
-        return;
+class EffectQueueManager extends JsonDbManager {
+    constructor() {
+        super("Effect Queue", "/effects/effectqueues");
     }
 
-    if (effectQueue.id != null) {
-        effectQueues[effectQueue.id] = effectQueue;
-    } else {
-        const uuidv1 = require("uuid/v1");
-        effectQueue.id = uuidv1();
-        effectQueues[effectQueue.id] = effectQueue;
+    /**
+     * @emits
+     * @returns {void}
+     */
+    triggerUiRefresh() {
+        frontendCommunicator.send("all-queues", this.getAllItems());
     }
+}
 
-    try {
-        const effectQueuesDb = getEffectQueuesDb();
+const effectQueueManager = new EffectQueueManager();
 
-        effectQueuesDb.push("/" + effectQueue.id, effectQueue);
-
-        logger.debug(`Saved effect queue ${effectQueue.id} to file.`);
-        effectQueueRunner.updateQueueConfig(effectQueue);
-
-        return effectQueue;
-    } catch (err) {
-        logger.warn(`There was an error saving an effect queue.`, err);
-        return null;
-    }
-};
-
-/**
- *
- * @param {SavedEffectQueue[]} allEffectQueues
- */
-const saveAllEffectQueues = async(allEffectQueues) => {
-    /** @type {Record<string,SavedEffectQueue>} */
-    const effectQueuesObject = allEffectQueues.reduce((acc, current) => {
-        acc[current.id] = current;
-        return acc;
-    }, {});
-
-    effectQueues = effectQueuesObject;
-
-    try {
-        const effectQueueDb = getEffectQueuesDb();
-
-        effectQueueDb.push("/", effectQueues);
-
-        logger.debug(`Saved all effect queues to file.`);
-
-    } catch (err) {
-        logger.warn(`There was an error saving all effect queues.`, err);
-        return null;
-    }
-};
-
-const deleteEffectQueue = (queueId) => {
-    if (queueId == null) {
-        return;
-    }
-
-    delete effectQueues[queueId];
-
-    try {
-        const queuesDb = getEffectQueuesDb();
-
-        queuesDb.delete("/" + queueId);
-
-        logger.debug(`Deleted effect queue: ${queueId}`);
-
-    } catch (err) {
-        logger.warn(`There was an error deleting an effect queue.`, err);
-    }
-
-    effectQueueRunner.removeQueue(queueId);
-};
-
-const getEffectQueue = (queueId) => {
-    if (queueId == null) {
-        return null;
-    }
-    return effectQueues[queueId];
-};
-
-const triggerUiRefresh = () => {
-    frontendCommunicator.send("all-queues", effectQueues);
-};
-
-frontendCommunicator.onAsync("getEffectQueues", async () => effectQueues);
+frontendCommunicator.onAsync("getEffectQueues",
+    async () => effectQueueManager.getAllItems());
 
 frontendCommunicator.onAsync("saveEffectQueue",
-    (/** @type {SavedEffectQueue} */ effectQueue) => saveEffectQueue(effectQueue));
+    async (/** @type {SavedEffectQueue} */ effectQueue) => await effectQueueManager.saveItem(effectQueue));
 
 frontendCommunicator.onAsync("saveAllEffectQueues",
-    async (/** @type {SavedEffectQueue[]} */ allEffectQueues) => {
-        saveAllEffectQueues(allEffectQueues);
-    }
-);
+    async (/** @type {SavedEffectQueue[]} */ allEffectQueues) => await effectQueueManager.saveAllItems(allEffectQueues));
 
-frontendCommunicator.on("deleteEffectQueue", (queueId) => {
-    deleteEffectQueue(queueId);
-});
+frontendCommunicator.on("deleteEffectQueue",
+    (/** @type {string} */ effectQueueId) => effectQueueManager.deleteItem(effectQueueId));
 
-
-
-exports.loadEffectQueues = loadEffectQueues;
-exports.getEffectQueue = getEffectQueue;
-exports.saveEffectQueue = saveEffectQueue;
-exports.deleteEffectQueue = deleteEffectQueue;
-exports.triggerUiRefresh = triggerUiRefresh;
+module.exports = effectQueueManager;

--- a/backend/effects/queues/effect-queue-manager.js
+++ b/backend/effects/queues/effect-queue-manager.js
@@ -2,9 +2,10 @@
 
 const frontendCommunicator = require("../../common/frontend-communicator");
 const JsonDbManager = require("../../database/json-db-manager");
+const effectQueueRunner = require("./effect-queue-runner");
 
 /**
- * @typedef SavedEffectQueue
+ * @typedef EffectQueue
  * @property {string} id - the id of the effect queue
  * @property {string} name - the name of the effect queue
  * @property {string} mode - the mode of the effect queue
@@ -13,11 +14,22 @@ const JsonDbManager = require("../../database/json-db-manager");
  */
 
 /**
- * @extends {JsonDbManager<SavedPresetEffectList>}
+ * @extends {JsonDbManager<EffectQueue>}
  */
 class EffectQueueManager extends JsonDbManager {
     constructor() {
         super("Effect Queue", "/effects/effectqueues");
+    }
+
+    /**
+     * @param {EffectQueue}
+     * @returns {Promise.<EffectQueue>}
+     * */
+    async saveItem(effectQueue) {
+        const savedEffectQueue = await super.saveItem(effectQueue);
+        effectQueueRunner.updateQueueConfig(savedEffectQueue);
+
+        return savedEffectQueue;
     }
 
     /**

--- a/backend/import/setups/setup-importer.js
+++ b/backend/import/setups/setup-importer.js
@@ -108,7 +108,7 @@ function importSetup(setup, selectedCurrency) {
     // effect queues
     const effectQueues = setup.components.effectQueues || [];
     for (const queue of effectQueues) {
-        effectQueueManager.saveEffectQueue(queue);
+        effectQueueManager.saveItem(queue);
     }
     effectQueueManager.triggerUiRefresh();
 
@@ -152,7 +152,7 @@ function importSetup(setup, selectedCurrency) {
     // preset effect lists
     const presetEffectLists = setup.components.presetEffectLists || [];
     for (const presetLists of presetEffectLists) {
-        presetEffectListManager.savePresetEffectList(presetLists);
+        presetEffectListManager.saveItem(presetLists);
     }
     presetEffectListManager.triggerUiRefresh();
 
@@ -188,7 +188,7 @@ function removeSetupComponents(components) {
                     frontendCommunicator.send("remove-currency", { id, name });
                     break;
                 case "effectQueues":
-                    effectQueueManager.deleteEffectQueue(id);
+                    effectQueueManager.deleteItem(id);
                     break;
                 case "events":
                     eventsAccess.removeEventFromMainEvents(id);
@@ -200,7 +200,7 @@ function removeSetupComponents(components) {
                     frontendCommunicator.send("remove-hotkey", id);
                     break;
                 case "presetEffectLists":
-                    presetEffectListManager.deletePresetEffectList(id);
+                    presetEffectListManager.deleteItem(id);
                     break;
                 case "timers":
                     timerAccess.deleteTimer(id);

--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -65,7 +65,7 @@ exports.runPresetList = async function(req, res) {
         });
     }
 
-    const presetList = presetEffectListManager.getPresetEffectList(presetListId);
+    const presetList = presetEffectListManager.getItem(presetListId);
     if (presetList == null) {
         return res.status(404).send({
             status: "error",


### PR DESCRIPTION
### Description of the Change
This creates a class which can be extended by manager classes that interact with a json db. It removes and prevents code duplication and centralizes the data interaction. I updated the effect queues and preset effects lists already, but it may be nice to implement it in other parts of the codebase as well.


### Testing
I tested if all changed functionality still works as it should.