### PR TITLE
Add a new event for chat mode changes

### DIFF
--- a/backend/events/builtin/twitchEventSource.js
+++ b/backend/events/builtin/twitchEventSource.js
@@ -295,6 +295,23 @@ module.exports = {
                     return `**${eventData.username}** sent you the following whisper: ${eventData.message}`;
                 }
             }
+        },
+        {
+            id: "chat-mode-changed",
+            name: "Chat Mode Changed",
+            description: "When the chat mode settings have been updated by a moderator.",
+            cached: false,
+            manualMetadata: {
+                chatMode: "Followers",
+                moderator: "Firebot",
+                duration: "30"
+            },
+            activityFeed: {
+                icon: "fad fa-comment-alt",
+                getMessage: (eventData) => {
+                    return `**${eventData.moderator}** has set the chat mode to **${eventData.chatMode}**.`;
+                }
+            }
         }
     ]
 };

--- a/backend/events/filters/builtin-filter-loader.js
+++ b/backend/events/filters/builtin-filter-loader.js
@@ -5,6 +5,9 @@ const filterManager = require("./filter-manager");
 exports.loadFilters = () => {
     [
         'bits-badge-tier',
+        'chat-mode-duration',
+        'chat-mode-setting',
+        'chat-mode',
         'cheer-bits-amount',
         'donation-amount',
         'donation-from',

--- a/backend/events/filters/builtin/chat-mode-duration.js
+++ b/backend/events/filters/builtin/chat-mode-duration.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const { ComparisonType } = require("../../../../shared/filter-constants");
+
+module.exports = {
+    id: "firebot:chatmodeduration",
+    name: "Duration",
+    description: "Filter by a chat mode's duration (only for Slow (seconds) and Follower (minutes))",
+    events: [
+        { eventSourceId: "twitch", eventId: "chat-mode-changed" }
+    ],
+    comparisonTypes: [
+        ComparisonType.IS,
+        ComparisonType.IS_NOT,
+        ComparisonType.LESS_THAN,
+        ComparisonType.LESS_THAN_OR_EQUAL_TO,
+        ComparisonType.GREATER_THAN,
+        ComparisonType.GREATER_THAN_OR_EQUAL_TO
+    ],
+    valueType: "number",
+    predicate: (filterSettings, eventData) => {
+
+        const { comparisonType, value } = filterSettings;
+        const { eventMeta } = eventData;
+
+        const duration = eventMeta.duration;
+
+        if (duration == null) {
+            return true;
+        }
+
+        switch (comparisonType) {
+        case ComparisonType.IS: {
+            return duration === value;
+        }
+        case ComparisonType.IS_NOT: {
+            return duration !== value;
+        }
+        case ComparisonType.LESS_THAN: {
+            return duration < value;
+        }
+        case ComparisonType.LESS_THAN_OR_EQUAL_TO: {
+            return duration <= value;
+        }
+        case ComparisonType.GREATER_THAN: {
+            return duration > value;
+        }
+        case ComparisonType.GREATER_THAN_OR_EQUAL_TO: {
+            return duration >= value;
+        }
+        default:
+            return false;
+        }
+    }
+};

--- a/backend/events/filters/builtin/chat-mode-setting.js
+++ b/backend/events/filters/builtin/chat-mode-setting.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const { ComparisonType } = require("../../../../shared/filter-constants");
+
+module.exports = {
+    id: "firebot:chatmodesetting",
+    name: "Setting",
+    description: "Filter by a chat mode's setting",
+    events: [
+        { eventSourceId: "twitch", eventId: "chat-mode-changed" }
+    ],
+    comparisonTypes: [ComparisonType.IS],
+    valueType: "preset",
+    presetValues: () => {
+        return [
+            {
+                value: "enabled",
+                display: "Enabled"
+            },
+            {
+                value: "disabled",
+                display: "Disabled"
+            }
+        ];
+    },
+    getSelectedValueDisplay: (filterSettings) => {
+        switch (filterSettings.value) {
+        case "enabled":
+            return "Enabled";
+        case "disabled":
+            return "Disabled";
+        default:
+            return "[Not set]";
+        }
+    },
+    predicate: async (filterSettings, eventData) => {
+
+        const { value } = filterSettings;
+        const { eventMeta } = eventData;
+
+        const chatModeDisabled = eventMeta.chatMode.includes("off");
+
+        switch (value) {
+        case "enabled": {
+            return !chatModeDisabled;
+        }
+        case "disabled": {
+            return chatModeDisabled;
+        }
+        default:
+            return chatModeDisabled;
+        }
+    }
+};

--- a/backend/events/filters/builtin/chat-mode.js
+++ b/backend/events/filters/builtin/chat-mode.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { ComparisonType } = require("../../../../shared/filter-constants");
+
+module.exports = {
+    id: "firebot:chatmode",
+    name: "Chat Mode",
+    description: "Filter by a chat mode",
+    events: [
+        { eventSourceId: "twitch", eventId: "chat-mode-changed" }
+    ],
+    comparisonTypes: [ComparisonType.IS, ComparisonType.IS_NOT],
+    valueType: "preset",
+    presetValues: () => {
+        return [
+            {
+                value: "emoteonly",
+                display: "Emote Only"
+            },
+            {
+                value: "followers",
+                display: "Followers"
+            },
+            {
+                value: "subscribers",
+                display: "Subscribers Only"
+            },
+            {
+                value: "slow",
+                display: "Slow"
+            },
+            {
+                value: "r9kbeta",
+                display: "Unique Chat"
+            }
+        ];
+    },
+    getSelectedValueDisplay: (filterSettings) => {
+        switch (filterSettings.value) {
+        case "emoteonly":
+            return "Emote Only";
+        case "followers":
+            return "Followers";
+        case "subscribers":
+            return "Subscribers Only";
+        case "slow":
+            return "Slow";
+        case "r9kbeta":
+            return "Unique Chat";
+        default:
+            return "[Not set]";
+        }
+    },
+    predicate: async (filterSettings, eventData) => {
+
+        const { comparisonType, value } = filterSettings;
+        const { eventMeta } = eventData;
+
+        switch (comparisonType) {
+        case "is":
+            return eventMeta.chatMode.includes(value);
+        case "is not":
+            return !eventMeta.chatMode.includes(value);
+        default:
+            return false;
+        }
+    }
+};

--- a/backend/events/twitch-events.js
+++ b/backend/events/twitch-events.js
@@ -1,6 +1,7 @@
 "use strict";
 
 exports.chatMessage = require('./twitch-events/chat-message');
+exports.chatModeChanged = require('./twitch-events/chat-mode-changed');
 exports.cheer = require('./twitch-events/cheer');
 exports.follow = require('./twitch-events/follow');
 exports.giftSub = require('./twitch-events/gift-sub');

--- a/backend/events/twitch-events/chat-mode-changed.js
+++ b/backend/events/twitch-events/chat-mode-changed.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const eventManager = require("../EventManager");
+
+/** @param {import("@twurple/pubsub").PubSubChatModActionMessage} message */
+exports.triggerChatModeChanged = (message) => {
+    eventManager.triggerEvent("twitch", "chat-mode-changed", {
+        chatMode: message.action,
+        moderator: message.userName,
+        duration: message.args ? parseInt(message.args[0]) : null
+    });
+};

--- a/backend/twitch-api/pubsub/pubsub-client.js
+++ b/backend/twitch-api/pubsub/pubsub-client.js
@@ -129,6 +129,18 @@ async function createClient() {
                 twitchEventsHandler.viewerTimeout.triggerTimeout(message);
                 frontendCommunicator.send("twitch:chat:user:delete-messages", message.args[0]);
                 break;
+            case "emoteonly":
+            case "emoteonlyoff":
+            case "subscribers":
+            case "subscribersoff":
+            case "followers":
+            case "followersoff":
+            case "slow":
+            case "slowoff":
+            case "r9kbeta": // Unique Chat
+            case "r9kbetaoff":
+                twitchEventsHandler.chatModeChanged.triggerChatModeChanged(message);
+                break;
             default:
                 return;
             }

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -24,6 +24,8 @@ exports.loadReplaceVariables = () => {
         'chat-message-emote-urls',
         'chat-message',
         'chat-messages',
+        'chat-mode-duration',
+        'chat-mode',
         'cheer-bits',
         'cheer-message',
         'cheer-total-bits',

--- a/backend/variables/builtin/chat-mode-duration.js
+++ b/backend/variables/builtin/chat-mode-duration.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const {
+    EffectTrigger
+} = require("../../effects/models/effectModels");
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+let triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:chat-mode-changed"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model = {
+    definition: {
+        handle: "chatModeDuration",
+        description: "The duration relevant to either follower (minutes) or slow (seconds) mode.",
+        triggers: triggers,
+        categories: [VariableCategory.TRIGGER],
+        possibleDataOutput: [OutputDataType.number]
+    },
+    evaluator: (trigger) => {
+        return trigger.metadata.eventData.duration;
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/chat-mode.js
+++ b/backend/variables/builtin/chat-mode.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const {
+    EffectTrigger
+} = require("../../effects/models/effectModels");
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+let triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:chat-mode-changed"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model = {
+    definition: {
+        handle: "chatMode",
+        description: "The mode to which the chat has been updated.",
+        triggers: triggers,
+        categories: [VariableCategory.TRIGGER],
+        possibleDataOutput: [OutputDataType.text]
+    },
+    evaluator: (trigger) => {
+        switch (trigger.metadata.eventData.chatMode) {
+        case "emoteonly":
+        case "emoteonlyoff":
+            return "Emote Only";
+        case "followers":
+        case "followersoff":
+            return "Followers";
+        case "subscribers":
+        case "subscribersoff":
+            return "Subscribers Only";
+        case "slow":
+        case "slowoff":
+            return "Slow";
+        case "r9kbeta":
+        case "r9kbetaoff":
+            return "Unique Chat";
+        default:
+            return "";
+        }
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/moderator.js
+++ b/backend/variables/builtin/moderator.js
@@ -7,13 +7,13 @@ const {
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
 
 let triggers = {};
-triggers[EffectTrigger.EVENT] = ["twitch:banned", "twitch:timeout"];
+triggers[EffectTrigger.EVENT] = ["twitch:banned", "twitch:timeout", "twitch:chat-mode-changed"];
 triggers[EffectTrigger.MANUAL] = true;
 
 const model = {
     definition: {
         handle: "moderator",
-        description: "The name of the moderator that performed the action (ban or timeout).",
+        description: "The name of the moderator that performed the action (ban, timeout or chat mode change).",
         triggers: triggers,
         categories: [VariableCategory.USER, VariableCategory.TRIGGER],
         possibleDataOutput: [OutputDataType.text]


### PR DESCRIPTION
### Description of the Change
This adds an event that triggers when a chat mode change has been made. 

I added three filters:
- A chat mode filter with which you can filter Emote Only, Followers, Subscribers Only, Slow, and Unique chat
- A setting filter to check if a chat mode has been enabled or disabled
- A duration filter for slow (seconds) and followers (minutes)

I also added two variables: `$chatMode` and `$chatModeDuration`.

### Testing
I tested if the event works, including the filters and variables.


### Screenshots
![image](https://user-images.githubusercontent.com/72231755/149846692-dd4b2d02-5435-41dc-b5ec-995b659f8800.png)
