### PR TITLE
Fix the event listeners for StreamElements and add a formatted amount

### DIFF
--- a/backend/integrations/builtin/streamelements/streamelements-event-handler.js
+++ b/backend/integrations/builtin/streamelements/streamelements-event-handler.js
@@ -55,11 +55,41 @@ exports.registerEvents = () => {
     eventManager.registerEventSource(eventSourceDefinition);
 };
 
+const currencies = new Map([
+    ["USD", "$"],
+    ["AUD", "$"],
+    ["CAD", "$"],
+    ["HKD", "$"],
+    ["MXN", "$"],
+    ["NZD", "$"],
+    ["SGD", "$"],
+    ["EUR", "€"],
+    ["GBP", "£"],
+    ["BRL", "R$"],
+    ["CHF", "CHF"],
+    ["DKK", "kr"],
+    ["NOK", "kr"],
+    ["SEK", "kr"],
+    ["HUF", "Ft"],
+    ["ILS", "₪"],
+    ["INR", "₹"],
+    ["JPY", "¥"],
+    ["MYR", "RM"],
+    ["PHP", "₱"],
+    ["PLN", "zł"],
+    ["UAH", "₴"],
+    ["RUB", "₽"],
+    ["TWD", "NT$"],
+    ["THB", "฿"],
+    ["TRY", "₺"]
+]);
+
 exports.processDonationEvent = (eventData) => {
     eventManager.triggerEvent(EVENT_SOURCE_ID, EventId.DONATION, {
         donationAmount: eventData.amount,
+        formattedDonationAmount: currencies.get(eventData.currency) + eventData.amount,
         donationMessage: eventData.message,
-        from: eventData.name
+        from: eventData.displayName
     });
 };
 

--- a/backend/integrations/builtin/streamelements/streamelements.js
+++ b/backend/integrations/builtin/streamelements/streamelements.js
@@ -92,13 +92,10 @@ class StreamElementsIntegration extends EventEmitter {
 
         this._socket.on('event', (data) => {
             logger.debug("Received streamelements event:", data);
-            if (data
-                && data.listener === "tip-latest"
-                && data.event
-                && data.event.type === 'tip') {
-                seEventsHandler.processDonationEvent(data.event);
-            } else if (data && data.listener === "follower-latest") {
-                seEventsHandler.processFollowEvent(data.event);
+            if (data && data.type === "tip") {
+                seEventsHandler.processDonationEvent(data);
+            } else if (data && data.type === "follow") {
+                seEventsHandler.processFollowEvent(data);
             }
         });
     }

--- a/backend/variables/builtin/donation-amount-formatted.js
+++ b/backend/variables/builtin/donation-amount-formatted.js
@@ -6,13 +6,13 @@ const { EffectTrigger } = require("../../../shared/effect-constants");
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
 
 let triggers = {};
-triggers[EffectTrigger.EVENT] = ["streamlabs:donation", "streamlabs:eldonation", "tipeeestream:donation"];
+triggers[EffectTrigger.EVENT] = ["streamlabs:donation", "streamlabs:eldonation", "tipeeestream:donation", "streamelements:donation"];
 triggers[EffectTrigger.MANUAL] = true;
 
 const model = {
     definition: {
         handle: "donationAmountFormatted",
-        description: "The amount (w/currency symbol) of a donation from StreamLabs/Tipeee/ExtraLife",
+        description: "The amount (w/currency symbol) of a donation from StreamElements/StreamLabs/Tipeee/ExtraLife",
         triggers: triggers,
         categories: [VariableCategory.COMMON, VariableCategory.TRIGGER],
         possibleDataOutput: [OutputDataType.TEXT]


### PR DESCRIPTION
### Description of the Change
It seems the websocket data has changed for actual events (so not the test data): https://dev.streamelements.com/docs/kappa/ZG9jOjYxMzcxNTY-connecting-via-websocket-using-o-auth2

I updated the listener to get the proper data, and I also added a formatter for the amount. The documentations says that `amount` is an Int32, so apparently the amount gets rounded? 


### Applicable Issues
#1029 


### Testing
I tested the follow event, the donation event is not testable unfortunately since the test functionality provides different data.