### PR TITLE
Add query param handling for preset effect list GET requests

### DIFF
--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -75,11 +75,18 @@ exports.runPresetList = async function(req, res) {
 
     const body = req.body || {};
     const query = req.query || {};
-    let { args, username } = body;
-
-    if (req.method === "GET") {
+    let args, username;
+    
+    // GET
+    if (req.method === "GET")
+    {
         username = query.username;
         args = query;
+
+    // POST
+    } else {
+        username = body.username;
+        args = body.args;
     }
 
     const processEffectsRequest = {

--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -84,9 +84,13 @@ exports.runPresetList = async function(req, res) {
         args = query;
 
     // POST
-    } else {
+    } else if (req.method === "POST") {
         username = body.username;
         args = body.args;
+        
+    // Not GET or POST
+    } else {
+        return res.status(404).send({ status: "error", message: "Invalid request method" });
     }
 
     const processEffectsRequest = {

--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -74,7 +74,13 @@ exports.runPresetList = async function(req, res) {
     }
 
     const body = req.body || {};
-    const { args, username } = body;
+    const query = req.query || {};
+    let { args, username } = body;
+
+    if (req.method === "GET") {
+        username = query.username;
+        args = query;
+    }
 
     const processEffectsRequest = {
         trigger: {


### PR DESCRIPTION
### Description of the Change
Username and args sent via query string are now passed to a preset effect list when API is hit via GET request.


### Applicable Issues
#1613


### Testing
Created a simple preset effect list that performs TTS using both an arg and the username. Verified that GET requests now use the query string and POST requests are still able to use the request body.


### Screenshots
N/A