### PR TITLE
Added displayName to fix #1607

### DIFF
--- a/backend/chat/chat-helpers.js
+++ b/backend/chat/chat-helpers.js
@@ -204,7 +204,7 @@ function parseMessageParts(firebotChatMessage, parts) {
                 if (!firebotChatMessage.whisper &&
                 !firebotChatMessage.tagged &&
                 streamer.loggedIn &&
-                p.text.includes(streamer.username)) {
+                (p.text.includes(streamer.username) || p.text.includes(streamer.displayName))) {
                     firebotChatMessage.tagged = true;
                 }
             }


### PR DESCRIPTION
### Description of the Change
Added check for `streamer.displayName` to username tag check for Chat Notification so that it triggers on both names and not only the username.


### Applicable Issues
#1607 


### Testing
Manually tested that the bot notifies on both variants of the username
