### PR TITLE
#1638 make $arrayFind return index

### DIFF
--- a/backend/variables/builtin/array-find.js
+++ b/backend/variables/builtin/array-find.js
@@ -24,16 +24,20 @@ function getPropertyAtPath(obj, propertyPath) {
 const model = {
     definition: {
         handle: "arrayFind",
-        usage: "arrayFind[jsonArray, matcher, propertyPath]",
-        description: "Finds a matching element in the array or null",
+        usage: "arrayFind[jsonArray, matcher, propertyPath, returnIndex]",
+        description: "Finds a matching element in the array or null. Returns either the object index or the object",
         examples: [
             {
-                usage: 'arrayFind["[1,2,3]", 1]',
-                description: "Finds 1 in the array"
+                usage: 'arrayFind["["a","b","c"]", "b"]',
+                description: 'Returns "b"'
             },
             {
                 usage: 'arrayFind["[{\\"username\\": \\"ebiggz\\"},{\\"username\\": \\"MageEnclave\\"}]", ebiggz, username]',
-                description: 'Finds object with username of "ebiggz"'
+                description: 'Returns the object where "username"="ebiggz"'
+            },
+            {
+                usage: 'arrayFind["["a","b","c"]", "b", null, true]',
+                description: 'Returns 1'
             }
         ],
         categories: [VariableCategory.ADVANCED],


### PR DESCRIPTION
### Description of the Change
Added a new boolean optional parameter to return the index instead of the object. 
New usage : $arrayFind[jsonArray, matcher, propertyPath, returnIndex]
Also proposed an update to the descriptions to clarify the behaviour. 

This change goes along the lines of my last proposition in the bug report thread. 
Rationale : 
- Changing the behavior to return index just for arrays of non objects would be inconsistant and possibly break existing setups
- Creating an additional function would add clutter and more easily overwhelm the user base that's not used to programming
- Adding an optional parameter keeps current behavior unchanged while expanding the capabilities. 

### Applicable Issues
#1638 

### Testing
Created a chat command with the following : 
$arrayFind["[\"a\",\"b\",\"c\"]", b] | 
$arrayFind["[{\"username\": \"ebiggz\"},{\"username\": \"MageEnclave\"}]", ebiggz, username] | 
$arrayFind["[\"a\",\"b\",\"c\"]", b, null, true] | 
$arrayFind["[{\"username\": \"ebiggz\"},{\"username\": \"MageEnclave\"}]", ebiggz, username, true] || 
$arrayFind["[\"a\",\"b\",\"c\"]", d]  | 
$arrayFind["[{\"username\": \"ebiggz\"},{\"username\": \"MageEnclave\"}]", toto, username] | 
$arrayFind["[\"a\",\"b\",\"c\"]", d, null, true] | 
$arrayFind["[{\"username\": \"ebiggz\"},{\"username\": \"MageEnclave\"}]", toto, username, true]

Also tested a number of them by setting a customVariable and requesting it back

### Screenshots
![test_arrayFind](https://user-images.githubusercontent.com/6044734/160257727-fa9d0c88-f8bb-4611-a438-34a8b0f5983e.png)



