### PR TITLE
Fix github link

### DIFF
--- a/gui/app/directives/modals/misc/aboutModal.js
+++ b/gui/app/directives/modals/misc/aboutModal.js
@@ -12,7 +12,7 @@
                 <p>{{$ctrl.version}}</p>
 
                 <h5><b>Source</b></h5>
-                <p><a href ng-click="$root.openLinkExternally('https://github.com/crowbartools/Firebot/Firebot')">GitHub</a></p>
+                <p><a href ng-click="$root.openLinkExternally('https://github.com/crowbartools/Firebot')">GitHub</a></p>
 
                 <h5><b>Support</b></h5> 
                 <span>Experiencing a problem or have a suggestion?</span></br>


### PR DESCRIPTION
There was an additional /Firebot in the URL, resulting in a 404

### Description of the Change
Removed part of the URL from the Github link in the About window, to point at the correct location of the source.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
