### PR TITLE
#1638 add $arrayFindIndex variable

### DIFF
--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -12,6 +12,7 @@ exports.loadReplaceVariables = () => {
         'array-add',
         'array-filter',
         'array-find',
+        'array-find-index',
         'array-join',
         'array-length',
         'array-remove',

--- a/backend/variables/builtin/array-find-index.js
+++ b/backend/variables/builtin/array-find-index.js
@@ -48,7 +48,7 @@ const model = {
             try {
                 matcher = JSON.parse(matcher);
             } catch (err) {
-                //fail silently
+                return null;
             }
 
             if (propertyPath === 'null' || propertyPath === "") {
@@ -74,7 +74,7 @@ const model = {
                     return JSON.stringify(found != -1 ? found : null);
                 }
             } catch (error) {
-                // fail silently
+                return null;
             }
         }
         return null;

--- a/backend/variables/builtin/array-find-index.js
+++ b/backend/variables/builtin/array-find-index.js
@@ -1,0 +1,84 @@
+// Migration: done
+
+'use strict';
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+function getPropertyAtPath(obj, propertyPath) {
+    let data = obj;
+    const pathNodes = propertyPath.split(".");
+    for (let i = 0; i < pathNodes.length; i++) {
+        if (data == null) {
+            break;
+        }
+        let node = pathNodes[i];
+        // parse to int for array access
+        if (!isNaN(node)) {
+            node = parseInt(node);
+        }
+        data = data[node];
+    }
+    return data;
+}
+
+const model = {
+    definition: {
+        handle: "arrayFindIndex",
+        usage: "arrayFindIndex[jsonArray, matcher, propertyPath]",
+        description: "Finds a matching element in the array and returns it's index, or null if the element is absent",
+        examples: [
+            {
+                usage: 'arrayFindIndex["[\\"a\\",\\"b\\",\\"c\\"]", b]',
+                description: 'Returns 1 , the index of "b"'
+            },
+            {
+                usage: 'arrayFindIndex["[{\\"username\\": \\"alastor\\"},{\\"username\\": \\"ebiggz\\"}]", alastor, username]',
+                description: 'Returns 0, the index of the object where "username"="alastor"'
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT, OutputDataType.NUMBER]
+    },
+    evaluator: (_, jsonArray, matcher, propertyPath = null) => {
+        if (jsonArray != null) {
+            if (matcher === undefined || matcher === "") {
+                return null;
+            }
+
+            try {
+                matcher = JSON.parse(matcher);
+            } catch (err) {
+                //fail silently
+            }
+
+            if (propertyPath === 'null' || propertyPath === "") {
+                propertyPath = null;
+            }
+
+            try {
+                const array = JSON.parse(jsonArray);
+                if (Array.isArray(array)) {
+                    let found;
+
+                    // propertyPath arg not specified
+                    if (propertyPath == null || propertyPath === "") {
+                        found = array.findIndex(v => v === matcher);
+
+                    // property path specified
+                    } else {
+                        found = array.findIndex(v => {
+                            const property = getPropertyAtPath(v, propertyPath);
+                            return property === matcher;
+                        });
+                    }
+                    return JSON.stringify(found != -1 ? found : null);
+                }
+            } catch (error) {
+                // fail silently
+            }
+        }
+        return null;
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
This adds a $arrayFindIndex[jsonArray, matcher, propertyPath] variable that extracts the index of the array `jsonArray` where the item matches `matcher`. If `propertyPath` is filled, it tries to match the object item by following the property path. 
If it can't find a match, it returns null. 

### Applicable Issues
#1638 

### Testing
Created a chat command with the following : 
$arrayFindIndex["[\"a\",\"b\",\"c\"]", b] | 
$arrayFindIndex["[{\"username\": \"alastor\"},{\"username\": \"ebiggz\"}]", alastor, username] || 
$arrayFindIndex["[\"a\",\"b\",\"c\"]", d]  | 
$arrayFindIndex["[{\"username\": \"alastor\"},{\"username\": \"ebiggz\"}]", toto, username]

Checked the return value is "1 | 0 || null | null"

### Screenshots
![test_arrayFindIndex](https://user-images.githubusercontent.com/6044734/160293775-84910250-5939-4739-9bc0-6bd449042684.png)

