### PR TITLE
Adds a notice to Channel Detail embed  #1639

### DIFF
--- a/backend/integrations/builtin/discord/send-discord-message-effect.js
+++ b/backend/integrations/builtin/discord/send-discord-message-effect.js
@@ -72,6 +72,10 @@ module.exports = {
                             </div>
 
                         </div>
+
+                        <div ng-show="effect.embedType === 'channel'">
+                            <br /><b>*</b> Must be live for this to post.
+                        </div>
                     </div>
                 </eos-container>
 


### PR DESCRIPTION
### Description of the Change
Adds a simple notification that shows up if someone selects Channel Detail embed that the channel has to be live for it to work.


### Applicable Issues
#1639 


### Testing
Tested to see that it only shows up when Channel Details and not for Custom Embed.


### Screenshots
![image](https://user-images.githubusercontent.com/4147439/160297547-7ff32a7e-699b-4c71-8330-8dc879ec832e.png)