### PR TITLE
Fix customVariable and userMetadata parameters checks

### DIFF
--- a/backend/variables/builtin/custom-variable.js
+++ b/backend/variables/builtin/custom-variable.js
@@ -35,7 +35,7 @@ const model = {
     evaluator: (_, name, propertyPath, defaultData) => {
         const data = customVariableManager.getCustomVariable(name, propertyPath, defaultData);
         if (data == null) {
-            return defaultData;
+            return null;
         }
 
         if (isObjectOrArray(data)) {

--- a/backend/variables/builtin/custom-variable.js
+++ b/backend/variables/builtin/custom-variable.js
@@ -33,12 +33,15 @@ const model = {
         possibleDataOutput: [OutputDataType.NUMBER, OutputDataType.TEXT]
     },
     evaluator: (_, name, propertyPath, defaultData) => {
-        let data = customVariableManager.getCustomVariable(name, propertyPath, defaultData);
-        if (data == null || !isObjectOrArray(data)) {
-            return 'null';
+        const data = customVariableManager.getCustomVariable(name, propertyPath, defaultData);
+        if (data == null) {
+            return defaultData;
         }
 
-        data = JSON.stringify(data);
+        if (isObjectOrArray(data)) {
+            return JSON.stringify(data);
+        }
+
         return data;
     }
 };

--- a/backend/variables/builtin/custom-variable.js
+++ b/backend/variables/builtin/custom-variable.js
@@ -7,7 +7,7 @@ const customVariableManager = require("../../common/custom-variable-manager");
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
 
 function isObjectOrArray(data) {
-    return Array.isArray(data) || (typeof data === 'object' && !(typeof data === 'string' || data instanceof String));
+    return Array.isArray(data) || (typeof data === 'object' && !(data instanceof String));
 }
 
 const model = {
@@ -34,10 +34,12 @@ const model = {
     },
     evaluator: (_, name, propertyPath, defaultData) => {
         let data = customVariableManager.getCustomVariable(name, propertyPath, defaultData);
-        if (data && isObjectOrArray(data)) {
-            data = JSON.stringify(data);
+        if (data == null || !isObjectOrArray(data)) {
+            return 'null';
         }
-        return data != null ? data : "null";
+
+        data = JSON.stringify(data);
+        return data;
     }
 };
 

--- a/backend/variables/builtin/user-metadata.js
+++ b/backend/variables/builtin/user-metadata.js
@@ -26,12 +26,15 @@ const model = {
     },
     evaluator: async (_, username, key, defaultValue = null, propertyPath = null) => {
         const userDb = require("../../database/userDatabase");
-        let data = await userDb.getUserMetadata(username, key, propertyPath);
-        if (data == null || !isObjectOrArray(data)) {
+        const data = await userDb.getUserMetadata(username, key, propertyPath);
+        if (data == null) {
             return defaultValue;
         }
+
+        if (isObjectOrArray(data)) {
+            return JSON.stringify(data);
+        }
         
-        data = JSON.stringify(data);
         return data;
     }
 };

--- a/backend/variables/builtin/user-metadata.js
+++ b/backend/variables/builtin/user-metadata.js
@@ -3,7 +3,7 @@
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
 
 function isObjectOrArray(data) {
-    return Array.isArray(data) || (typeof data === 'object' && !(typeof data === 'string' || data instanceof String));
+    return Array.isArray(data) || (typeof data === 'object' && !(data instanceof String));
 }
 
 const model = {
@@ -27,10 +27,12 @@ const model = {
     evaluator: async (_, username, key, defaultValue = null, propertyPath = null) => {
         const userDb = require("../../database/userDatabase");
         let data = await userDb.getUserMetadata(username, key, propertyPath);
-        if (data && isObjectOrArray(data)) {
-            data = JSON.stringify(data);
+        if (data == null || !isObjectOrArray(data)) {
+            return defaultValue;
         }
-        return data != null ? data : defaultValue;
+        
+        data = JSON.stringify(data);
+        return data;
     }
 };
 


### PR DESCRIPTION
### Description of the Change
Apply recommendations on improving #1648 to customVariable and userMetadata, that have the same issues. 

### Testing
 - Set customVariable `test` to `[{"username":"alastor"}, {"username":"buttastor"}]`
 - Output to chat 
> $customVariable[test] | 
> $customVariable[test, 1] | 
> $customVariable[test, 1, defaultValue] || 
> $customVariable[test2] | 
> $customVariable[test, 4] | 
> $customVariable[test, 4, defaultValue]
 - Checked that the output is `[{"username":"alastor"},{"username":"buttastor"}] | {"username":"buttastor"} | {"username":"buttastor"} || | | defaultValue`

 - Set customVariable `test` to `{ "username" : "alastor", "location" : "pungeon"}`
 - Output to chat : 
> $customVariable[test, "username"] | 
> $customVariable[test, "username", defaultValue] || 
> $customVariable[test, "username2"] | 
> $customVariable[test, "username2", defaultValue]
 - Checked that the output is `alastor | alastor || | defaultValue`

 - Checked that previous version of `customVariable` produced the same outputs

 - Set user metadata `test` to `{"propertyPath" : "test", "path" : "wrong"}`
 - Output to chat  : 
> $userMetadata[$target, test] | 
> $userMetadata[$target, test, defaultValue] | 
> $userMetadata[$target, test, null, propertyPath] | 
> $userMetadata[$target, test2] || 
> $userMetadata[$target, test2, defaultValue] | 
> $userMetadata[$target, test2, null, propertyPath] | 
> $userMetadata[$target, test, defaultValue, propertyPath2]
 - Checked that the output is `{"propertyPath":"test","path":"wrong"} | {"propertyPath":"test","path":"wrong"} | test | || defaultValue | null | defaultValue`
 - Checked that previous version of `userMetadata` produced the same outputs
