### PR TITLE
Add log level option to Log Message effect

### DIFF
--- a/backend/effects/builtin/log-message.js
+++ b/backend/effects/builtin/log-message.js
@@ -18,16 +18,53 @@ const addFirebotLogMessage = {
             <p class="muted">Enter the message you would like to write to the Firebot log file.</p>
             <input ng-model="effect.logMessage" id="log-message-text" type="text" class="form-control" placeholder="Enter log message text" replace-variables>
         </eos-container>
+        
+        <eos-container header="Log Level" pad-top="true">
+            <p class="muted">Choose the log level you would like the message written as. Note that <strong>Debug</strong> level messages will ONLY be written when Debug Mode is enabled.</p>
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="log-message-type-effect-log-level">{{effect.logLevel ? effect.logLevel : "Pick one"}}</span> <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                <li ng-repeat="logLevel in logLevelTypes"
+                    ng-click="effect.logLevel = logLevel">
+                    <a href>{{logLevel}}</a>
+                </li>
+            </ul>
+        </eos-container>
     `,
+    optionsController: ($scope) => {
+        $scope.logLevelTypes = ["Info", "Warning", "Error", "Debug"];
+        $scope.effect.logLevel = $scope.effect.logLevel ?? "Info";
+    },
     optionsValidator: effect => {
         let errors = [];
-        if (effect.logMessage == null || effect.logMessage === "") {
+        if (!(effect.logMessage?.length > 1)) {
             errors.push("Please input a log message.");
+        }
+        if (effect.logLevel == null) {
+            errors.push("Please select a log level.");
         }
         return errors;
     },
     onTriggerEvent: async ({ effect }) => {
-        logger.info(effect.logMessage);
+        switch (effect.logLevel) {
+            case "Error":
+                logger.error(effect.logMessage);
+                break;
+
+            case "Warning":
+                logger.warn(effect.logMessage);
+                break;
+
+            case "Debug":
+                logger.debug(effect.logMessage);
+                break;
+
+            // Use Info as default
+            default:
+                logger.info(effect.logMessage);
+                break;
+        }
     }
 };
 


### PR DESCRIPTION
### Description of the Change
Adds a Log Level dropdown that defaults to Info but has all four log levels: Info, Warning, Error, and Debug.


### Applicable Issues
#1669


### Testing
Created a command with a Log Message effect and tested all 4 log levels. Verified in log file.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/161877017-90c99471-ea4f-4296-8328-9503e9ba77cf.png)