### PR TITLE
Fix $chatMessages username bug

### DIFF
--- a/backend/variables/builtin/chat-messages.js
+++ b/backend/variables/builtin/chat-messages.js
@@ -18,7 +18,7 @@ const model = {
         if (username == null) {
             username = trigger.metadata.username;
         }
-        let viewer = await viewerDB.getUserByUsername(trigger.metadata.username);
+        let viewer = await viewerDB.getUserByUsername(username);
         if (!viewer) {
             return 0;
         }


### PR DESCRIPTION
### Description of the Change
Update `$chatMessages` to use `username` parameter instead of always using `triggers.metadata.username`


### Applicable Issues
#1672


### Testing
Trust me, it works


### Screenshots
N/A
