### PR TITLE
Get all preset effect lists via API

### DIFF
--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -55,6 +55,27 @@ exports.runEffects = async function(req, res) {
     }
 };
 
+exports.getPresetLists = async function(req, res) {
+    const presetLists = presetEffectListManager.getAllItems();
+
+    if (presetLists == null) {
+        return res.status(500).send({
+            status: "error",
+            message: "Unknown error getting preset effect lists"
+        });
+    }
+
+    const formattedPresetLists = presetLists.map(l => {
+        return {
+            id: l.id,
+            name: l.name,
+            args: l.args.map(a => a.name)
+        };
+    });
+
+    return res.json(formattedPresetLists);
+};
+
 exports.runPresetList = async function(req, res) {
     const presetListId = req.params.presetListId;
 

--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -8,7 +8,7 @@ exports.getEffects = function(req, res) {
     let effectDefs = effectsManager.getEffectDefinitions();
 
     if (req.query.trigger) {
-        effectDefs = effectDefs.filter(e => e.triggers == null || e.triggers[req.query.trigger]);
+        effectDefs = effectDefs.filter(effect => effect.triggers == null || effect.triggers[req.query.trigger]);
     }
 
     res.json(effectDefs);
@@ -65,11 +65,11 @@ exports.getPresetLists = async function(req, res) {
         });
     }
 
-    const formattedPresetLists = presetLists.map(l => {
+    const formattedPresetLists = presetLists.map(presetList => {
         return {
-            id: l.id,
-            name: l.name,
-            args: l.args.map(a => a.name)
+            id: presetList.id,
+            name: presetList.name,
+            args: presetList.args.map(arg => arg.name)
         };
     });
 

--- a/server/api/v1/v1Router.js
+++ b/server/api/v1/v1Router.js
@@ -31,15 +31,15 @@ router
     .get(effects.getEffects)
     .post(effects.runEffects);
 
-router.route("/effects/preset/:presetListId")
-    .post(effects.runPresetList);
-
-router.route("/effects/preset/:presetListId")
-    .post(effects.runPresetList)
-    .get(effects.runPresetList);
+router.route("/effects/preset")
+    .get(effects.getPresetLists);
 
 router.route("/effects/:effectId")
     .get(effects.getEffect);
+
+router.route("/effects/preset/:presetListId")
+    .get(effects.runPresetList)
+    .post(effects.runPresetList);
 
 
 // Fonts


### PR DESCRIPTION
### Description of the Change
Adds an API endpoint at `api/v1/effects/preset` to GET all preset effect lists, including ID, name, and a list of arguments they take


### Applicable Issues
N/A


### Testing
GET-ted the list. Hooray!


### Screenshots
N/A