### PR TITLE
Basic Command API endpoints

### DIFF
--- a/backend/effects/builtin/log-message.js
+++ b/backend/effects/builtin/log-message.js
@@ -38,7 +38,7 @@ const addFirebotLogMessage = {
     },
     optionsValidator: effect => {
         let errors = [];
-        if (!(effect.logMessage?.length > 1)) {
+        if (!(effect.logMessage?.length > 0)) {
             errors.push("Please input a log message.");
         }
         if (effect.logLevel == null) {

--- a/server/api/v1/controllers/commandsApiController.js
+++ b/server/api/v1/controllers/commandsApiController.js
@@ -1,0 +1,191 @@
+"use strict";
+
+const commandManager = require("../../../../backend/chat/commands/CommandManager");
+const commandHandler = require("../../../../backend/chat/commands/commandHandler");
+
+exports.getSystemCommands = async function(req, res) {
+    const sysCommands = commandManager.getAllSystemCommandDefinitions();
+
+    if (sysCommands == null) {
+        return res.status(500).send({
+            status: "error",
+            message: "Unknown error getting system commands"
+        });
+    }
+
+    const formattedSysCommands = sysCommands.map(c => {
+        return {
+            id: c.id,
+            trigger: c.trigger,
+            name: c.name
+        };
+    });
+
+    return res.json(formattedSysCommands);
+};
+
+exports.getSystemCommand = async function(req, res) {
+    const sysCommandId = req.params.sysCommandId;
+
+    if (!(sysCommandId?.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No sysCommandId provided"
+        });
+    }
+
+    const sysCommand = commandManager.getSystemCommandById(sysCommandId);
+
+    if (sysCommand == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `System command '${sysCommandId}' not found`
+        });
+    }
+
+    return res.json(sysCommand.definition);
+};
+
+exports.runSystemCommand = async function(req, res) {
+    const sysCommandId = req.params.sysCommandId;
+
+    if (!(sysCommandId?.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No sysCommandId provided"
+        });
+    }
+
+    const sysCommand = commandManager.getSystemCommandById(sysCommandId);
+
+    if (sysCommand == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `System command '${sysCommandId}' not found`
+        });
+    }
+
+    const { trigger, args } = getCommandTriggerAndArgs(req);
+
+    try {
+        commandHandler.runSystemCommandFromEffect(sysCommandId, trigger, args);
+    } catch (e) {
+        return res.status(500).send({
+            status: "error",
+            message: `Error executing system command '${sysCommandId}': ${e}`
+        });
+    }
+
+    return res.status(200).send({
+        status: "success",
+        message: `System command '${sysCommandId}' executed successfully`
+    });
+};
+
+exports.getCustomCommands = async function(req, res) {
+    const customCommands = commandManager.getAllCustomCommands();
+
+    if (customCommands == null) {
+        return res.status(500).send({
+            status: "error",
+            message: "Unknown error getting custom commands"
+        });
+    }
+
+    const formattedCustomCommands = customCommands.map(c => {
+        return {
+            id: c.id,
+            trigger: c.trigger,
+            description: c.description
+        };
+    });
+
+    return res.json(formattedCustomCommands);
+};
+
+exports.getCustomCommand = async function(req, res) {
+    const customCommandId = req.params.customCommandId;
+
+    if (!(customCommandId?.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No customCommandId provided"
+        });
+    }
+
+    const customCommand = commandManager.getCustomCommandById(customCommandId);
+
+    if (customCommand == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Custom command '${customCommandId}' not found`
+        });
+    }
+
+    return res.json(customCommand);
+};
+
+exports.runCustomCommand = async function(req, res) {
+    const customCommandId = req.params.customCommandId;
+
+    if (!(customCommandId?.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No customCommandId provided"
+        });
+    }
+
+    const customCommand = commandManager.getCustomCommandById(customCommandId);
+
+    if (customCommand == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Custom command '${customCommandId}' not found`
+        });
+    }
+
+    const { trigger, args } = getCommandTriggerAndArgs(req);
+
+    try {
+        commandHandler.runCustomCommandFromEffect(customCommandId, trigger, args);
+    } catch (e) {
+        return res.status(500).send({
+            status: "error",
+            message: `Error executing custom command '${customCommandId}': ${e}`
+        });
+    }
+
+    return res.status(200).send({
+        status: "success",
+        message: `Custom command '${customCommandId}' executed successfully`
+    });
+};
+
+function getCommandTriggerAndArgs(req) {
+    const body = req.body || {};
+    const query = req.query || {};
+    let args, username, metadata;
+
+    // GET
+    if (req.method === "GET")
+    {
+        args = query.args;
+        username = query.username;
+
+    // POST
+    } else if (req.method === "POST") {
+        args = body.args;
+        username = body.username;
+        metadata = body.metadata;
+    }
+
+    username = username ?? "API User";
+
+    const trigger = {
+        metadata: metadata || { }
+    };
+
+    trigger.metadata.username = trigger.metadata.username ?? username;
+
+    return { trigger, args };
+}

--- a/server/api/v1/controllers/commandsApiController.js
+++ b/server/api/v1/controllers/commandsApiController.js
@@ -13,11 +13,11 @@ exports.getSystemCommands = async function(req, res) {
         });
     }
 
-    const formattedSysCommands = sysCommands.map(c => {
+    const formattedSysCommands = sysCommands.map(command => {
         return {
-            id: c.id,
-            trigger: c.trigger,
-            name: c.name
+            id: command.id,
+            trigger: command.trigger,
+            name: command.name
         };
     });
 
@@ -92,11 +92,11 @@ exports.getCustomCommands = async function(req, res) {
         });
     }
 
-    const formattedCustomCommands = customCommands.map(c => {
+    const formattedCustomCommands = customCommands.map(command => {
         return {
-            id: c.id,
-            trigger: c.trigger,
-            description: c.description
+            id: command.id,
+            trigger: command.trigger,
+            description: command.description
         };
     });
 

--- a/server/api/v1/v1Router.js
+++ b/server/api/v1/v1Router.js
@@ -42,6 +42,30 @@ router.route("/effects/:effectId")
     .get(effects.getEffect);
 
 
+// Commands
+const commands = require("./controllers/commandsApiController");
+
+router.route("/commands/system")
+    .get(commands.getSystemCommands);
+
+router.route("/commands/system/:sysCommandId")
+    .get(commands.getSystemCommand);
+
+router.route("/commands/system/:sysCommandId/run")
+    .get(commands.runSystemCommand)
+    .post(commands.runSystemCommand);
+
+router.route("/commands/custom")
+    .get(commands.getCustomCommands);
+
+router.route("/commands/custom/:customCommandId")
+    .get(commands.getCustomCommand);
+
+router.route("/commands/custom/:customCommandId/run")
+    .get(commands.runCustomCommand)
+    .post(commands.runCustomCommand);
+
+
 // Fonts
 const fonts = require("./controllers/fontsApiController");
 router.route("/fonts")


### PR DESCRIPTION
### Description of the Change
Adds the following API endpoints for commands:

`/api/v1/commands/system`
- GET list of all system command IDs, names, and base triggers

`/api/v1/commands/system/:sysCommandId`
- GET full definition for specified system command

`/api/v1/commands/system/:sysCommandId/run`
- GET or POST to run system command. Accepts parameters of `username`, `args`, and (POST only) trigger `metadata` object

`/api/v1/commands/custom`
`/api/v1/commands/custom/:customCommandId`
`/api/v1/commands/custom/:customCommandId/run`
Same as above, but for user-defined custom commands. Note that custom command list returns description instead of name.

**NOTE:** This currently executes a command using the same method call as the **Run Command** effect, so subcommand triggers are not supported, just as in the effect.


### Applicable Issues
N/A


### Testing
Tested against all endpoints, verified data and also command execution where applicable.


### Screenshots
N/A
