### PR TITLE
Add custom variable option when creating clip

### DIFF
--- a/backend/effects/builtin/clips.js
+++ b/backend/effects/builtin/clips.js
@@ -6,6 +6,7 @@ const { settings } = require("../../common/settings-access");
 const mediaProcessor = require("../../common/handlers/mediaProcessor");
 const webServer = require("../../../server/httpServer");
 const utils = require("../../utility");
+const customVariableManager = require("../../common/custom-variable-manager");
 
 const clip = {
     definition: {
@@ -43,6 +44,18 @@ const clip = {
                     <input type="checkbox" ng-model="effect.showInOverlay">
                     <div class="control__indicator"></div>
                 </label>
+            </div>
+
+            <div style="padding-top:15px">
+                <label class="control-fb control--checkbox"> Put clip URL in a variable <tooltip text="'Put the clip URL into a variable so you can use it later'"></tooltip>
+                    <input type="checkbox" ng-model="effect.options.putClipUrlInVariable">
+                    <div class="control__indicator"></div>
+                </label>
+                <div ng-if="effect.options.putClipUrlInVariable" style="padding-left: 15px;">
+                    <firebot-input input-title="Variable Name" model="effect.options.variableName" placeholder-text="Enter name" />
+                    <firebot-input style="margin-top: 10px;" input-title="Variable TTL" model="effect.options.variableTtl" input-type="number" disable-variables="true" placeholder-text="Enter secs | Optional" />
+                    <firebot-input style="margin-top: 10px;" input-title="Variable Property Path" model="effect.options.variablePropertyPath" input-type="text" disable-variables="true" placeholder-text="Optional" />
+                </div>
             </div>
 
             <!--<div style="padding-top:20px">
@@ -101,6 +114,10 @@ const clip = {
             }
         };
 
+        if ($scope.effect.options == null) {
+            $scope.effect.options = { };
+        }
+
         // Calculate 16:9
         // This checks to see which field the user is filling out, and then adjust the other field so it's always 16:9.
         $scope.calculateSize = function(widthOrHeight, size) {
@@ -147,6 +164,9 @@ const clip = {
         if (effect.postInDiscord && effect.discordChannelId == null) {
             errors.push("Please select Discord channel.");
         }
+        if (effect.options.putClipUrlInVariable && !(effect.options.variableName?.length > 0)) {
+            errors.push("Please enter a variable name.");
+        }
         return errors;
     },
     onTriggerEvent: async event => {
@@ -192,6 +212,9 @@ const clip = {
                 });
             }
 
+            if (effect.options.putClipUrlInVariable) {
+                customVariableManager.addCustomVariable(effect.options.variableName, clip.url, effect.options.variableTtl, effect.options.variablePropertyPath);
+            }
 
             await utils.wait(clipDuration * 1000);
         }

--- a/backend/effects/builtin/clips.js
+++ b/backend/effects/builtin/clips.js
@@ -213,7 +213,12 @@ const clip = {
             }
 
             if (effect.options.putClipUrlInVariable) {
-                customVariableManager.addCustomVariable(effect.options.variableName, clip.url, effect.options.variableTtl, effect.options.variablePropertyPath);
+                customVariableManager.addCustomVariable(
+                    effect.options.variableName,
+                    clip.url,
+                    effect.options.variableTtl || 0,
+                    effect.options.variablePropertyPath || null
+                );
             }
 
             await utils.wait(clipDuration * 1000);


### PR DESCRIPTION
### Description of the Change
Adds an option to the **Create Clip** effect to save the clip URL to a custom variable for use in later effects. Validates that a variable name is entered if the option to save the URL is selected.


### Applicable Issues
#1667


### Testing
Created a clip via effect, verified data value and timeout.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/162103329-16c08aa6-bc87-4153-ab38-c4fbee2ec324.png)
