### PR TITLE
Only send HTTP body on POST, PUT, or PATCH

### DIFF
--- a/backend/effects/builtin/http-request.js
+++ b/backend/effects/builtin/http-request.js
@@ -241,12 +241,16 @@ const effect = {
             }
         }
 
+        const sendBodyData = effect.method.toLowerCase() === "post" ||
+            effect.method.toLowerCase() === "put" ||
+            effect.method.toLowerCase() === "patch";
+
         try {
             const response = await axios({
                 method: effect.method.toLowerCase(),
                 url: effect.url,
                 headers,
-                data: bodyData
+                data: sendBodyData === true ? bodyData : null
             });
 
             if (effect.options.putResponseInVariable) {


### PR DESCRIPTION
### Description of the Change
Changes the HTTP Request effect to only send body data on POST, PUT, or PATCH requests.


### Applicable Issues
#1664


### Testing
Verified that POSTs send body and GETs no longer do.


### Screenshots
N/A