### PR TITLE
feat(variables/#1680): add ability to delete variables via inspector

### DIFF
--- a/backend/app-management/electron/window-management.js
+++ b/backend/app-management/electron/window-management.js
@@ -443,9 +443,20 @@ function sendVariableExpireToInspector(key, value) {
     });
 }
 
+function sendVariableDeleteToInspector(key) {
+    if (variableInspectorWindow == null || variableInspectorWindow.isDestroyed()) {
+        return;
+    }
+
+    variableInspectorWindow.webContents.send("variable-deleted", {
+        key
+    });
+}
+
 exports.createVariableInspectorWindow = createVariableInspectorWindow;
 exports.sendVariableCreateToInspector = sendVariableCreateToInspector;
 exports.sendVariableExpireToInspector = sendVariableExpireToInspector;
+exports.sendVariableDeleteToInspector = sendVariableDeleteToInspector;
 exports.createStreamPreviewWindow = createStreamPreviewWindow;
 exports.createMainWindow = createMainWindow;
 exports.createSplashScreen = createSplashScreen;

--- a/backend/common/custom-variable-manager.js
+++ b/backend/common/custom-variable-manager.js
@@ -183,7 +183,7 @@ function deleteCustomVariable(name) {
     } catch (error) {
         logger.debug(`Error deleting custom variable ${name}: ${error}`);
     }
-};
+}
 
 ipcMain.on("customVariableDelete", (_, key) => {
     deleteCustomVariable(key);

--- a/backend/common/custom-variable-manager.js
+++ b/backend/common/custom-variable-manager.js
@@ -3,6 +3,7 @@
 const logger = require('../logwrapper');
 const eventManager = require("../events/EventManager");
 const windowManagement = require("../app-management/electron/window-management");
+const { ipcMain } = require("electron");
 
 const NodeCache = require("node-cache");
 
@@ -19,6 +20,10 @@ const onCustomVariableExpire = (key, value) => {
     windowManagement.sendVariableExpireToInspector(key, value);
 };
 
+const onCustomVariableDelete = (key) => {
+    windowManagement.sendVariableDeleteToInspector(key);
+};
+
 cache.on("expired", onCustomVariableExpire);
 
 cache.on("set", function(key, value) {
@@ -30,6 +35,8 @@ cache.on("set", function(key, value) {
 
     windowManagement.sendVariableCreateToInspector(key, value, cache.getTtl(key));
 });
+
+cache.on("del", onCustomVariableDelete);
 
 function getVariableCacheDb() {
     const profileManager = require("../common/profile-manager");
@@ -161,3 +168,25 @@ exports.getCustomVariable = (name, propertyPath, defaultData = null) => {
         return defaultData;
     }
 };
+
+function deleteCustomVariable(name) {
+    const data = cache.get(name);
+
+    if (data == null) {
+        logger.debug(`Cannot delete custom variable ${name}: Variable does not exist.`);
+    }
+
+    try {
+        cache.del(name);
+        
+        logger.debug(`Custom variable ${name} deleted`);
+    } catch (error) {
+        logger.debug(`Error deleting custom variable ${name}: ${error}`);
+    }
+};
+
+ipcMain.on("customVariableDelete", (_, key) => {
+    deleteCustomVariable(key);
+});
+
+exports.deleteCustomVariable = deleteCustomVariable;

--- a/gui/variable-inspector/index.html
+++ b/gui/variable-inspector/index.html
@@ -374,6 +374,10 @@
           toggleExpanded() {
             this.expanded = !this.expanded;
           },
+          deleteVariable() {
+            console.log("DELETING VARIABLE", this.variable.key);
+            window.ipcRenderer.deleteVariable(this.variable.key);
+          },
         },
         computed: {
           history() {
@@ -388,6 +392,7 @@
                         <div class="var-cell" :class="{ 'var-row-collapsed': !expanded }">{{variable.history[0].value}}</div>
                         <div class="var-cell"><expire-display :ttl="variable.history[0].ttl" :action="variable.history[0].action" /></div>
                         <div class="var-cell">{{variable.history[0].action}}</div>
+                        <div class="var-cell"><button @click="deleteVariable">Delete</a></div>
                         <div style="width: 15px;">
                             <caret-icon :direction="expanded ? 'down' : 'right'" />
                         </div>
@@ -500,6 +505,16 @@
               },
             ],
           });
+        }
+      });
+
+      window.ipcRenderer.on("variable-deleted", ({ key }) => {
+        console.log("VAR DELETE");
+        console.log(key);
+        const foundVar = app.variables.find(variable => variable.key === key);
+
+        if (foundVar) {
+          app.variables.splice(app.variables.indexOf(foundVar), 1);
         }
       });
     </script>

--- a/gui/variable-inspector/index.html
+++ b/gui/variable-inspector/index.html
@@ -16,6 +16,7 @@
         background: #43454b;
         color: white;
         padding: 10px;
+        cursor: pointer;
       }
       .var-table .var:nth-child(even) {
         background: #3e4046;
@@ -31,8 +32,8 @@
         overflow: hidden;
       }
       .caret {
-        width: 24px;
-        height: 24px;
+        width: 15px;
+        height: 15px;
         color: white;
       }
       .search-field {
@@ -207,6 +208,7 @@
         font-size: 14px;
         font-weight: 400;
         cursor: pointer;
+        margin-left: 10px;
       }
         .delete-button:hover {
           background-color: #c9302c;
@@ -302,8 +304,7 @@
         <div style="flex: 1">Value</div>
         <div style="flex: 1">Expires</div>
         <div style="flex: 1">Action</div>
-        <div style="flex: 1">Manage</div>
-        <div style="width: 24px"></div>
+        <div style="width: 15px"></div>
       </div>
       <div class="var-table">
         <variable-row
@@ -408,14 +409,13 @@
           },
         },
         template: `
-                <div class="var">
+                <div class="var" @click="toggleExpanded()">
                     <div class="header" style="display:flex; color: white;">
                         <div class="var-cell">{{variable.key}}</div>
                         <div class="var-cell" :class="{ 'var-row-collapsed': !expanded }">{{variable.history[0].value}}</div>
                         <div class="var-cell"><expire-display :ttl="variable.history[0].ttl" :action="variable.history[0].action" /></div>
                         <div class="var-cell">{{variable.history[0].action}}</div>
-                        <div class="var-cell"><button class="delete-button" @click="deleteVariable"><i class="fad fa-trash-alt"></i></a></div>
-                        <div style="width: 24px; cursor: pointer;" @click="toggleExpanded()">
+                        <div style="width: 15px;">
                             <caret-icon :direction="expanded ? 'down' : 'right'" />
                         </div>
                     </div>
@@ -424,14 +424,14 @@
                             <div style="height: 1px; background: #807676; flex: 1;"></div>
                             <div style="margin: 0 13px; font-size: 12px; color: #909090;">History</div>
                             <div style="height: 1px; background: #807676; flex: 1;"></div>
+                            <button class="delete-button" @click.stop="deleteVariable" title="Delete Variable"><i class="fad fa-trash-alt"></i></a>
                         </div>
                         <div v-for="h in history" style="display:flex; color: white;">
                             <div class="var-cell"></div>
                             <div class="var-cell">{{h.value}}</div>
                             <div class="var-cell"></div>
                             <div class="var-cell">{{h.action}}</div>
-                            <div class="var-cell"></div>
-                            <div style="width: 24px;"></div>
+                            <div style="width: 15px;"></div>
                         </div>
                         <div v-if="history.length < 1" style="opacity: 0.75;">No changes captured yet.</div>
                     </div>

--- a/gui/variable-inspector/index.html
+++ b/gui/variable-inspector/index.html
@@ -16,7 +16,6 @@
         background: #43454b;
         color: white;
         padding: 10px;
-        cursor: pointer;
       }
       .var-table .var:nth-child(even) {
         background: #3e4046;
@@ -32,8 +31,8 @@
         overflow: hidden;
       }
       .caret {
-        width: 15px;
-        height: 15px;
+        width: 24px;
+        height: 24px;
         color: white;
       }
       .search-field {
@@ -198,10 +197,32 @@
           transform: scale(1);
         }
       }
+
+      .delete-button {
+        padding: 7px 12px;
+        background-color: #d9534f;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        color: white;
+        font-size: 14px;
+        font-weight: 400;
+        cursor: pointer;
+      }
+        .delete-button:hover {
+          background-color: #c9302c;
+          border-color: transparent;
+        }
     </style>
   </head>
 
   <body>
+    <script>
+      // Load the FontAwesome assets
+      console.log(window.ipcRenderer.fontAwesome5KitUrl);
+      let myScript = document.createElement("script");
+      myScript.setAttribute("src", window.ipcRenderer.fontAwesome5KitUrl);
+      document.body.appendChild(myScript);
+    </script>
     <div id="app" style="font-family: sans-serif">
       <div
         style="
@@ -281,7 +302,8 @@
         <div style="flex: 1">Value</div>
         <div style="flex: 1">Expires</div>
         <div style="flex: 1">Action</div>
-        <div style="width: 15px"></div>
+        <div style="flex: 1">Manage</div>
+        <div style="width: 24px"></div>
       </div>
       <div class="var-table">
         <variable-row
@@ -386,14 +408,14 @@
           },
         },
         template: `
-                <div class="var" @click="toggleExpanded()">
+                <div class="var">
                     <div class="header" style="display:flex; color: white;">
                         <div class="var-cell">{{variable.key}}</div>
                         <div class="var-cell" :class="{ 'var-row-collapsed': !expanded }">{{variable.history[0].value}}</div>
                         <div class="var-cell"><expire-display :ttl="variable.history[0].ttl" :action="variable.history[0].action" /></div>
                         <div class="var-cell">{{variable.history[0].action}}</div>
-                        <div class="var-cell"><button @click="deleteVariable">Delete</a></div>
-                        <div style="width: 15px;">
+                        <div class="var-cell"><button class="delete-button" @click="deleteVariable"><i class="fad fa-trash-alt"></i></a></div>
+                        <div style="width: 24px; cursor: pointer;" @click="toggleExpanded()">
                             <caret-icon :direction="expanded ? 'down' : 'right'" />
                         </div>
                     </div>
@@ -408,7 +430,8 @@
                             <div class="var-cell">{{h.value}}</div>
                             <div class="var-cell"></div>
                             <div class="var-cell">{{h.action}}</div>
-                            <div style="width: 15px;"></div>
+                            <div class="var-cell"></div>
+                            <div style="width: 24px;"></div>
                         </div>
                         <div v-if="history.length < 1" style="opacity: 0.75;">No changes captured yet.</div>
                     </div>
@@ -509,8 +532,7 @@
       });
 
       window.ipcRenderer.on("variable-deleted", ({ key }) => {
-        console.log("VAR DELETE");
-        console.log(key);
+        console.log("VAR DELETE", key);
         const foundVar = app.variables.find(variable => variable.key === key);
 
         if (foundVar) {

--- a/gui/variable-inspector/index.html
+++ b/gui/variable-inspector/index.html
@@ -341,7 +341,7 @@
         },
         methods: {
           toggleExpanded() {
-            this.expanded = !this.expanded;
+            this.variable.expanded = !this.variable.expanded;
           },
           updateSecondsDisplay() {
             if (this.secondsLeft < 1) {
@@ -388,14 +388,9 @@
 
       Vue.component("variable-row", {
         props: ["variable"],
-        data: function () {
-          return {
-            expanded: false,
-          };
-        },
         methods: {
           toggleExpanded() {
-            this.expanded = !this.expanded;
+            this.variable.expanded = !this.variable.expanded;
           },
           deleteVariable() {
             console.log("DELETING VARIABLE", this.variable.key);
@@ -412,14 +407,14 @@
                 <div class="var" @click="toggleExpanded()">
                     <div class="header" style="display:flex; color: white;">
                         <div class="var-cell">{{variable.key}}</div>
-                        <div class="var-cell" :class="{ 'var-row-collapsed': !expanded }">{{variable.history[0].value}}</div>
+                        <div class="var-cell" :class="{ 'var-row-collapsed': !variable.expanded }">{{variable.history[0].value}}</div>
                         <div class="var-cell"><expire-display :ttl="variable.history[0].ttl" :action="variable.history[0].action" /></div>
                         <div class="var-cell">{{variable.history[0].action}}</div>
                         <div style="width: 15px;">
-                            <caret-icon :direction="expanded ? 'down' : 'right'" />
+                            <caret-icon :direction="variable.expanded ? 'down' : 'right'" />
                         </div>
                     </div>
-                    <div v-if="expanded">
+                    <div v-if="variable.expanded">
                         <div style="display: flex; padding: 10px 10px;align-items: center;">
                             <div style="height: 1px; background: #807676; flex: 1;"></div>
                             <div style="margin: 0 13px; font-size: 12px; color: #909090;">History</div>
@@ -478,6 +473,7 @@
               action: "set",
             },
           ],
+          expanded: false
         }));
       });
 
@@ -502,6 +498,7 @@
                 action: "set",
               },
             ],
+            expanded: false
           });
         }
       });

--- a/gui/variable-inspector/preload.js
+++ b/gui/variable-inspector/preload.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { contextBridge, ipcRenderer } = require('electron');
+const secrets = require("../../secrets.json");
 
 contextBridge.exposeInMainWorld('ipcRenderer', {
     on: (channel, listener) => {
@@ -8,6 +9,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
             listener(data);
         });
     },
+    fontAwesome5KitUrl: `https://kit.fontawesome.com/${secrets.fontAwesome5KitId}.js`,
     deleteVariable: (key) => {
         ipcRenderer.send("customVariableDelete", key);
     }

--- a/gui/variable-inspector/preload.js
+++ b/gui/variable-inspector/preload.js
@@ -7,5 +7,8 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
         ipcRenderer.on(channel, (_, data) => {
             listener(data);
         });
+    },
+    deleteVariable: (key) => {
+        ipcRenderer.send("customVariableDelete", key);
     }
 });


### PR DESCRIPTION
### Description of the Change
Adds a delete button to permanently remove (i.e. not just expire) a custom variable in the custom variable inspector.


### Applicable Issues
#1680


### Testing
Created several custom variables, deleted them, closed and reopened inspector window to ensure variables had been deleted and that other variables were intact.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/163290727-db4d9387-c554-45d2-84f7-1de1c1f8ac7c.png)