### PR TITLE
feat: Add URL moderation allowlist

### DIFF
--- a/backend/utility.js
+++ b/backend/utility.js
@@ -17,7 +17,7 @@ const escapeRegExp = (str) => {
 };
 
 const getUrlRegex = () => {
-    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/])/i;
+    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/]|\w?)/gi;
 };
 
 /**

--- a/gui/app/controllers/moderation.controller.js
+++ b/gui/app/controllers/moderation.controller.js
@@ -28,5 +28,13 @@
                     resolveObj: {}
                 });
             };
+
+            $scope.showEditUrlAllowlistModal = () => {
+                utilityService.showModal({
+                    component: "editUrlAllowlistModal",
+                    backdrop: true,
+                    resolveObj: {}
+                });
+            };
         });
 }());

--- a/gui/app/directives/modals/misc/editUrlAllowlistModal.js
+++ b/gui/app/directives/modals/misc/editUrlAllowlistModal.js
@@ -1,0 +1,180 @@
+"use strict";
+
+(function() {
+
+    const fs = require("fs");
+
+    angular.module("firebotApp")
+        .component("editUrlAllowlistModal", {
+            template: `
+            <div class="modal-header">
+                <button type="button" class="close" ng-click="$ctrl.dismiss()"><span>&times;</span></button>
+                <h4 class="modal-title">Edit URL Allowlist</h4>
+            </div>
+            <div class="modal-body">
+                <p class="muted" style="margin-bottom:10px;">URLs found in messages containing any words or phrases listed here will be automatically allowed.</p>
+                <p class="muted" style="margin-bottom:20px;">NOTE: If multiple URLs are found in a message and ANY of them are not allowed, the entire message will be deleted.</p>
+                <div style="margin: 0 0 25px;display: flex;flex-direction: row;">
+
+                    <div class="dropdown">
+                        <button class="btn btn-primary dropdown-toggle" type="button" id="add-options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                            <span class="dropdown-text"><i class="fas fa-plus-circle"></i> Add Word(s)</span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="add-options">
+                            <li role="menuitem" ng-click="$ctrl.addWord()"><a href style="padding-left: 10px;"><i class="fad fa-plus-circle" style="margin-right: 5px;"></i> Add single word</a></li>
+                            <li role="menuitem" ng-click="$ctrl.showImportModal()"><a href style="padding-left: 10px;"><i class="fad fa-file-import" style="margin-right: 5px;"></i> Import from .txt file <tooltip text="'Import a list of words/phrases from a txt file'"></tooltip></a></li>
+                        </ul>
+                    </div>
+
+                    <div style="display: flex;flex-direction: row;justify-content: space-between;margin-left: auto;">
+                        <searchbar placeholder-text="Search words..." query="$ctrl.search" style="flex-basis: 250px;"></searchbar>
+                    </div>
+                </div>
+                <div>
+                    <sortable-table
+                        table-data-set="$ctrl.cms.chatModerationData.urlAllowlist"
+                        headers="$ctrl.wordHeaders"
+                        query="$ctrl.search"
+                        clickable="false"
+                        starting-sort-field="createdAt"
+                        sort-initially-reversed="true"
+                        page-size="5"
+                        no-data-message="No allowed URLs have been saved.">
+                    </sortable-table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button ng-show="$ctrl.cms.chatModerationData.urlAllowlist.length > 0" type="button" class="btn btn-danger pull-left" ng-click="$ctrl.deleteAllWords()">Delete All Allowed URLs</button>
+            </div>
+            `,
+            bindings: {
+                resolve: "<",
+                close: "&",
+                dismiss: "&"
+            },
+            controller: function(chatModerationService, utilityService, logger) {
+                let $ctrl = this;
+
+                $ctrl.search = "";
+
+                $ctrl.cms = chatModerationService;
+
+                $ctrl.$onInit = function() {
+                // When the compontent is initialized
+                // This is where you can start to access bindings, such as variables stored in 'resolve'
+                // IE $ctrl.resolve.shouldDelete or whatever
+                };
+
+                $ctrl.wordHeaders = [
+                    {
+                        name: "TEXT",
+                        icon: "fa-quote-right",
+                        dataField: "text",
+                        headerStyles: {
+                            'width': '375px'
+                        },
+                        sortable: true,
+                        cellTemplate: `{{data.text}}`,
+                        cellController: () => {}
+                    },
+                    {
+                        name: "CREATED AT",
+                        icon: "fa-calendar",
+                        dataField: "createdAt",
+                        sortable: true,
+                        cellTemplate: `{{data.createdAt | prettyDate}}`,
+                        cellController: () => {}
+                    },
+                    {
+                        headerStyles: {
+                            'width': '15px'
+                        },
+                        cellStyles: {
+                            'width': '15px'
+                        },
+                        sortable: false,
+                        cellTemplate: `<i class="fal fa-trash-alt clickable" style="color:#ff3737;" ng-click="clicked()" uib-tooltip="Delete" tooltip-append-to-body="true"></i>`,
+                        cellController: ($scope, chatModerationService) => {
+                            $scope.clicked = () => {
+                                chatModerationService.removeAllowedUrlByText($scope.data.text);
+                            };
+                        }
+                    }
+                ];
+
+                $ctrl.addWord = () => {
+                    utilityService.openGetInputModal(
+                        {
+                            model: "",
+                            label: "Add allowed URL",
+                            saveText: "Add",
+                            inputPlaceholder: "Enter allowed URL",
+                            validationFn: (value) => {
+                                return new Promise(resolve => {
+                                    if (value == null || value.trim().length < 1 || value.trim().length > 359) {
+                                        resolve(false);
+                                    } else if (chatModerationService.chatModerationData.urlAllowlist
+                                        .some(u => u.text === value.toLowerCase())) {
+                                        resolve(false);
+                                    } else {
+                                        resolve(true);
+                                    }
+                                });
+                            },
+                            validationText: "Allowed URL can't be empty and can't already exist."
+
+                        },
+                        (newWord) => {
+                            chatModerationService.addAllowedUrls([newWord.trim()]);
+                        });
+                };
+
+                $ctrl.showImportModal = () => {
+                    utilityService.showModal({
+                        component: "txtFileWordImportModal",
+                        size: 'sm',
+                        resolveObj: {},
+                        closeCallback: data => {
+                            let filePath = data.filePath,
+                                delimiter = data.delimiter;
+
+                            let contents;
+                            try {
+                                contents = fs.readFileSync(filePath, "utf8");
+                            } catch (err) {
+                                logger.error("error reading file for allowed URLs", err);
+                                return;
+                            }
+
+                            let words = [];
+                            if (delimiter === 'newline') {
+                                words = contents.replace(/\r\n/g, "\n").split("\n");
+                            } else if (delimiter === "comma") {
+                                words = contents.split(",");
+                            } else if (delimiter === "space") {
+                                words = contents.split(" ");
+                            }
+
+                            if (words != null) {
+                                chatModerationService.addAllowedUrls(words);
+                            }
+                        }
+                    });
+                };
+
+                $ctrl.deleteAllWords = function() {
+                    utilityService.showConfirmationModal({
+                        title: "Delete All Allowed URLs",
+                        question: `Are you sure you want to delete all allowed URLs?`,
+                        confirmLabel: "Delete",
+                        confirmBtnType: "btn-danger"
+                    }).then(confirmed => {
+                        if (confirmed) {
+                            chatModerationService.removeAllAllowedUrls();
+                        }
+                    });
+                };
+            }
+        });
+}());

--- a/gui/app/directives/modals/misc/editUrlAllowlistModal.js
+++ b/gui/app/directives/modals/misc/editUrlAllowlistModal.js
@@ -12,29 +12,29 @@
                 <h4 class="modal-title">Edit URL Allowlist</h4>
             </div>
             <div class="modal-body">
-                <p class="muted" style="margin-bottom:10px;">URLs found in messages containing any words or phrases listed here will be automatically allowed.</p>
+                <p class="muted" style="margin-bottom:10px;">URLs found in messages containing any URL parts listed here will be automatically allowed.</p>
                 <p class="muted" style="margin-bottom:20px;">NOTE: If multiple URLs are found in a message and ANY of them are not allowed, the entire message will be deleted.</p>
                 <div style="margin: 0 0 25px;display: flex;flex-direction: row;">
 
                     <div class="dropdown">
                         <button class="btn btn-primary dropdown-toggle" type="button" id="add-options" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                            <span class="dropdown-text"><i class="fas fa-plus-circle"></i> Add Word(s)</span>
+                            <span class="dropdown-text"><i class="fas fa-plus-circle"></i> Add URL(s)</span>
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="add-options">
-                            <li role="menuitem" ng-click="$ctrl.addWord()"><a href style="padding-left: 10px;"><i class="fad fa-plus-circle" style="margin-right: 5px;"></i> Add single word</a></li>
-                            <li role="menuitem" ng-click="$ctrl.showImportModal()"><a href style="padding-left: 10px;"><i class="fad fa-file-import" style="margin-right: 5px;"></i> Import from .txt file <tooltip text="'Import a list of words/phrases from a txt file'"></tooltip></a></li>
+                            <li role="menuitem" ng-click="$ctrl.addUrl()"><a href style="padding-left: 10px;"><i class="fad fa-plus-circle" style="margin-right: 5px;"></i> Add single URL</a></li>
+                            <li role="menuitem" ng-click="$ctrl.showImportModal()"><a href style="padding-left: 10px;"><i class="fad fa-file-import" style="margin-right: 5px;"></i> Import from .txt file <tooltip text="'Import a list of URLs from a txt file'"></tooltip></a></li>
                         </ul>
                     </div>
 
                     <div style="display: flex;flex-direction: row;justify-content: space-between;margin-left: auto;">
-                        <searchbar placeholder-text="Search words..." query="$ctrl.search" style="flex-basis: 250px;"></searchbar>
+                        <searchbar placeholder-text="Search URLs..." query="$ctrl.search" style="flex-basis: 250px;"></searchbar>
                     </div>
                 </div>
                 <div>
                     <sortable-table
                         table-data-set="$ctrl.cms.chatModerationData.urlAllowlist"
-                        headers="$ctrl.wordHeaders"
+                        headers="$ctrl.urlHeaders"
                         query="$ctrl.search"
                         clickable="false"
                         starting-sort-field="createdAt"
@@ -45,7 +45,7 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button ng-show="$ctrl.cms.chatModerationData.urlAllowlist.length > 0" type="button" class="btn btn-danger pull-left" ng-click="$ctrl.deleteAllWords()">Delete All Allowed URLs</button>
+                <button ng-show="$ctrl.cms.chatModerationData.urlAllowlist.length > 0" type="button" class="btn btn-danger pull-left" ng-click="$ctrl.deleteAllUrls()">Delete All Allowed URLs</button>
             </div>
             `,
             bindings: {
@@ -66,7 +66,7 @@
                 // IE $ctrl.resolve.shouldDelete or whatever
                 };
 
-                $ctrl.wordHeaders = [
+                $ctrl.urlHeaders = [
                     {
                         name: "TEXT",
                         icon: "fa-quote-right",
@@ -103,7 +103,7 @@
                     }
                 ];
 
-                $ctrl.addWord = () => {
+                $ctrl.addUrl = () => {
                     utilityService.openGetInputModal(
                         {
                             model: "",
@@ -125,8 +125,8 @@
                             validationText: "Allowed URL can't be empty and can't already exist."
 
                         },
-                        (newWord) => {
-                            chatModerationService.addAllowedUrls([newWord.trim()]);
+                        (newUrl) => {
+                            chatModerationService.addAllowedUrls([newUrl.trim()]);
                         });
                 };
 
@@ -147,23 +147,23 @@
                                 return;
                             }
 
-                            let words = [];
+                            let urls = [];
                             if (delimiter === 'newline') {
-                                words = contents.replace(/\r\n/g, "\n").split("\n");
+                                urls = contents.replace(/\r\n/g, "\n").split("\n");
                             } else if (delimiter === "comma") {
-                                words = contents.split(",");
+                                urls = contents.split(",");
                             } else if (delimiter === "space") {
-                                words = contents.split(" ");
+                                urls = contents.split(" ");
                             }
 
-                            if (words != null) {
-                                chatModerationService.addAllowedUrls(words);
+                            if (urls != null) {
+                                chatModerationService.addAllowedUrls(urls);
                             }
                         }
                     });
                 };
 
-                $ctrl.deleteAllWords = function() {
+                $ctrl.deleteAllUrls = function() {
                     utilityService.showConfirmationModal({
                         title: "Delete All Allowed URLs",
                         question: `Are you sure you want to delete all allowed URLs?`,

--- a/gui/app/directives/modals/misc/txtFileWordImportModal.js
+++ b/gui/app/directives/modals/misc/txtFileWordImportModal.js
@@ -8,7 +8,7 @@
             template: `
             <div class="modal-header">
                 <button type="button" class="close" ng-click="$ctrl.dismiss()"><span>&times;</span></button>
-                <h4 class="modal-title">Import Words From TXT</h4>
+                <h4 class="modal-title">Import Items From TXT</h4>
             </div>
             <div class="modal-body">
 
@@ -21,7 +21,7 @@
 
                 <div style="margin-top: 15px;">
                     <div class="modal-subheader" style="padding: 0 0 4px 0">
-                        Seperator <tooltip text="'Tell Firebot how the words/phrases in the txt file are seperated'"></tooltip>
+                        Seperator <tooltip text="'Tell Firebot how the items in the txt file are seperated'"></tooltip>
                     </div>
                     <div class="dropdown">
                         <button class="btn btn-default dropdown-toggle" type="button" id="options-sounds" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/gui/app/index.html
+++ b/gui/app/index.html
@@ -284,6 +284,7 @@
     <script type="text/javascript" src="./directives/modals/misc/edit-overlay-instances-modal.js"></script>
     <script type="text/javascript" src="./directives/modals/misc/edit-stream-info-modal.js"></script>
     <script type="text/javascript" src="./directives/modals/misc/editBannedWordsModal.js"></script>
+    <script type="text/javascript" src="./directives/modals/misc/editUrlAllowlistModal.js"></script>
     <script type="text/javascript" src="./directives/modals/misc/errorDetailModal.js"></script>
     <script type="text/javascript" src="./directives/modals/misc/fontManagementModal.js"></script>
     <script type="text/javascript" src="./directives/modals/misc/give-currency-modal.js"></script>

--- a/gui/app/services/chat-moderation.service.js
+++ b/gui/app/services/chat-moderation.service.js
@@ -34,7 +34,8 @@
                     exemptRoles: []
                 },
                 bannedWords: [],
-                bannedRegularExpressions: []
+                bannedRegularExpressions: [],
+                urlAllowlist: []
             };
 
             service.loadChatModerationData = () => {
@@ -71,6 +72,10 @@
 
                     if (service.chatModerationData.settings.urlModeration.exemptRoles == null) {
                         service.chatModerationData.settings.urlModeration.exemptRoles = [];
+                    }
+
+                    if (service.chatModerationData.urlAllowlist == null) {
+                        service.chatModerationData.urlAllowlist = [];
                     }
                 }
             };
@@ -148,6 +153,44 @@
             service.removeAllBannedRegularExpressions = () => {
                 service.chatModerationData.bannedRegularExpressions = [];
                 backendCommunicator.fireEvent("removeAllBannedRegularExpressions");
+            };
+
+            service.addAllowedUrls = (urls) => {
+                let normalizedUrls = urls
+                    .filter(u => u != null && u.trim().length > 0 && u.trim().length < 360)
+                    .map(u => u.trim().toLowerCase());
+
+                let mapped = [...new Set(normalizedUrls)].map(u => {
+                    return {
+                        text: u,
+                        createdAt: moment().valueOf()
+                    };
+                });
+
+                service.chatModerationData.urlAllowlist =
+                    service.chatModerationData.urlAllowlist.concat(mapped);
+
+                backendCommunicator.fireEvent("addAllowedUrls", mapped);
+            };
+
+            service.removeAllowedUrlAtIndex = (index) => {
+                let word = service.chatModerationData.urlAllowlist[index];
+                if (word) {
+                    backendCommunicator.fireEvent("removeAllowedUrl", word.text);
+                    service.chatModerationData.urlAllowlist.splice(index, 1);
+                }
+            };
+
+            service.removeAllowedUrlByText = (text) => {
+                let index = service.chatModerationData.urlAllowlist.findIndex(u => u.text === text);
+                if (index > -1) {
+                    service.removeAllowedUrlAtIndex(index);
+                }
+            };
+
+            service.removeAllAllowedUrls = () => {
+                service.chatModerationData.urlAllowlist = [];
+                backendCommunicator.fireEvent("removeAllAllowedUrls");
             };
 
             service.registerPermitCommand = () => {

--- a/gui/app/templates/_moderation.html
+++ b/gui/app/templates/_moderation.html
@@ -107,7 +107,7 @@
       <div class="content-block moderation-feature-block">
         <div class="content-block-body">
           <div class="title-toggle-button-container">
-            <div class="font-semibold text-3xl" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">Url Moderation</div>
+            <div class="font-semibold text-3xl" ng-class="{ muted: !cms.chatModerationData.settings.urlModeration.enabled }">URL Moderation</div>
             <div class="toggle-button-container">
               <toggle-button
                 toggle-model="cms.chatModerationData.settings.urlModeration.enabled"
@@ -120,10 +120,13 @@
             A !permit command is automatically added to System Commands.
           </div>
           <div style="display: block;width: 100%;" class="my-8" ng-show="cms.chatModerationData.settings.urlModeration.enabled">
-            <div class="mb-4 text-2xl font-semibold">
-              Exempt Roles <tooltip text="'These roles are exempt from the url moderation.'" />
+            <div class="my-8">
+              <div class="mb-4 text-2xl font-semibold">
+                Exempt Roles <tooltip text="'These roles are exempt from the url moderation.'" />
+              </div>
+              <exempt-roles model="cms.chatModerationData.settings.urlModeration.exemptRoles" on-update="cms.saveChatModerationSettings()"></exempt-roles>
             </div>
-            <exempt-roles model="cms.chatModerationData.settings.urlModeration.exemptRoles" on-update="cms.saveChatModerationSettings()"></exempt-roles>
+            <button ng-click="showEditUrlAllowlistModal()" class="btn btn-default">Edit URL Allowlist</button>
           </div>
           <div
             class="title-toggle-button-container my-8"


### PR DESCRIPTION
### Description of the Change
Adds an allowlist feature to URL moderation to automatically permit links that match allowlist rules. Also updated URL regex to match URLs that don't have trailing `/` after domain name (e.g. `https://firebot.app` vs `https://firebot.app/`).


### Applicable Issues
#1564


### Testing
- Added terms to the URL allowlist one at a time
- Imported terms en masse to the URL allowlist from a text file
- Deleted individual terms from the URL allowlist 
- Deleted entire URL allowlist at once
- Verified URL allowlist DB file saves
- Verified URL allowlist reloads when reopening Firebot
- Tested moderation with alternate account
  - Message with single URL that matched a rule allowed
  - Message with single URL that did NOT match a rule deleted
  - Message with multiple URLs that all matched rules allowed
  - Message with multiple URLs where at least one URL did NOT match a rule deleted


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/163436783-9ab501a4-8937-4d6f-815f-f3388370328e.png)
![image](https://user-images.githubusercontent.com/1764877/163436832-f0890e74-6010-47c4-8acb-e1254268a226.png)
