### PR TITLE
fix: Issues with topMetaData

### DIFF
--- a/backend/variables/builtin/top-metadata.js
+++ b/backend/variables/builtin/top-metadata.js
@@ -32,10 +32,24 @@ const model = {
 
         let topMetadataUsers = await userDatabase.getTopMetadata(metadataKey, count);
 
-        let topUsersDisplay = topMetadataUsers.map((u, i) => {
-            return `#${i + 1}) ${u.displayName} - ${util.commafy(u.metadata[metadataKey])}`;
-        }).join(", ");
+        let topUsersDisplay = topMetadataUsers
+            // filter out any results not containing key in metadata
+            .filter(user => (user.metadata && user.metadata[metadataKey] != null))
 
+            // map each entry to #position) name - amount
+            .map((user, idx) => {
+                return `#${idx + 1}) ${user.displayName} - ${util.commafy(user.metadata[metadataKey])}`;
+            })
+
+            // convert to commafied string
+            .join(', ');
+
+        // no one in list: output none
+        if (topUsersDisplay === '') {
+            return '(none)';
+        }
+
+        // return list
         return topUsersDisplay;
     }
 };


### PR DESCRIPTION
### Description of the Change
With assistance of SReject changed the way the query is done so that it filters out any results not containing the key in metadata before it returns the data to the variable-replace function.

### Applicable Issues
Refs: #1686

### Testing
Created a command with `$topMetadata[lurk, 5]` which only returns the 4 records in the database.
Changed the variable to check for a metadata key not in the database and now it returns `(none)` instead of the variable itself.


### Screenshots
![image](https://user-images.githubusercontent.com/4147439/163549641-589e0e9f-9558-452b-905e-b2821d8594e3.png)