### PR TITLE
Feat: Added a remove user metadata effect

### DIFF
--- a/backend/database/userDatabase.js
+++ b/backend/database/userDatabase.js
@@ -157,11 +157,12 @@ async function updateUserMetadata(username, key, value, propertyPath) {
     }
 }
 
-frontendCommunicator.onAsync("update-user-metadata", async ({ username, key, value }) => {
-    updateUserMetadata(username, key, value);
-});
+async function removeUserMetadata(username, key) {
 
-frontendCommunicator.onAsync("delete-user-metadata", async ({ username, key }) => {
+    if (username == null || username.length < 1 || key == null || key.length < 1) {
+        return;
+    }
+
     const user = await getTwitchUserByUsername(username);
     if (user == null) {
         return;
@@ -174,6 +175,14 @@ frontendCommunicator.onAsync("delete-user-metadata", async ({ username, key }) =
     user.metadata = metadata;
 
     await updateUser(user);
+}
+
+frontendCommunicator.onAsync("update-user-metadata", async ({ username, key, value }) => {
+    updateUserMetadata(username, key, value);
+});
+
+frontendCommunicator.onAsync("delete-user-metadata", async ({ username, key }) => {
+    removeUserMetadata(username, key);
 });
 
 async function getUserMetadata(username, key, propertyPath) {
@@ -921,6 +930,7 @@ exports.setChatUsersOnline = setChatUsersOnline;
 exports.getTopViewTimeUsers = getTopViewTimeUsers;
 exports.addNewUserFromChat = addNewUserFromChat;
 exports.getOnlineUsers = getOnlineUsers;
+exports.removeUserMetadata = removeUserMetadata;
 exports.updateUserMetadata = updateUserMetadata;
 exports.getUserMetadata = getUserMetadata;
 exports.getAllUsernames = getAllUsernames;

--- a/backend/effects/builtin-effect-loader.js
+++ b/backend/effects/builtin-effect-loader.js
@@ -38,6 +38,7 @@ exports.loadEffects = () => {
         'play-video', // No migration needed.
         'random-effect',
         'random-reddit-image',
+        'remove-user-metadata',
         'reset-timer',
         'run-command',
         'run-program',

--- a/backend/effects/builtin/remove-user-metadata.js
+++ b/backend/effects/builtin/remove-user-metadata.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { EffectCategory } = require('../../../shared/effect-constants');
+
+const effect = {
+    definition: {
+        id: "firebot:remove-user-metadata",
+        name: "Remove User Metadata",
+        description: "Remove a key from metadata associated to a given user",
+        icon: "fad fa-user-cog",
+        categories: [EffectCategory.ADVANCED, EffectCategory.SCRIPTING],
+        dependencies: []
+    },
+    globalSettings: {},
+    optionsTemplate: `
+        <eos-container header="Username">
+            <input type="text" class="form-control" aria-describedby="basic-addon3" ng-model="effect.username" placeholder="Enter username" replace-variables menu-position="below" />
+        </eos-container>
+
+        <eos-container header="Metadata Key" pad-top="true">
+            <p class="muted">Define which key you want to delete from this users metadata.</p>
+            <input ng-model="effect.key" type="text" class="form-control" id="chat-text-setting" placeholder="Enter key name" replace-variables>
+        </eos-container>
+    `,
+    optionsController: () => {},
+    optionsValidator: effect => {
+        let errors = [];
+        if (effect.username == null || effect.username === "") {
+            errors.push("Please provide a username.");
+        }
+        if (effect.key == null || effect.key === "") {
+            errors.push("Please provide a key name.");
+        }
+        return errors;
+    },
+    onTriggerEvent: async event => {
+        const { effect } = event;
+        const { username, key } = effect;
+
+        const userDb = require("../../database/userDatabase");
+
+        await userDb.removeUserMetadata(username, key);
+
+        return true;
+    }
+};
+
+module.exports = effect;


### PR DESCRIPTION
### Description of the Change
Moved the deleteusermetadata function into its own function so it can be used outisde of the frontendCommunicator, and renamed it to removeUserMetadata.
Made the delete-user-metadata frontend call use the removeUserMetadata function.

Added a new effect for removing user metadata as well as added it to the builtin-effect-loader.


### Applicable Issues
Refs: #1688



### Testing
Added the newly effect to a !unlurk command, which works together with a !lurk command which sets the metadata key lurk for the user running the command, when user types in chat later this triggers !unlurk which then removes the lurk metadata key.

Also tested that the metadata key remove function works from the viewer modal after I rearranged the userDatabase file.

### Screenshots
![Selecting the effect](https://user-images.githubusercontent.com/4147439/163560563-8863ee59-a459-4ebf-83ef-3e7bcced7c7b.png)
![Setting up the effect](https://user-images.githubusercontent.com/4147439/163560382-25623010-41bc-435e-949a-06216eb3dd44.png)
![Viewer modal before issuing commands](https://user-images.githubusercontent.com/4147439/163560471-1822cb11-44dc-441e-b635-ab315e5499a9.png)
![Key has been set via !lurk](https://user-images.githubusercontent.com/4147439/163560779-9461d7cc-1662-4047-a257-9ef583392663.png)
![Key has been removed via !unlurk](https://user-images.githubusercontent.com/4147439/163560928-c59c34bd-2ce1-40c2-b8fa-03331de04ea3.png)
Kind of hard to show that a key got removed, so added a new one while removing the one in question just to show it was gone.