### PR TITLE
Fix: Adjusted z-index for dropdown-menu

### DIFF
--- a/gui/scss/core/_bootstrap-overrides.scss
+++ b/gui/scss/core/_bootstrap-overrides.scss
@@ -265,7 +265,7 @@ textarea.form-control {
     border-radius: 2px;
     border: 2px solid $dropdown-menu-border;
     background-color: $dropdown-menu-bg;
-    z-index: 2080;
+    z-index: 999999999;
 
     &:not(.effect-overflow-menu) {
         min-width: 125px;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixed so the dropdown-menu triggered by the meatball menu don't get covered by sticky-bottom "Reward Limit" line by raising the z-index for dropdown-menu.

### Applicable Issues
Refs: #1571


### Testing
Tested the meatball menu with a limited channel reward list so the limit bar is high up in the UI to force the menu to go lower than the bar in the UI. See screenshots.

### Screenshots
Before change:
![Before](https://user-images.githubusercontent.com/4147439/163568567-8e476bb5-b087-45aa-828d-c2217f86c926.png)
After change:
![image](https://user-images.githubusercontent.com/4147439/163568602-52cfe493-c264-4689-8377-95b38eb662d7.png)



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
