### PR TITLE
fix: elgato light effects have clearer message

### DIFF
--- a/backend/integrations/builtin/elgato/effects/update-key-lights.js
+++ b/backend/integrations/builtin/elgato/effects/update-key-lights.js
@@ -80,7 +80,7 @@ const effect = {
 
         $q.when(backendCommunicator.fireEventAsync("getKeyLights"))
             .then(keyLights => {
-                if (keyLights) {
+                if (keyLights?.length > 0) {
                     $scope.keyLights = keyLights;
 
                     $scope.hasKeylights = true;

--- a/backend/integrations/builtin/elgato/effects/update-light-strips.js
+++ b/backend/integrations/builtin/elgato/effects/update-light-strips.js
@@ -67,7 +67,7 @@ const effect = {
 
         $q.when(backendCommunicator.fireEventAsync("getLightStrips"))
             .then(lightStrips => {
-                if (lightStrips) {
+                if (lightStrips?.length > 0) {
                     $scope.lightStrips = lightStrips;
 
                     $scope.hasLightStrips = true;


### PR DESCRIPTION
### Description of the Change
Updated the Elgato light effects to display the "no lights" message when the array exists but has 0 elements.


### Applicable Issues
N/A


### Testing
Verified that when no lights are found but the integration is working correctly, the "no lights" messages are shown.