### PR TITLE
feat: add $arrayElement variable

### DIFF
--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -10,6 +10,7 @@ exports.loadReplaceVariables = () => {
         'arg-count',
         'arg',
         'array-add',
+        'array-element',
         'array-filter',
         'array-find',
         'array-find-index',

--- a/backend/variables/builtin/array-element.js
+++ b/backend/variables/builtin/array-element.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+const model = {
+    definition: {
+        handle: "arrayElement",
+        usage: "arrayElement[jsonArray, index]",
+        description: "Returns the element at the given index of the input JSON array.",
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT, OutputDataType.NUMBER]
+    },
+    evaluator: (_, jsonArray, index) => {
+        if (jsonArray) {
+            try {
+                let array = JSON.parse(jsonArray);
+                if (Array.isArray(array)) {
+                    return array[index];
+                }
+            } catch (error) {
+                //fail silently
+            }
+        }
+        return null;
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
Adds the `$arrayElement` variable that will return the element at the specified index of a JSON array, given the format `$arrayElement[jsonArray, index]`.


### Applicable Issues
#1627


### Testing
Created a custom variable that was set using the `$arrayElement` variable around a `$splitText` variable and verified that the array element at the specified index was saved as the custom variable value.


### Screenshots
N/A