### PR TITLE
feat: discord image embed

### DIFF
--- a/backend/integrations/builtin/discord/discord-embed-builder.js
+++ b/backend/integrations/builtin/discord/discord-embed-builder.js
@@ -17,6 +17,11 @@ function buildCustomEmbed(customEmbedData) {
             icon_url: customEmbedData.authorIconUrl //eslint-disable-line camelcase
         };
     }
+    if (customEmbedData.imageUrl) {
+        customEmbed.image = {
+            url: customEmbedData.imageUrl //eslint-disable-line camelcase
+        };
+    }
     return customEmbed;
 }
 

--- a/backend/integrations/builtin/discord/send-discord-message-effect.js
+++ b/backend/integrations/builtin/discord/send-discord-message-effect.js
@@ -71,6 +71,10 @@ module.exports = {
                                 <firebot-input input-title="Author Icon URL" model="effect.customEmbed.authorIconUrl"></firebot-input>
                             </div>
 
+                            <div style="margin-top:10px;">
+                                <firebot-input input-title="Image URL" model="effect.customEmbed.imageUrl"></firebot-input>
+                            </div>
+
                         </div>
 
                         <div ng-show="effect.embedType === 'channel'">


### PR DESCRIPTION
### Description of the Change
Adds the option to embed an image to a Rich Embed Discord message effect.

### Applicable Issues
No issue


### Testing
Tested with an image URL assigned to the effect and without.
Both works as intended, with an URL it posts the message with the image attached, without an URL it posts without.

### Screenshots
Discord Embed Settings:
![image](https://user-images.githubusercontent.com/4147439/164910449-ebdcc3fd-741e-4921-83b6-91ffa0037939.png)

Output in Discord:
![image](https://user-images.githubusercontent.com/4147439/164894276-93c4ae5d-1560-483a-bc8c-465ab706690e.png)