### PR TITLE
fix: color select illegible in dark mode #1693

### DIFF
--- a/gui/scss/Light.scss
+++ b/gui/scss/Light.scss
@@ -45,6 +45,8 @@ $sort-tags-bg: #d3d3d3;
 
 $toggle-button-off-bg-color: #757373;
 
+$change-note-palette-title-color: $light-text-color;
+
 // Chat Window
 $chatWhisperColor: #c235ef;
 $chatTextColor: #000000;

--- a/gui/scss/Midnight.scss
+++ b/gui/scss/Midnight.scss
@@ -44,6 +44,8 @@ $sort-tags-bg: #808080;
 
 $toggle-button-off-bg-color: #ffffff;
 
+$change-note-palette-title-color: orange;
+
 // Chat Window
 $chatWhisperColor: #e660f2;
 $chatTextColor: $content-text-color;

--- a/gui/scss/Obsidian.scss
+++ b/gui/scss/Obsidian.scss
@@ -44,6 +44,8 @@ $sort-tags-bg: #808080;
 
 $toggle-button-off-bg-color: #ffffff;
 
+$change-note-palette-title-color: orange;
+
 // Chat Window
 $chatWhisperColor: #e660f2;
 $chatTextColor: $content-text-color;

--- a/gui/scss/core/_global.scss
+++ b/gui/scss/core/_global.scss
@@ -1773,3 +1773,7 @@ column-resizer {
   cursor: col-resize;
   z-index: 10000
 }
+
+.note-palette-title {
+  color: $change-note-palette-title-color;
+}


### PR DESCRIPTION
### Description of the Change
Added a variable for changing the color of the palette title depending on theme selection to make it readable with the darker themes.

### Applicable Issues
#1693 

### Testing
Changed between themes to check that font color changes in the palette and that it is readable.

### Screenshots
Obsidian:
![image](https://user-images.githubusercontent.com/4147439/164909152-30b65136-fc84-44d5-947e-61f2e61de74d.png)
Light: 
![image](https://user-images.githubusercontent.com/4147439/164909173-5e8213fd-5ae7-4bcf-aff9-14f75e2ceb39.png)
Midnight: 
![image](https://user-images.githubusercontent.com/4147439/164909200-8ec2325a-73fc-490d-b1dd-39b38fee3d64.png)