### PR TITLE
feat: customizable last seen text

### DIFF
--- a/backend/effects/builtin/shoutout.js
+++ b/backend/effects/builtin/shoutout.js
@@ -136,7 +136,7 @@ const effect = {
                             <div class="firebot-shoutout-game-dimmer" />
                             <div class="firebot-shoutout-game-text-wrapper">
                                 <div class="firebot-shoutout-game-lastseen">
-                                    LAST SEEN PLAYING
+                                {{effect.lastGameText}}
                                 </div>
                                 Science & Technology
                             </div>
@@ -162,6 +162,9 @@ const effect = {
                     <div class="control__indicator"></div>
                 </label>
             </div>
+
+            <firebot-input input-title="Last Playing Text" model="effect.lastGameText" placeholder-text="Enter text" />
+
         </eos-container>
         <eos-container header="Username" pad-top="true">
             <firebot-input model="effect.username" placeholder-text="Enter username" />
@@ -328,7 +331,7 @@ const effect = {
                             <div class="firebot-shoutout-game-dimmer" />
                             <div class="firebot-shoutout-game-text-wrapper">
                                 <div class="firebot-shoutout-game-lastseen">
-                                    LAST SEEN PLAYING
+                                    ${data.lastGameText}
                                 </div>
                                 ${data.gameName}
                             </div>


### PR DESCRIPTION
### Description of the Change
Added a new text field to the Shoutout effect so that Last Seen Playing text can be customized.

### Applicable Issues
#1691

### Testing
See screenshots, different text shows different text in the overlay.

### Screenshots
Effect Settings:
![image](https://user-images.githubusercontent.com/4147439/164910378-f006cf82-e763-41ed-bc10-204cc997deaf.png)
In action:
![image](https://user-images.githubusercontent.com/4147439/164910345-efc8b573-9ec8-4e03-b55e-c7a66c8cd0b9.png)
In action:
![image](https://user-images.githubusercontent.com/4147439/164910353-151dbbb0-d8f2-46d5-b458-ffab297eb8be.png)