### PR TITLE
fix: elg light strip color name case sensitivity

### DIFF
--- a/backend/integrations/builtin/elgato/elgato.js
+++ b/backend/integrations/builtin/elgato/elgato.js
@@ -34,7 +34,7 @@ class ElgatoIntegration extends EventEmitter {
         frontendCommunicator.onAsync("getKeyLights", async () => {
             return this.keyLightController.keyLights || [];
         });
-        
+
         frontendCommunicator.onAsync("getLightStrips", async () => {
             return this.lightStripController.lightStrips || [];
         });
@@ -117,7 +117,7 @@ class ElgatoIntegration extends EventEmitter {
                 // Otherwise, convert from the color name
                 } else {
                     try {
-                        hsvColor = colorConvert.keyword.hsv(colorValue);
+                        hsvColor = colorConvert.keyword.hsv(colorValue.toLowerCase());
                     } catch {
                         logger.debug('Unable to convert "' + colorValue + '" to HSV color');
                         return;


### PR DESCRIPTION
### Description of the Change
When a color name (not hex code) is specified for Elgato Light Strip color, the name is now converted to lowercase first in order to properly convert.


### Applicable Issues
N/A


### Testing
Tested both `blue` and `Blue` to ensure that lights changed to specified color.


### Screenshots
N/A