### PR TITLE
fix: Mutiple bugs with chat-based gift sub event

### DIFF
--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -60,12 +60,12 @@ exports.triggerSubGift = (subInfo) => {
     }
 
     eventManager.triggerEvent("twitch", "subs-gifted", {
-        username: subInfo.displayName,
-        giftSubMonths: subInfo.streak || 1,
+        username: subInfo.gifterDisplayName || subInfo.gifter || "Anonymous",
+        giftSubMonths: subInfo.months || 1,
         gifteeUsername: subInfo.displayName,
-        gifterUsername: subInfo.gifterDisplayName || subInfo.displayName,
+        gifterUsername: subInfo.gifterDisplayName || subInfo.gifter,
         subPlan: subInfo.planName,
-        isAnonymous: !!subInfo.gifterUserId,
+        isAnonymous: !subInfo.gifterUserId,
         giftDuration: subInfo.giftDuration
     });
     logger.debug(`Gift Sub event triggered`);


### PR DESCRIPTION
### Description of the Change
This fixes multiple bugs with the change to use chat-based gift sub events (reported in #1662, changed in #1663). Bugs fixed:
- Fix `username` field value to use gifter fields or "Anonymous" when anonymous, as `displayName` corresponds to the recipient, not the gifter.
- Fix `giftSubMonths` to use `months` field as `streak` does not exist on chat sub event.
- Fix `gifterUsername` to fallback to `gifter` instead of `displayName`, as `displayName` corresponds to the recipient, not the gifter.
- Fix `isAnonymous` property to correctly trigger anonymous gifts.


### Applicable Issues
Related to issue #1662/PR #1663.


### Testing
Gifted a sub to my bot and received the following data back for verification. Verified all fields both from this and also from twurple source.
``` javascript
{
  userId: '626526988',
  displayName: 'zunderstreambot',
  gifter: 'zunderscore',
  gifterUserId: '50989853',
  gifterDisplayName: 'zunderscore',
  gifterGiftCount: 0,
  giftDuration: 1,
  plan: '1000',
  planName: "Captain Hoppers' Swabbies",
  isPrime: false,
  months: 7
}
```


### Screenshots
N/A