### PR TITLE
feat: add category var, refactor usage of "game"

### DIFF
--- a/backend/effects/builtin/stream-game.js
+++ b/backend/effects/builtin/stream-game.js
@@ -7,8 +7,8 @@ const twitchApi = require("../../twitch-api/api");
 const model = {
     definition: {
         id: "firebot:streamgame",
-        name: "Set Stream Game",
-        description: "Set the stream game.",
+        name: "Set Stream Category",
+        description: "Set the stream category/game.",
         icon: "fad fa-gamepad",
         categories: [EffectCategory.COMMON, EffectCategory.MODERATION, EffectCategory.TWITCH],
         dependencies: []
@@ -16,21 +16,21 @@ const model = {
     optionsTemplate: `
         <eos-container header="Mode">
             <div class="controls-fb" style="padding-bottom: 5px;">
-                <label class="control-fb control--radio">Set specific game  <tooltip text="'Search for a specific game to set.'"></tooltip>
+                <label class="control-fb control--radio">Set specific category  <tooltip text="'Search for a specific category to set.'"></tooltip>
                     <input type="radio" ng-model="effect.mode" value="specific"/>
                     <div class="control__indicator"></div>
                 </label>
-                <label class="control-fb control--radio">Custom game <tooltip text="'Input any name and Firebot will set the closest game it finds when effect is ran (useful with replace variables).'"></tooltip>
+                <label class="control-fb control--radio">Custom category <tooltip text="'Input any name and Firebot will set the closest category it finds when effect is ran (useful with replace variables).'"></tooltip>
                     <input type="radio" ng-model="effect.mode" value="custom"/>
                     <div class="control__indicator"></div>
                 </label>
             </div>
         </eos-container>
 
-        <eos-container header="Specific Game" pad-top="true" ng-if="effect.mode === 'specific'" >
+        <eos-container header="Specific Category" pad-top="true" ng-if="effect.mode === 'specific'" >
 
             <ui-select ng-model="selectedGame" theme="bootstrap" spinner-enabled="true" on-select="gameSelected($item)" style="margin-bottom:10px;">
-                <ui-select-match placeholder="Search for game">
+                <ui-select-match placeholder="Search for category/game">
                     <div style="height: 21px; display:flex; flex-direction: row; align-items: center;">
                         <img style="height: 21px; width: 21px; border-radius: 5px; margin-right:5px;" ng-src="{{$select.selected.boxArtUrl}}">
                         <div style="font-weight: 100;font-size: 17px;">{{$select.selected.name}}</div>
@@ -46,8 +46,8 @@ const model = {
 
         </eos-container>
 
-        <eos-container header="Custom Game" pad-top="true" ng-if="effect.mode === 'custom'">
-            <input ng-model="effect.gameName" class="form-control" type="text" placeholder="Enter game name" replace-variables>
+        <eos-container header="Custom Category" pad-top="true" ng-if="effect.mode === 'custom'">
+            <input ng-model="effect.gameName" class="form-control" type="text" placeholder="Enter category/game name" replace-variables>
         </eos-container>
     `,
     optionsController: ($scope, $q, backendCommunicator) => {
@@ -82,9 +82,9 @@ const model = {
     optionsValidator: effect => {
         let errors = [];
         if (effect.mode === "specific" && (effect.gameId == null || effect.gameId === "")) {
-            errors.push("Please search for and select a game.");
+            errors.push("Please search for and select a category/game.");
         } else if (effect.mode === "custom" && effect.gameName == null) {
-            errors.push("Please input a title for a game.");
+            errors.push("Please input a title for a category/game.");
         }
         return errors;
     },
@@ -97,7 +97,7 @@ const model = {
                 const category = categories.find(c => c.name.toLowerCase() === event.effect.gameName.toLowerCase());
 
                 if (!category) {
-                    logger.error("Couldn't find a category with this name");
+                    logger.error("Couldn't find a category/game with this name");
                     return;
                 }
 

--- a/backend/restrictions/builtin/channel-game.js
+++ b/backend/restrictions/builtin/channel-game.js
@@ -6,14 +6,14 @@ const channelAccess = require("../../twitch-api/resource/channels");
 const model = {
     definition: {
         id: "firebot:channelGame",
-        name: "Channel Game",
-        description: "Restricts use to when the game is a specific game.",
+        name: "Channel Category/Game",
+        description: "Restricts use to when the category/game is a specific category/game.",
         triggers: []
     },
     optionsTemplate: `
         <div>
             <ui-select ng-model="selectedGame" theme="bootstrap" spinner-enabled="true" on-select="gameSelected($item)" style="margin-bottom:10px;">
-                <ui-select-match placeholder="Search for game">
+                <ui-select-match placeholder="Search for category/game">
                     <div style="height: 21px; display:flex; flex-direction: row; align-items: center;">
                         <img style="height: 28px; width: 21px; border-radius: 5px; margin-right:5px;" ng-src="{{$select.selected.boxArtUrl}}">
                         <div style="font-weight: 100;font-size: 17px;">{{$select.selected.name}}</div>
@@ -60,7 +60,7 @@ const model = {
             if (restriction.name != null) {
                 resolve(restriction.name);
             } else {
-                resolve('[Game Not Set]');
+                resolve('[Category/Game Not Set]');
             }
         });
     },
@@ -81,7 +81,7 @@ const model = {
 
             const currentGameId = channel.gameId;
             if (currentGameId == null) {
-                return reject(`Can't determine the game being played.`);
+                return reject(`Can't determine the category/game being played.`);
             }
 
             let passed = false;
@@ -92,7 +92,7 @@ const model = {
             if (passed) {
                 resolve();
             } else {
-                reject(`Channel game isn't set to the correct game.`);
+                reject(`Channel category/game isn't set to the correct category/game.`);
             }
         });
     }

--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -22,6 +22,7 @@ exports.loadReplaceVariables = () => {
         'bits-badge-tier',
         'bits-badge-unlocked-message',
         'bot',
+        'category',
         'category-image-url',
         'chat-message-emote-urls',
         'chat-message',

--- a/backend/variables/builtin/category.js
+++ b/backend/variables/builtin/category.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const twitchChannels = require("../../twitch-api/resource/channels");
+const accountAccess = require("../../common/account-access");
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+const model = {
+    definition: {
+        handle: "category",
+        description: "Gets the current category/game set for your channel",
+        examples: [
+            {
+                usage: "category[$target]",
+                description: "When in a command, gets the category/game set for the target user."
+            },
+            {
+                usage: "category[$user]",
+                description: "Gets the category/game set for associated user (i.e. who triggered command, pressed button, etc)."
+            },
+            {
+                usage: "category[ChannelOne]",
+                description: "Gets the category/game set for a specific channel."
+            }
+        ],
+        categories: [VariableCategory.COMMON, VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async (_, username) => {
+        if (username == null) {
+            username = accountAccess.getAccounts().streamer.username;
+        }
+
+        const channelInfo = await twitchChannels.getChannelInformationByUsername(username);
+
+        return channelInfo?.gameName || "";
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/game.js
+++ b/backend/variables/builtin/game.js
@@ -2,40 +2,30 @@
 
 "use strict";
 
-const twitchChannels = require("../../twitch-api/resource/channels");
-const accountAccess = require("../../common/account-access");
-const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+const category = require("./category");
 
 const model = {
     definition: {
         handle: "game",
-        description: "Gets the current game set for your channel",
+        description: category.definition.description,
         examples: [
             {
                 usage: "game[$target]",
-                description: "When in a command, gets the game set for the target user."
+                description: "When in a command, gets the category/game set for the target user."
             },
             {
                 usage: "game[$user]",
-                description: "Gets the game set for associated user (Ie who triggered command, pressed button, etc)."
+                description: "Gets the category/game set for associated user (i.e. who triggered command, pressed button, etc)."
             },
             {
                 usage: "game[ChannelOne]",
-                description: "Gets the game set for a specific channel."
+                description: "Gets the category/game set for a specific channel."
             }
         ],
-        categories: [VariableCategory.COMMON, VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT]
+        categories: category.definition.categories,
+        possibleDataOutput: category.definition.possibleDataOutput
     },
-    evaluator: async (_, username) => {
-        if (username == null) {
-            username = accountAccess.getAccounts().streamer.username;
-        }
-
-        const channelInfo = await twitchChannels.getChannelInformationByUsername(username);
-
-        return channelInfo != null ? channelInfo.gameName : "";
-    }
+    evaluator: category.evaluator
 };
 
 module.exports = model;

--- a/gui/app/controllers/quotes.controller.js
+++ b/gui/app/controllers/quotes.controller.js
@@ -109,7 +109,7 @@
                     cellController: () => {}
                 },
                 {
-                    name: "GAME",
+                    name: "CATEGORY/GAME",
                     icon: "fa-gamepad-alt",
                     dataField: "game",
                     sortable: true,
@@ -121,7 +121,7 @@
                         'width': '175px',
                         'padding': '0px 3px'
                     },
-                    cellTemplate: `<div style="width:175px;white-space: nowrap;overflow: hidden;text-overflow: ellipsis;">{{data.game || "Unknown Game"}}</div>`,
+                    cellTemplate: `<div style="width:175px;white-space: nowrap;overflow: hidden;text-overflow: ellipsis;">{{data.game || "Unknown Category/Game"}}</div>`,
                     cellController: () => {}
                 },
                 {

--- a/gui/app/directives/modals/quotes/addOrEditQuoteModal.js
+++ b/gui/app/directives/modals/quotes/addOrEditQuoteModal.js
@@ -55,12 +55,12 @@
 
                     <div>
                         <div class="modal-subheader" style="padding: 0 0 4px 0">
-                            GAME
+                            CATEGORY/GAME
                         </div>
                         <div style="width: 100%; position: relative;">
                             <div class="form-group" ng-class="{'has-error': $ctrl.gameError}">
                                 <input type="text" id="gameField" class="form-control" ng-model="$ctrl.quote.game" ng-keyup="$event.keyCode == 13 && $ctrl.save() " aria-describedby="gameHelpBlock" placeholder="Enter game">
-                                <span id="gameHelpBlock" class="help-block" ng-show="$ctrl.gameError">Please provide a game name.</span>
+                                <span id="gameHelpBlock" class="help-block" ng-show="$ctrl.gameError">Please provide a category/game name.</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Description of the Change
Added new `category` variable with logic from `game` variable, updated `game` variable to use `category` variable logic to prevent duplicate code, updated several UI locations to change "game" to "category" or "category/game" for clarity & consistency with Twitch nomenclature and to match other places in the UI (e.g. "Category Changed" event).


### Applicable Issues
#1661


### Testing
Verified UI changes, verified new `category` variable works just like `game`, verified `game` still works as before.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/165659332-297f0d0f-cc12-4770-afe0-5c961e0e1412.png)
![image](https://user-images.githubusercontent.com/1764877/165659356-a725b1a5-759b-4ab1-aab1-1b3f121b59d8.png)
![image](https://user-images.githubusercontent.com/1764877/165659379-fc59ed51-8c21-4bdb-a02e-cd4f6e20173d.png)
![image](https://user-images.githubusercontent.com/1764877/165659404-82baa3e8-852b-4901-ba94-e987f19793e6.png)
![image](https://user-images.githubusercontent.com/1764877/165659440-2df24197-b574-4782-b470-837d1c93a302.png)
![image](https://user-images.githubusercontent.com/1764877/165659457-ecfc50d9-57f2-4310-a650-86b06fd44ead.png)
