### PR TITLE
#1705 Fallback username for anonymous cheers

### DIFF
--- a/backend/events/twitch-events/cheer.js
+++ b/backend/events/twitch-events/cheer.js
@@ -5,7 +5,7 @@ const eventManager = require("../../events/EventManager");
 /** @param {import("@twurple/pubsub").PubSubBitsMessage} cheerInfo */
 exports.triggerCheer = (cheerInfo) => {
     eventManager.triggerEvent("twitch", "cheer", {
-        username: cheerInfo.userName,
+        username: cheerInfo.userName || "An Anonymous Cheerer",
         isAnonymous: cheerInfo.isAnonymous,
         bits: cheerInfo.bits,
         totalBits: cheerInfo.totalBits,
@@ -16,7 +16,7 @@ exports.triggerCheer = (cheerInfo) => {
 /** @param {import("@twurple/pubsub").PubSubBitsBadgeUnlockMessage} unlockInfo */
 exports.triggerBitsBadgeUnlock = (unlockInfo) => {
     eventManager.triggerEvent("twitch", "bits-badge-unlocked", {
-        username: unlockInfo.userName,
+        username: unlockInfo.userName || "An Anonymous Cheerer",
         message: unlockInfo.message || "",
         badgeTier: unlockInfo.badgeTier
     });


### PR DESCRIPTION

### Description of the Change
Fall back to "An Anonymous Cheerer" when pubsub provides an undefined `userName`. 
I'm not particular about the spaces in the username, was just trying to mimic the fallback for anonymous gifts of "An Anonymous Gifter"

### Applicable Issues
#1705


### Testing
Cheered 25 bits both anonymously and non-anonymously. Event was set up with chat message effect with text `$user has cheered $cheerBitsAmount`


### Screenshots
Before:
![image](https://user-images.githubusercontent.com/556514/165873507-431e4bee-2e4b-4967-b875-123c616d397a.png)

After:
![image](https://user-images.githubusercontent.com/556514/165873310-3a0115e7-dcea-4d15-bed1-ee1921d71aa0.png)