### PR TITLE
Fix: $vars menu position for custom-variable

### DIFF
--- a/backend/effects/builtin/custom-variable.js
+++ b/backend/effects/builtin/custom-variable.js
@@ -16,7 +16,7 @@ const fileWriter = {
     optionsTemplate: `
         <eos-container header="Variable Name">
             <p class="muted">You'll use this name to reference this elsewhere via $customVariable[name].</p>
-            <input ng-model="effect.name" type="text" class="form-control" id="chat-text-setting" placeholder="Enter name" replace-variables>
+            <input ng-model="effect.name" type="text" class="form-control" id="chat-text-setting" placeholder="Enter name" replace-variables menu-position="below">
         </eos-container>
 
         <eos-container header="Variable Data" pad-top="true">


### PR DESCRIPTION
### Description of the Change
Added a menu position override for the Variable Name input field


### Applicable Issues
#1632


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
After the change has been applied:
![image](https://user-images.githubusercontent.com/4147439/166214782-bf79c39f-710e-47b8-aac1-e72fbb00ab33.png)
See screenshot from before in the following comment:
https://github.com/crowbartools/Firebot/issues/1632#issuecomment-1076380419
