### PR TITLE
fix: allow setting user currency to 0

### DIFF
--- a/backend/database/currencyDatabase.js
+++ b/backend/database/currencyDatabase.js
@@ -162,7 +162,7 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
 
         // Run our checks. Stop if we have a bad value, currency, or roles.
         value = parseInt(value);
-        if (roleIds === [] || currencyId === null || value === null || value === 0 || isNaN(value)) {
+        if (roleIds === [] || currencyId === null || value === null || (value === 0 && adjustType.toLowerCase() !== "set") || isNaN(value)) {
             return resolve();
         }
 
@@ -222,9 +222,9 @@ function addCurrencyToOnlineUsers(currencyId, value, ignoreDisable = false, adju
             return reject();
         }
 
-        // Don't do anything for 0 points or non numbers.
+        // Don't do anything for non numbers or 0 if we're not specifically setting a value.
         value = parseInt(value);
-        if (isNaN(value) || value === 0) {
+        if (isNaN(value) || (value === 0 && adjustType.toLowerCase() !== "set")) {
             return resolve();
         }
 
@@ -257,9 +257,9 @@ function adjustCurrencyForAllUsers(currencyId, value, ignoreDisable = false,
             return reject();
         }
 
-        // Don't do anything for 0 points or non numbers.
+        // Don't do anything for non numbers or 0 if we're not specifically setting a value.
         value = parseInt(value);
-        if (isNaN(value) || value === 0) {
+        if (isNaN(value) || (value === 0 && adjustType.toLowerCase() !== "set")) {
             return resolve();
         }
 


### PR DESCRIPTION
### Description of the Change
Updates the currency database to allow specifically setting a user's currency value to 0.


### Applicable Issues
#1603


### Testing
Ensured that currency could be set to 0 via the **Update Currency** effect for a single user, all online users, all users, and all online users in a specific role.


### Screenshots
N/A