### PR TITLE
feat: allow local videos to play at 0 volume

### DIFF
--- a/backend/effects/builtin/play-video.js
+++ b/backend/effects/builtin/play-video.js
@@ -165,7 +165,7 @@ const playVideo = {
         <eos-container header="Volume" pad-top="true" ng-if="effect.videoType != 'Random Twitch Clip' && effect.videoType != 'Twitch Clip'">
             <div class="volume-slider-wrapper">
                 <i class="fal fa-volume-down volume-low"></i>
-                <rzslider rz-slider-model="effect.volume" rz-slider-options="{floor: 1, ceil: 10, hideLimitLabels: true}"></rzslider>
+                <rzslider rz-slider-model="effect.volume" rz-slider-options="{floor: 0, ceil: 10, hideLimitLabels: true}"></rzslider>
                 <i class="fal fa-volume-up volume-high"></i>
             </div>
         </eos-container>


### PR DESCRIPTION
### Description of the Change
Adjust volume slider to allow volume of 0 (effectively muted) on local video option in **Play Video** effect.


### Applicable Issues
#1714


### Testing
Played a video with sound in the overlay at volume 0, verified that no audio played. Played another video with higher volume level, verified that audio track played.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/166520135-4bda3e65-437b-4a42-9ab5-54d9b7baf431.png)
