### PR TITLE
fix: clear effects "default" overlay name

### DIFF
--- a/backend/effects/builtin/clear-effects.js
+++ b/backend/effects/builtin/clear-effects.js
@@ -88,6 +88,10 @@ const delay = {
         }
 
         $scope.getSelectedOverlayDisplay = () => {
+            if ($scope.effect.overlayInstance == null) {
+                return "Default";
+            }
+
             if ($scope.effect.overlayInstance === "all") {
                 return "All";
             }


### PR DESCRIPTION
### Description of the Change
Fix display bug in **Clear Effects** effect where choosing Default overlay when overlay instances are enabled would result in a blank entry.


### Applicable Issues
#1721


### Testing
Verified that choosing Default overlay now actually displayed "Default" and that clearing the overlay still works.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/167051574-2f8ed38f-1344-49aa-82e7-6eb1cc90b8c1.png)