### PR TITLE
feat: currencyRank variable

### DIFF
--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -38,6 +38,7 @@ exports.loadReplaceVariables = () => {
         'count',
         'counter',
         'currency',
+        'currency-rank',
         'current-viewer-count',
         'custom-role-user-count',
         'custom-role-users',

--- a/backend/variables/builtin/currency-rank.js
+++ b/backend/variables/builtin/currency-rank.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+const currencyDatabase = require("../../database/currencyDatabase");
+
+const model = {
+    definition: {
+        handle: "currencyRank",
+        description: "Returns the rank of the given user based on how much of the given currency they have.",
+        usage: "currencyRank[currencyName, username]",
+        categories: [VariableCategory.USER, VariableCategory.NUMBERS],
+        possibleDataOutput: [OutputDataType.NUMBER]
+    },
+    evaluator: async (_, currencyName, username) => {
+
+        if (currencyName == null || username == null) {
+            return 0;
+        }
+
+        let currencyData = currencyDatabase.getCurrencies();
+
+        if (currencyData == null) {
+            return 0;
+        }
+
+        let currencies = Object.values(currencyData);
+
+        let currency = currencies.find(c => c.name.toLowerCase() === currencyName.toLowerCase());
+
+        if (currency == null) {
+            return 0;
+        }
+
+        let rank = await currencyDatabase.getUserCurrencyRank(currency.id, username, true);
+
+        return rank;
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
Add `currencyRank` variable to determine the given viewer's rank based on the amount of the given currency they have relative to user viewers.


### Applicable Issues
#1626


### Testing
Verified that a valid user and currency return the given rank, and that both an invalid currency and/or invalid user returns 0.


### Screenshots
N/A