### PR TITLE
feat: add $regexMatches variable

### DIFF
--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -95,6 +95,7 @@ exports.loadReplaceVariables = () => {
         'random-advice',
         'read-api',
         'read-file',
+        'regex-matches',
         'regexExec',
         'regexTest',
         'replace',

--- a/backend/variables/builtin/regex-matches.js
+++ b/backend/variables/builtin/regex-matches.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+const model = {
+    definition: {
+        handle: "regexMatches",
+        description: "Filter a string with a regular expression and return a JSON array of all matches",
+        usage: "regexMatches[string, expression]",
+        examples: [
+            {
+                usage: "regexMatches[string, expression, flags]",
+                description: "Add flags to the regex evaluation."
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (_, stringToEvaluate, expression, flags) => {
+        const regex = RegExp(expression, flags);
+        const matches = stringToEvaluate.match(regex);
+
+        return JSON.stringify([...matches]);
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
Add `$regexMatches` variable that returns a JSON array of all regex matches in a string.


### Applicable Issues
Related to #1728


### Testing
Created a string and an expression and verified that all matches in the string were returned as a JSON array.


### Screenshots
N/A