### PR TITLE
style: organize chat settings into common groups

### DIFF
--- a/gui/app/directives/modals/chat/chat-settings-modal.js
+++ b/gui/app/directives/modals/chat/chat-settings-modal.js
@@ -10,21 +10,31 @@
                 </div>
                 <div class="modal-body">
                     <div class="py-0 px-4">
-                        <chat-settings-toggle
+
+                        <!-- Main Chat Settings -->
+                        <div class="mt-8 chat-settings-group">
+                            <div class="display-1 mb-2 font-black">Main Settings</div>
+
+                            <chat-settings-toggle
                             setting="settings.getShowChatViewerList()"
                             title="Show Chat User List"
                             input-id="chatUserList"
                             on-update="settings.setShowChatViewerList(setting)"
-                        ></chat-settings-toggle>
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.showActivityFeed()"
-                            title="Show Activity Feed"
-                            input-id="activityFeed"
-                            on-update="settings.setShowActivityFeed(setting)"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.showActivityFeed()"
+                                title="Show Activity Feed"
+                                input-id="activityFeed"
+                                on-update="settings.setShowActivityFeed(setting)"
+                            ></chat-settings-toggle>
+                        </div>
 
-                        <div class="mt-8">
+
+                        <!-- Sound Settings -->
+                        <div class="mt-8 chat-settings-group">
+                            <div class="display-1 mb-2 font-black">Sound Settings</div>
+
                             <div class="mb-2 font-black">Tag Notification Sound</div>
                             <span class="btn-group mb-2.5" uib-dropdown>
                                 <button type="button" class="btn btn-primary" uib-dropdown-toggle>
@@ -49,7 +59,11 @@
                                 <i class="fal fa-volume-up volume-high pb-2 text-4xl"></i>
                             </div>
                         </div>
-                        <div class="my-8">
+
+                        <!-- Display Style Settings -->
+                        <div class="mt-8 chat-settings-group">
+                            <div class="display-1 mb-2 font-black">Display Settings</div>
+
                             <div class="font-black">Display Style</div>
                             <div class="permission-type controls-fb-inline">
                                 <label class="control-fb control--radio">Modern
@@ -61,94 +75,106 @@
                                     <div class="control__indicator"></div>
                                 </label>
                             </div>
-                        </div>
-                        <chat-settings-toggle
-                            setting="settings.chatAlternateBackgrounds()"
-                            title="Alternate Backgrounds"
-                            input-id="alternateBackgrounds"
-                            on-update="settings.setChatAlternateBackgrounds(setting)"
-                        ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.chatHideDeletedMessages()"
-                            title="Hide Deleted Messages"
-                            tooltip="'Turning this on will cover deleted messages with a blackbox. Hovering over the message will reveal it. Great for letting your mods hide spoilers!'"
-                            input-id="hideDeletedMessages"
-                            on-update="settings.setChatHideDeletedMessages(setting)"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.chatAlternateBackgrounds()"
+                                title="Alternate Backgrounds"
+                                input-id="alternateBackgrounds"
+                                on-update="settings.setChatAlternateBackgrounds(setting)"
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.getShowAvatars()"
-                            title="Show Avatars"
-                            input-id="showAvatars"
-                            on-update="settings.setShowAvatars(setting)"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.getShowAvatars()"
+                                title="Show Avatars"
+                                input-id="showAvatars"
+                                on-update="settings.setShowAvatars(setting)"
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.getShowTimestamps()"
-                            title="Show Timestamps"
-                            input-id="showTimestamps"
-                            on-update="settings.setShowTimestamps(setting)"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.getShowTimestamps()"
+                                title="Show Timestamps"
+                                input-id="showTimestamps"
+                                on-update="settings.setShowTimestamps(setting)"
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.getShowBttvEmotes()"
-                            title="Show BTTV Emotes"
-                            external-link="https://betterttv.com/"
-                            input-id="bttvEmotes"
-                            on-update="setShowThirdPartyEmotes('bttv')"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.getShowPronouns()"
+                                title="Show Pronouns"
+                                external-link="https://pronouns.alejo.io/"
+                                input-id="showPronouns"
+                                on-update="settings.setShowPronouns(setting)"
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.getShowFfzEmotes()"
-                            title="Show FFZ Emotes"
-                            external-link="https://frankerfacez.com/"
-                            input-id="ffzEmotes"
-                            on-update="setShowThirdPartyEmotes('ffz')"
-                        ></chat-settings-toggle>
+                            <chat-settings-toggle
+                                setting="settings.getChatCustomFontSizeEnabled()"
+                                title="Show Custom Font Size"
+                                input-id="showCustomFontSize"
+                                on-update="toggleCustomFontEnabled()"
+                            ></chat-settings-toggle>
 
-                        <chat-settings-toggle
-                            setting="settings.getShowSevenTvEmotes()"
-                            title="Show 7TV Emotes"
-                            external-link="https://7tv.app/"
-                            input-id="sevenTvEmotes"
-                            on-update="setShowThirdPartyEmotes('7tv')"
-                        ></chat-settings-toggle>
-
-                        <chat-settings-toggle
-                            setting="settings.getShowPronouns()"
-                            title="Show Pronouns"
-                            external-link="https://pronouns.alejo.io/"
-                            input-id="showPronouns"
-                            on-update="settings.setShowPronouns(setting)"
-                        ></chat-settings-toggle>
-
-                        <chat-settings-toggle
-                            setting="settings.getChatCustomFontSizeEnabled()"
-                            title="Show Custom Font Size"
-                            input-id="showCustomFontSize"
-                            on-update="toggleCustomFontEnabled()"
-                        ></chat-settings-toggle>
-
-                        <div class="volume-slider-wrapper" ng-show="settings.getChatCustomFontSizeEnabled()">
-                            <rzslider rz-slider-model="customFontSize" rz-slider-options="fontSliderOptions"></rzslider>
+                            <div class="volume-slider-wrapper" ng-show="settings.getChatCustomFontSizeEnabled()">
+                                <rzslider rz-slider-model="customFontSize" rz-slider-options="fontSliderOptions"></rzslider>
+                            </div>
                         </div>
 
+                        <!-- Emote Settings -->
+                        <div class="mt-8 chat-settings-group">
+                            <div class="display-1 mb-2 font-black">Emote Settings</div>
+
+                            <chat-settings-toggle
+                                setting="settings.getShowBttvEmotes()"
+                                title="Show BTTV Emotes"
+                                external-link="https://betterttv.com/"
+                                input-id="bttvEmotes"
+                                on-update="setShowThirdPartyEmotes('bttv')"
+                            ></chat-settings-toggle>
+
+                            <chat-settings-toggle
+                                setting="settings.getShowFfzEmotes()"
+                                title="Show FFZ Emotes"
+                                external-link="https://frankerfacez.com/"
+                                input-id="ffzEmotes"
+                                on-update="setShowThirdPartyEmotes('ffz')"
+                            ></chat-settings-toggle>
+
+                            <chat-settings-toggle
+                                setting="settings.getShowSevenTvEmotes()"
+                                title="Show 7TV Emotes"
+                                external-link="https://7tv.app/"
+                                input-id="sevenTvEmotes"
+                                on-update="setShowThirdPartyEmotes('7tv')"
+                            ></chat-settings-toggle>
+                        </div>
+
+                        <!-- Filter Settings -->
                         <div class="mt-8">
-                            <div class="mb-2 font-black" id="showCustomFontSize">Clear Chat Feed</div>
-                            <dropdown-select
-                                options="clearChatFeedOptions"
-                                selected="chatFeedMode"
-                                on-update="setChatFeedMode(option)"
-                            ></dropdown-select>
+                            <div class="display-1 mb-2 font-black">Filter Settings</div>
+
+                            <div>
+                                <div class="mb-2 font-black" id="showCustomFontSize">Clear Chat Feed</div>
+                                <dropdown-select
+                                    options="clearChatFeedOptions"
+                                    selected="chatFeedMode"
+                                    on-update="setChatFeedMode(option)"
+                                ></dropdown-select>
+                            </div>
+                        
+                            <chat-settings-toggle
+                                setting="settings.chatHideDeletedMessages()"
+                                title="Hide Deleted Messages"
+                                tooltip="'Turning this on will cover deleted messages with a blackbox. Hovering over the message will reveal it. Great for letting your mods hide spoilers!'"
+                                input-id="hideDeletedMessages"
+                                on-update="settings.setChatHideDeletedMessages(setting)"
+                            ></chat-settings-toggle>
+
+                            <chat-settings-toggle
+                                setting="settings.chatHideBotAccountMessages()"
+                                title="Hide messages from Bot account"
+                                input-id="hideBotMessages"
+                                on-update="settings.setChatHideBotAccountMessages(setting)"
+                            ></chat-settings-toggle>
                         </div>
 
-                        <chat-settings-toggle
-                            setting="settings.chatHideBotAccountMessages()"
-                            title="Hide messages from Bot account"
-                            input-id="hideBotMessages"
-                            on-update="settings.setChatHideBotAccountMessages(setting)"
-                        ></chat-settings-toggle>
                     </div>
                 </div>
                 <div class="modal-footer"></div>

--- a/gui/scss/core/_chat.scss
+++ b/gui/scss/core/_chat.scss
@@ -764,3 +764,9 @@
     background: rgba(0, 0, 0, 0.6);
     padding: 10px;
 }
+
+.chat-settings-group{
+    border-bottom: 1px solid lightgray;
+    padding-bottom: 1em;
+    margin-bottom: 1em;
+}

--- a/gui/scss/core/_global.scss
+++ b/gui/scss/core/_global.scss
@@ -1777,3 +1777,7 @@ column-resizer {
 .note-palette-title {
   color: $change-note-palette-title-color;
 }
+
+.display-1{
+  font-size: 1.2em;
+}


### PR DESCRIPTION
Organized chat settings into common groups so that specific settings can be found easier.

### Description of the Change
This updates the chat settings modal to organize settings into common groups. 


### Applicable Issues
None, this was done in preparation for adding a setting to filter user roles from the chat user list.


### Testing
- Open firebot
- Open chat modal
- Make sure nothing looks broken.
- Make sure settings can still be toggled and their settings are saved.


### Screenshots
![image](https://user-images.githubusercontent.com/17416635/167744027-7a05541b-7e17-4e08-890a-400e9d4ac483.png)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
