### PR TITLE
feat: ability to filter users from the viewer list

### DIFF
--- a/backend/chat/chat-listeners/active-user-handler.js
+++ b/backend/chat/chat-listeners/active-user-handler.js
@@ -96,7 +96,6 @@ async function updateUserOnlineStatus(userDetails, updateDb = false) {
         onlineUsers.set(userDetails.id, true, ONLINE_TIMEOUT);
 
         const roles = await chatRolesManager.getUsersChatRoles(userDetails.id);
-        const details = await userDatabase.getUserById(userDetails.id);
 
         frontendCommunicator.send("twitch:chat:user-joined", {
             id: userDetails.id,
@@ -104,7 +103,7 @@ async function updateUserOnlineStatus(userDetails, updateDb = false) {
             roles: roles,
             profilePicUrl: userDetails.profilePicUrl,
             active: exports.userIsActive(userDetails.id),
-            disableViewerList: details.disableViewerList ? details.disableViewerList : false
+            disableViewerList: userDetails.disableViewerList
         });
 
         if (updateDb) {
@@ -134,7 +133,8 @@ exports.addOnlineUser = async (username) => {
                 username: twitchUser.name,
                 displayName: twitchUser.displayName,
                 twitchRoles: [],
-                profilePicUrl: twitchUser.profilePictureUrl
+                profilePicUrl: twitchUser.profilePictureUrl,
+                disableViewerList: false
             };
 
             chatHelpers.setUserProfilePicUrl(twitchUser.id, twitchUser.profilePictureUrl);
@@ -149,7 +149,8 @@ exports.addOnlineUser = async (username) => {
                 username: firebotUser.username,
                 displayName: firebotUser.displayName,
                 twitchRoles: firebotUser.twitchRoles,
-                profilePicUrl: firebotUser.profilePicUrl
+                profilePicUrl: firebotUser.profilePicUrl,
+                disableViewerList: !!firebotUser.disableViewerList
             };
             await updateUserOnlineStatus(userDetails, true);
         }
@@ -188,7 +189,8 @@ exports.addActiveUser = async (chatUser, includeInOnline = false, forceActive = 
             ...(chatUser.isMod ? ['mod'] : []),
             ...(chatUser.isVip ? ['vip'] : [])
         ],
-        profilePicUrl: (await chatHelpers.getUserProfilePicUrl(chatUser.userId))
+        profilePicUrl: (await chatHelpers.getUserProfilePicUrl(chatUser.userId)),
+        disableViewerList: !!user.disableViewerList
     };
 
     if (user == null) {

--- a/backend/chat/chat-listeners/active-user-handler.js
+++ b/backend/chat/chat-listeners/active-user-handler.js
@@ -96,13 +96,15 @@ async function updateUserOnlineStatus(userDetails, updateDb = false) {
         onlineUsers.set(userDetails.id, true, ONLINE_TIMEOUT);
 
         const roles = await chatRolesManager.getUsersChatRoles(userDetails.id);
+        const details = await userDatabase.getUserById(userDetails.id);
 
         frontendCommunicator.send("twitch:chat:user-joined", {
             id: userDetails.id,
             username: userDetails.displayName,
             roles: roles,
             profilePicUrl: userDetails.profilePicUrl,
-            active: exports.userIsActive(userDetails.id)
+            active: exports.userIsActive(userDetails.id),
+            disableViewerList: details.disableViewerList ? details.disableViewerList : false
         });
 
         if (updateDb) {

--- a/backend/database/userDatabase.js
+++ b/backend/database/userDatabase.js
@@ -31,6 +31,7 @@ const jsonDataHelpers = require("../common/json-data-helpers");
  * @property {number} chatMessages
  * @property {boolean} disableAutoStatAccrual
  * @property {boolean} disableActiveUserList
+ * @property {boolean} disableViewerList
  * @property {Object.<string, *>=} metadata
  * @property {Object.<string, number>} currency
  */
@@ -422,6 +423,7 @@ function createNewUser(userId, username, displayName, profilePicUrl, twitchRoles
             chatMessages: 0,
             disableAutoStatAccrual: disableAutoStatAccrual,
             disableActiveUserList: false,
+            disableViewerList: false,
             metadata: {},
             currency: {}
         };

--- a/gui/app/directives/chat/chat-user-category.js
+++ b/gui/app/directives/chat/chat-user-category.js
@@ -15,7 +15,7 @@
                 <div style="font-size: 12px; opacity: 0.6;">{{$ctrl.category}}</div>
                 <div
                     class="chat-user-wrapper"
-                    ng-repeat="user in cms.chatUsers | chatUserRole:$ctrl.roleKey | orderBy:'username':true | orderBy:'active':true as filtered track by user.id"
+                    ng-repeat="user in cms.getFilteredChatUserList() | chatUserRole:$ctrl.roleKey | orderBy:'username':true | orderBy:'active':true as filtered track by user.id"
                 >
                     <div class="chat-user-img-wrapper">
                         <img ng-src="{{user.profilePicUrl}}" />

--- a/gui/app/directives/modals/viewers/viewerDetailsModal.js
+++ b/gui/app/directives/modals/viewers/viewerDetailsModal.js
@@ -79,6 +79,13 @@
                             </label>
                         </div>
 
+                        <div ng-show="$ctrl.hasFirebotData" style="margin-top:20px; margin-bottom: 30px;">
+                            <label class="control-fb control--checkbox"> Don't show in viewer list <tooltip text="'Prevent the user from showing up in the viewer list next to chat.'"></tooltip>
+                                <input type="checkbox" ng-model="$ctrl.viewerDetails.firebotData.disableViewerList" ng-change="$ctrl.disableViewerListChange()">
+                                <div class="control__indicator"></div>
+                            </label>
+                        </div>
+
                         <div ng-hide="$ctrl.hasFirebotData" style="padding: left: 15px;">
                             <p class="muted">There is no Firebot data saved for this Twitch user.</p>
                             <button type="button" class="btn btn-default" ng-click="$ctrl.saveUser()">Save User in Firebot</button>
@@ -423,6 +430,14 @@
                         userId: $ctrl.resolve.userId,
                         field: "disableActiveUserList",
                         value: $ctrl.viewerDetails.firebotData.disableActiveUserList
+                    });
+                };
+
+                $ctrl.disableViewerListChange = () => {
+                    backendCommunicator.fireEvent("updateViewerDataField", {
+                        userId: $ctrl.resolve.userId,
+                        field: "disableViewerList",
+                        value: $ctrl.viewerDetails.firebotData.disableViewerList
                     });
                 };
 

--- a/gui/app/services/chat-messages.service.js
+++ b/gui/app/services/chat-messages.service.js
@@ -50,12 +50,7 @@
 
             // Return User List with people in role filtered out.
             service.getFilteredChatUserList = function() {
-                let userList = service.chatUsers;
-                userList = userList.filter(function(user) {
-                    return user.disableViewerList != null ? !user.disableViewerList : true;
-                });
-
-                return userList;
+                return service.chatUsers.filter((user) => !user.disableViewerList);
             };
 
             // Clear User List

--- a/gui/app/services/chat-messages.service.js
+++ b/gui/app/services/chat-messages.service.js
@@ -48,6 +48,16 @@
                 return userList;
             };
 
+            // Return User List with people in role filtered out.
+            service.getFilteredChatUserList = function() {
+                let userList = service.chatUsers;
+                userList = userList.filter(function(user) {
+                    return user.disableViewerList != null ? !user.disableViewerList : true;
+                });
+
+                return userList;
+            };
+
             // Clear User List
             service.clearUserList = function() {
                 service.chatUsers = [];


### PR DESCRIPTION
### Description of the Change
This implements #922. It gives users the ability to hide usernames from the viewer list that sits next to chat. This can be toggled on per user via the user modal.

When the setting is updated, the viewer will remain on the viewer list until the next time that viewer list refresh event occurs, at which time they will be filtered out.

### Applicable Issues
#922 


### Testing
- Connect firebot and let users show in the userlist.
- Click a username (preferably a persistent bot account) to open their modal.
- Click the new hide from viewer list option.
- Close the modal.
- Wait until the next chat refresh happens, and observe that the username disappears.
- Go into the viewer database and find the name again.
- Click it to open the viewer modal.
- Deselect the new option.
- Go back to chat and wait for the refresh, then observe the username comes back.


### Screenshots
![image](https://user-images.githubusercontent.com/17416635/167983285-8fad05c9-acbe-4265-933d-621706e21d41.png)