### PR TITLE
fix: #1731 swap alert message with user message

### DIFF
--- a/backend/integrations/builtin/streamloots/streamloots-event-handler.js
+++ b/backend/integrations/builtin/streamloots/streamloots-event-handler.js
@@ -72,11 +72,11 @@ exports.processStreamLootsEvent = (eventData) => {
     const metadata = {
         imageUrl: eventData.imageUrl,
         soundUrl: eventData.soundUrl,
-        message: eventData.message
+        message: getFieldValue("message", eventData.data.fields)
     };
 
     if (metadata.message == null) {
-        metadata.message = getFieldValue("message", eventData.data.fields);
+        metadata.message = eventData.message;
     }
 
     metadata.username = getFieldValue("username", eventData.data.fields);


### PR DESCRIPTION
### Description of the Change
Changed the user defined message and the alert message order, to use the user defined message first then fall back to the alert message if the user defined message is not sent 


### Applicable Issues
#1731


### Testing

played cards with and without user defined messages  both display 

### Screenshots
there are no ui changes 


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
