### PR TITLE
fix: #1731 swap alert message with user message and add $slootsAlertMessage

### DIFF
--- a/backend/integrations/builtin/streamloots/streamloots-event-handler.js
+++ b/backend/integrations/builtin/streamloots/streamloots-event-handler.js
@@ -36,6 +36,7 @@ const eventSourceDefinition = {
             manualMetadata: {
                 username: "Firebot",
                 message: "Test message",
+                alertMessage: "Alert Message",
                 cardRarity: {
                     type: "enum",
                     options: {
@@ -72,11 +73,12 @@ exports.processStreamLootsEvent = (eventData) => {
     const metadata = {
         imageUrl: eventData.imageUrl,
         soundUrl: eventData.soundUrl,
-        message: eventData.message
+        message: getFieldValue("message", eventData.data.fields),
+        alertMessage: eventData.message
     };
 
     if (metadata.message == null) {
-        metadata.message = getFieldValue("message", eventData.data.fields);
+        metadata.message = eventData.message;
     }
 
     metadata.username = getFieldValue("username", eventData.data.fields);

--- a/backend/integrations/builtin/streamloots/variables/sloots-alert-message.js
+++ b/backend/integrations/builtin/streamloots/variables/sloots-alert-message.js
@@ -9,16 +9,16 @@ triggers[EffectTrigger.MANUAL] = true;
 
 const model = {
     definition: {
-        handle: "slootsMessage",
-        description: "The users message included with a StreamLoots Chest/Card.",
+        handle: "slootsAlertMessage",
+        description: "The alert message included with a StreamLoots Chest/Card.",
         triggers: triggers,
         categories: [VariableCategory.COMMON, VariableCategory.TRIGGER],
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: (trigger) => {
-        const message = trigger.metadata.eventData && trigger.metadata.eventData.message;
+        const alertMessage = trigger.metadata.eventData && trigger.metadata.eventData.alertMessage;
 
-        return message || "";
+        return alertMessage || "";
     }
 };
 

--- a/backend/integrations/builtin/streamloots/variables/streamloots-variable-loader.js
+++ b/backend/integrations/builtin/streamloots/variables/streamloots-variable-loader.js
@@ -8,14 +8,17 @@ exports.registerVariables = () => {
     const slootsGiftee = require("../variables/sloots-giftee");
     const slootsImageUrl = require("../variables/sloots-image-url");
     const slootsMessage = require("../variables/sloots-message");
+    const slootsAlertMessage = require("../variables/sloots-alert-message");
     const slootsChestQuantity = require("../variables/sloots-quantity");
     const slootsSoundUrl = require("../variables/sloots-sound-url");
+
 
     variableManager.registerReplaceVariable(slootsCardName);
     variableManager.registerReplaceVariable(slootsCardRarity);
     variableManager.registerReplaceVariable(slootsGiftee);
     variableManager.registerReplaceVariable(slootsImageUrl);
     variableManager.registerReplaceVariable(slootsMessage);
+    variableManager.registerReplaceVariable(slootsAlertMessage);
     variableManager.registerReplaceVariable(slootsChestQuantity);
     variableManager.registerReplaceVariable(slootsSoundUrl);
 };


### PR DESCRIPTION
### Description of the Change
because the alert message will always have a value there was no way to get the alert message and user message separately
this will add $slootsAlertMessage, and add a fall back to the alert message if there is no user message supplied   


### Applicable Issues
#1731


### Testing
I have tested with  the streamloots website and sent cards with and without user messages 
this returns the alert message and user messages independently adding more flexibility 

 
### Screenshots

![image](https://user-images.githubusercontent.com/8982158/168406025-8810cbcc-cee6-4fa3-be5e-5bd1984f919a.png)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
