### PR TITLE
fix: chat links now use custom chat text size

### DIFF
--- a/gui/app/directives/chat/feed items/chat-message.js
+++ b/gui/app/directives/chat/feed items/chat-message.js
@@ -103,7 +103,7 @@
 
                                     <span ng-if="part.type === 'text'" style="{{$ctrl.chatSizeStyle}}">{{part.text}}</span>
 
-                                    <a ng-if="part.type === 'link'" ng-href="{{part.url}}" target="_blank">{{part.text}}</a>
+                                    <a ng-if="part.type === 'link'" style="{{$ctrl.chatSizeStyle}}" ng-href="{{part.url}}" target="_blank">{{part.text}}</a>
 
                                     <span
                                         ng-if="part.type === 'emote'"


### PR DESCRIPTION
### Description of the Change
Links in chat in the Dashboard now honor the custom chat text size


### Applicable Issues
N/A


### Testing
Verified link text is now the same size as other text.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/168632562-9ba316e1-5f06-4eb2-a10b-2bbd83975270.png)
