### PR TITLE
fix: copied commands no longer assign bad fallback subcmd id

### DIFF
--- a/gui/app/controllers/commands.controller.js
+++ b/gui/app/controllers/commands.controller.js
@@ -102,6 +102,11 @@
             $scope.duplicateCustomCommand = command => {
                 const copiedCommand = objectCopyHelper.copyObject("command", command);
 
+                // Make sure fallback ID is correct
+                if (copiedCommand.fallbackSubcommand?.id != null) {
+                    copiedCommand.fallbackSubcommand.id = "fallback-subcommand";
+                }
+
                 while (commandsService.triggerExists(copiedCommand.trigger)) {
                     copiedCommand.trigger += "copy";
                 }


### PR DESCRIPTION
### Description of the Change
When copying a command, we now reassign the correct `fallback-subcommand` ID to the fallback of the copy so that fallbacks will execute properly.


### Applicable Issues
#1759


### Testing
Copied a command and verified that fallback subcommand worked immediately after copy without need to delete/recreate fallback subcommand.


### Screenshots
N/A