### PR TITLE
fix: Active User Role for Streamer account

### DIFF
--- a/backend/chat/chat-helpers.js
+++ b/backend/chat/chat-helpers.js
@@ -378,7 +378,7 @@ exports.buildFirebotChatMessageFromText = async (text = "") => {
     /**@type {FirebotChatMessage} */
     const streamerFirebotChatMessage = {
         id: uuid(),
-        username: streamer.displayName,
+        username: streamer.username,
         userId: streamer.userId,
         rawText: text,
         profilePicUrl: streamer.avatar,


### PR DESCRIPTION
### Description of the Change
Using username instead of displayName when chat message is sent internally from Firebot chat field.


### Applicable Issues
#1771 


### Testing
When testing prior to change Streamers with capital letters in their username always fails to show up as an active user in the `Active User Role`, after change has applied testing with a username with capital letters they show up as active users when testing for the `Active User Role`.