### PR TITLE
fix: Active User Role for streamer account (#1771)

### DIFF
--- a/backend/chat/chat-listeners/active-user-handler.js
+++ b/backend/chat/chat-listeners/active-user-handler.js
@@ -181,7 +181,7 @@ exports.addActiveUser = async (chatUser, includeInOnline = false, forceActive = 
 
     const userDetails = {
         id: chatUser.userId,
-        username: chatUser.userName,
+        username: chatUser.userName.toLowerCase(),
         displayName: chatUser.displayName,
         twitchRoles: [
             ...(chatUser.isBroadcaster ? ['broadcaster'] : []),
@@ -201,24 +201,24 @@ exports.addActiveUser = async (chatUser, includeInOnline = false, forceActive = 
         await updateUserOnlineStatus(userDetails, true);
     }
 
-    await userDatabase.incrementDbField(chatUser.userId, "chatMessages");
+    await userDatabase.incrementDbField(userDetails.id, "chatMessages");
 
     if (!forceActive && user.disableActiveUserList) {
         return;
     }
 
-    const userActive = activeUsers.get(chatUser.userId);
+    const userActive = activeUsers.get(userDetails.id);
     if (!userActive) {
-        logger.debug(`Marking user ${chatUser.displayName} as active with ttl of ${ttl} secs`, ttl);
-        activeUsers.set(chatUser.userId, chatUser.userName, ttl);
-        activeUsers.set(chatUser.userName, chatUser.userId, ttl);
-        frontendCommunicator.send("twitch:chat:user-active", chatUser.userId);
+        logger.debug(`Marking user ${userDetails.displayName} as active with ttl of ${ttl} secs`, ttl);
+        activeUsers.set(userDetails.id, userDetails.username, ttl);
+        activeUsers.set(userDetails.username, userDetails.id, ttl);
+        frontendCommunicator.send("twitch:chat:user-active", userDetails.id);
     } else {
         // user is still active reset ttl
-        logger.debug(`Updating user ${chatUser.displayName}'s "active" ttl to ${ttl} secs`, ttl);
-        activeUsers.ttl(chatUser.userId, ttl);
-        activeUsers.ttl(chatUser.userName, ttl);
-        frontendCommunicator.send("twitch:chat:user-active", chatUser.userId);
+        logger.debug(`Updating user ${userDetails.displayName}'s "active" ttl to ${ttl} secs`, ttl);
+        activeUsers.ttl(userDetails.id, ttl);
+        activeUsers.ttl(userDetails.username, ttl);
+        frontendCommunicator.send("twitch:chat:user-active", userDetails.id);
     }
 };
 


### PR DESCRIPTION
### Description of the Change
Made sure that userDetails has the correct casing for username by applying .toLowerCase().


### Applicable Issues
#1771 


### Testing
Tested to make sure that the streamer shows up with the active user role as well as with the correct casing in viewer list, chat feed.


### Screenshots
Tested with setting for disabling active user disabled:
![image](https://user-images.githubusercontent.com/4147439/169665730-16f4f971-bdea-4e05-81ee-4e3d11f4f382.png)
Tested with setting for disabling active user enabled:
![image](https://user-images.githubusercontent.com/4147439/169665935-3b870c25-75d5-42df-b321-2357ea20f428.png)
