### PR TITLE
feat: optional quoted command arg handling

### DIFF
--- a/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.html
+++ b/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.html
@@ -199,6 +199,18 @@
               />
               <div class="control__indicator"></div>
             </label>
+            <label class="control-fb control--checkbox"
+              >Treat quoted text as single argument
+              <tooltip
+                text="'When this option is enabled, text inside of double quotes will be treated as a single argument without the quotes. Example: !command &quot;This is an argument&quot; will have a single argument with the value: This is an argument'"
+              ></tooltip>
+              <input
+                type="checkbox"
+                ng-model="$ctrl.command.treatQuotedTextAsSingleArg"
+                aria-label="..."
+              />
+              <div class="control__indicator"></div>
+            </label>
           </div>
           <div class="controls-fb-inline mt-4"></div>
         </div>

--- a/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.js
+++ b/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.js
@@ -33,7 +33,8 @@
                     sendFailMessage: true
                 },
                 aliases: [],
-                sortTags: []
+                sortTags: [],
+                treatQuotedTextAsSingleArg: false
             };
 
             $scope.trigger = "command";
@@ -133,6 +134,10 @@
 
                 if ($ctrl.command.aliases == null) {
                     $ctrl.command.aliases = [];
+                }
+
+                if ($ctrl.command.treatQuotedTextAsSingleArg == null) {
+                    $ctrl.command.treatQuotedTextAsSingleArg = false;
                 }
 
                 const modalId = $ctrl.resolve.modalId;


### PR DESCRIPTION
### Description of the Change
Adds optional quoted argument handling for custom commands. When the **Treat quoted text as single argument** option is selected for a custom command, an argument enclosed in double quotes is treated as a single argument. (i.e. `!command arg1 "This is arg2" arg3` has the arguments `arg1`, `This is arg2`, and `arg3`). 


### Applicable Issues
N/A


### Testing
Verified that commands either specifically set to false or those without the flag set default to false, and they continue to process arguments as before, simply splitting on spaces.
Verified that commands with the flag set to true will treat quoted text as a single argument without quotes.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/173251723-95cf4d19-c1fb-4372-9d3f-da8f07c7beac.png)
