### PR TITLE
Feat: #1792 adds Sequential Effect Queue type

### DIFF
--- a/backend/effects/queues/effect-queue-runner.js
+++ b/backend/effects/queues/effect-queue-runner.js
@@ -66,6 +66,16 @@ class EffectQueue {
                 setTimeout(() => {
                     resolve(this.runQueue());
                 }, (duration || 0) * 1000);
+            } else if (this.mode === "sequential") {
+                effectRunner.runEffects(runEffectsContext)
+                    .catch(err => {
+                        logger.warn(`Error while processing effects for queue ${this.id}`, err);
+                    })
+                    .finally(() => {
+                        setTimeout(() => {
+                            resolve(this.runQueue());
+                        }, (this.interval || 0) * 1000);
+                    });
             } else {
                 resolve();
             }

--- a/gui/app/controllers/effect-queues.controller.js
+++ b/gui/app/controllers/effect-queues.controller.js
@@ -39,7 +39,7 @@
                 {
                     name: "INTERVAL",
                     icon: "fa-clock",
-                    cellTemplate: `{{data.mode === 'interval' ? data.interval + 's' : 'n/a'}}`,
+                    cellTemplate: `{{(data.mode === 'interval' || data.mode === 'sequential') ? data.interval + 's' : 'n/a'}}`,
                     cellController: () => {}
                 }
             ];

--- a/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
+++ b/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
@@ -47,7 +47,7 @@
                     </div>
                 </div>
 
-                <div class="mt-6" ng-show="$ctrl.effectQueue.mode != null && $ctrl.effectQueue.mode ==='interval'">
+                <div class="mt-6" ng-show="$ctrl.effectQueue.mode != null && ($ctrl.effectQueue.mode ==='interval' || $ctrl.effectQueue.mode ==='sequential')">
                     <div class="modal-subheader pb-2 pt-0 px-0">Interval (secs)</div>
                     <div style="width: 100%; position: relative;">
                         <div class="form-group">

--- a/gui/app/services/effect-queues.service.js
+++ b/gui/app/services/effect-queues.service.js
@@ -50,6 +50,12 @@
                     display: "Interval",
                     description: "Runs effect lists on a set interval.",
                     iconClass: "fa-stopwatch"
+                },
+                {
+                    id: "sequential",
+                    display: "Sequential",
+                    description: "Runs effects in the list sequentially. Priority items will be added before non-priority. Optional delay defaults to 0s.",
+                    iconClass: "fa-arrow-down-1-9"
                 }
             ];
 


### PR DESCRIPTION
### Description of the Change

- Added a sequential option to effect-queue-runner.js / runQueue() utilising .finally so it doesn't proceed until the effect has finished, with optional delay, if not set or 0 will proceed immediately
- Added to gui in various locations
- Chose icon in the modal for this Effect Queue type as iconClass: "fa-arrow-down-1-9" however if that's not appropriate/not available then another would need to be selected

### Applicable Issues
#1792


### Testing

- Added a new effect queue with new type
- Added a new effect queue of a different type, and edited it to be this effect type
- Edited an effect queue of this type, and changed it to another
- Ran three commands which run a set of effects under the three existing types, and noted non-sequential behaviour
- Ran three commands which run a set of effects under the new Sequential type with 1s interval, and noted sequential behaviour
- Ran three commands which run a set of effects under the new Sequential type with 15s interval, and noted sequential behaviour with 15 seconds delay between the end of the last effect and start of the next effect

I did note the following error while running effects, however this appeared for me regardless of the type of Effect Queue and did not seem to be introduced by my code.

```js
warn: Error while processing effects for queue 523e3430-b7d8-11ec-9873-c1018255e0b7 
{
  message: "Cannot read property 'definition' of undefined",
  stack: "TypeError: Cannot read property 'definition' of undefined\n" +
    '    at validateEffectCanRun (F:\\vscode\\firebot\\Firebot\\backend\\common\\effect-runner.js:53:67)\n' +
    '    at Object.runEffects (F:\\vscode\\firebot\\Firebot\\backend\\common\\effect-runner.js:115:14)'
}
```

### Screenshots

Showing the GUI modal.

![Feat #1792 adds Sequential Effect Queue type-img01](https://user-images.githubusercontent.com/20862038/173546070-37477b26-d701-4929-850f-4df7b9cc8764.PNG)

Showing the type of Sequential showing in the effect queues grid list.

![Feat #1792 adds Sequential Effect Queue type-img02](https://user-images.githubusercontent.com/20862038/173546353-0e6d53eb-a0bb-4f09-bd76-7f989ae101e4.PNG)

