### PR TITLE
Fallback name for anonymous community gift subs

### DIFF
--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -20,8 +20,10 @@ exports.triggerCommunitySubGift = (subInfo) => {
 /** @param {import("@twurple/chat").ChatSubGiftInfo} subInfo */
 exports.triggerSubGift = (subInfo) => {
     if (settings.ignoreSubsequentSubEventsAfterCommunitySub()) {
-        logger.debug(`Attempting to process community gift sub from ${subInfo.gifterDisplayName} at ${moment().format("HH:mm:ss:SS")}`);
-        const cacheKey = `${subInfo.gifterDisplayName}:${subInfo.plan}`;
+        const gifterDisplayName = subInfo.gifterDisplayName ? subInfo.gifterDisplayName : "An Anonymous Gifter";
+
+        logger.debug(`Attempting to process community gift sub from ${gifterDisplayName} at ${moment().format("HH:mm:ss:SS")}`);
+        const cacheKey = `${gifterDisplayName}:${subInfo.plan}`;
 
         const cache = communitySubCache.get(cacheKey);
         if (cache != null) {
@@ -37,11 +39,11 @@ exports.triggerSubGift = (subInfo) => {
                         communitySubCache.set(cacheKey, {subCount: newCount, giftReceivers: giftReceivers});
                     } else {
                         eventManager.triggerEvent("twitch", "community-subs-gifted", {
-                            username: subInfo.gifterDisplayName,
+                            username: gifterDisplayName,
                             subCount: giftReceivers.length,
                             subPlan: subInfo.planName,
                             isAnonymous: !!subInfo.gifterUserId,
-                            gifterUsername: subInfo.gifterDisplayName,
+                            gifterUsername: gifterDisplayName,
                             giftReceivers: giftReceivers
                         });
 


### PR DESCRIPTION
### Description of the Change
Use the same "An Anonymous Gifter" fallback name in `triggerSubGift` as `triggerCommunitySubGift`. `subInfo.gifterDisplayName` is `null` for anonymous gift subs which, for example, would cause the `cacheKey` to erroneously be `:1000` for anon tier 1 subs. 

### Applicable Issues
#1662

### Testing
Before:
- Gifted 2 community subs anonymously
- Observed `No community gift sub data found in cache` in log

After:
- Gifted 2 community subs anonymously
- Did not observe `No community gift sub data found in cache`, instead saw `Community gift sub event triggered, deleting cache`

### Screenshots
None
