### PR TITLE
feat: async "run" API endpoint for preset lists

### DIFF
--- a/server/api/v1/controllers/effectsApiController.js
+++ b/server/api/v1/controllers/effectsApiController.js
@@ -76,7 +76,7 @@ exports.getPresetLists = async function(req, res) {
     return res.json(formattedPresetLists);
 };
 
-exports.runPresetList = async function(req, res) {
+async function runPresetEffectList(req, res, waitForCompletion = false) {
     const presetListId = req.params.presetListId;
 
     if (presetListId == null) {
@@ -125,9 +125,21 @@ exports.runPresetList = async function(req, res) {
     };
 
     try {
-        await effectRunner.processEffects(processEffectsRequest);
+        if (waitForCompletion === true) {
+            await effectRunner.processEffects(processEffectsRequest);
+        } else {
+            effectRunner.processEffects(processEffectsRequest);
+        }
         res.status(200).send({ status: "success" });
     } catch (err) {
         res.status(500).send({ status: "error", message: err.message });
     }
+}
+
+exports.runPresetListSynchronous = async function(req, res) {
+    runPresetEffectList(req, res, true);
+};
+
+exports.triggerPresetListAsync = async function(req, res) {
+    runPresetEffectList(req, res, false);
 };

--- a/server/api/v1/v1Router.js
+++ b/server/api/v1/v1Router.js
@@ -38,8 +38,12 @@ router.route("/effects/:effectId")
     .get(effects.getEffect);
 
 router.route("/effects/preset/:presetListId")
-    .get(effects.runPresetList)
-    .post(effects.runPresetList);
+    .get(effects.runPresetListSynchronous)
+    .post(effects.runPresetListSynchronous);
+
+router.route("/effects/preset/:presetListId/run")
+    .get(effects.triggerPresetListAsync)
+    .post(effects.triggerPresetListAsync);
 
 
 // Commands


### PR DESCRIPTION
### Description of the Change
Adds new `/effects/preset/:presetListId/run` API endpoint for preset effect lists. This matches the `/run` endpoint that commands have and will execute preset effect lists but asynchronously - it will NOT wait for the list to finish execution before returning an HTTP response. The existing `/effects/preset/:presetListId' endpoint will continue to work as it does and waits for a list to complete before returning a response.


### Applicable Issues
N/A


### Testing
Verified new endpoint triggers preset effect list and returns response immediately.
Verified existing endpoint still works as before.


### Screenshots
N/A