### PR TITLE
fix: Anonymous community sub detection in event

### DIFF
--- a/backend/events/twitch-events/gift-sub.js
+++ b/backend/events/twitch-events/gift-sub.js
@@ -42,7 +42,7 @@ exports.triggerSubGift = (subInfo) => {
                             username: gifterDisplayName,
                             subCount: giftReceivers.length,
                             subPlan: subInfo.planName,
-                            isAnonymous: !!subInfo.gifterUserId,
+                            isAnonymous: !subInfo.gifterUserId,
                             gifterUsername: gifterDisplayName,
                             giftReceivers: giftReceivers
                         });


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Change the condition on the community gift sub event to properly reflect the status of the sub being anonymous or not.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1796
Regression from https://github.com/crowbartools/Firebot/pull/1663

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
To reproduce: gift a non-anonymous community sub from Twitch. **You can not reproduce this without Twitch chat events.**

I was unable to test the fix due to testing requiring the usage of real Twitch events, but logic dictates this should fix the issue.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
