### PR TITLE
Fix: write to file delete by text #1790

### DIFF
--- a/backend/common/handlers/fileWriterProcessor.js
+++ b/backend/common/handlers/fileWriterProcessor.js
@@ -26,6 +26,9 @@ function removeLinesWithText(filepath, text) {
     const contents = fs.readFileSync(filepath, "utf8");
     return contents
         .split('\n')
+        .map(l => {
+            return l.replace('\r', "");
+        })
         .filter(l => l != null && l.trim() !== "")
         .filter(l => l !== text)
         .join('\n') + "\n";


### PR DESCRIPTION
### Description of the Change

Split on `\n` and remove `\r`. 

The issue is that a file with `\r\n` (`0D 0A`) as the EOL,
sent from a windows os will not replace the text while Splitting on just `\n`.

the text will retain the 0D of the EOL `\r`.

.Trim() would have been another option but Space and Tab at
the end of a line would cause the same problem.
if the user is expecting a space and its removed then it wont delete
the line, same with tab.


This PR should resolve issue #1790

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1790

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
```
63 68 65 73 74 0D 0A 68 61 6E 64 0D 0A 61 72 6D            chest..hand..arm
0D 0A 6E 65 63 6B 0D 0A 68 65 61 64 0D 0A 6C 65            ..neck..head..le
67 0D 0A 66 6F 6F 74 0D 0A 6B 6E 65 65 0D 0A 73            g..foot..knee..s
68 6F 75 6C 64 65 72 0D 0A 74 68 69 67 68 0D 0A            houlder..thigh..
66 69 6E 67 65 72 73 0D 0A 65 61 72 73 0D 0A 63            fingers..ears..c
68 65 65 6B 0D 0A 65 79 65 73 0D 0A 6E 6F 73 65            heek..eyes..nose
0D 0A 6C 69 70 73 0D 0A 74 6F 6E 67 75 65 0D 0A            ..lips..tongue..
63 68 69 6E 0D 0A 65 6C 62 6F 77 0A                        chin..elbow.
```
0D 0A is windows EOL cactors \r\n Carriage Return New Line, reading this file in and Splitting on the 0A \n 
results in 
63 68 65 73 74 0D 0A 68 61 6E 64 0D          chest. or chest\r 
then if you want to remove that with .filter(l => l !== "chest") 
"chest\r" is not Equal to "chest" 
and will not remove the line 



### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
