### PR TITLE
Fix: userFollow restriction

### DIFF
--- a/backend/twitch-api/resource/users.js
+++ b/backend/twitch-api/resource/users.js
@@ -46,7 +46,7 @@ const doesUserFollowChannel = async (username, channelName) => {
 
     const userFollow = await client.users.userFollowsBroadcaster(user.id, channel.id);
 
-    return userFollow != null;
+    return userFollow != null ? userFollow : false;
 };
 
 exports.getFollowDateForUser = getFollowDateForUser;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Return userFollow != null;
will return true or false based on if userFollow is null
It simply evaluates the expression.
If userFollow is null it returns false
if userFollow isn't null, it returns true.
this is not if the value form twitch is true or false or null

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1799

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->

![image](https://user-images.githubusercontent.com/8982158/177987352-cab3021d-da91-4036-b375-1a65a0dc729e.png)

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
