### PR TITLE
Feat: include overlay resources in backup option

### DIFF
--- a/backend/backupManager.js
+++ b/backend/backupManager.js
@@ -109,8 +109,15 @@ function startBackup(manualActivation = false, callback) {
     const folderPath = path.resolve(dataAccess.getPathInUserData("/"));
     //archive.directory(folderPath, "profiles");
 
+    let varIgnore = ['overlay-resources/**', 'backups/**', 'clips/**', 'logs/**', 'overlay.html'];
+    const includeResources = settings.backupIncludeResources();
+
+    if (includeResources) {
+        varIgnore = ['backups/**', 'clips/**', 'logs/**', 'overlay.html'];
+    }
+
     archive.glob('**/*', {
-        ignore: ['backups/**', 'clips/**', 'logs/**', 'overlay.html'],
+        ignore: varIgnore,
         cwd: folderPath
     });
 

--- a/backend/common/settings-access.js
+++ b/backend/common/settings-access.js
@@ -146,6 +146,15 @@ settings.backupOnExit = function() {
     return backupOnExit != null ? backupOnExit : true;
 };
 
+settings.backupIncludeResources = function() {
+    const save = getDataFromFile("/settings/backupIncludeResources");
+    return save != null ? save : true;
+};
+
+settings.setBackupIncludeResources = function(backupIncludeResources) {
+    pushDataToFile("/settings/backupIncludeResources", backupIncludeResources === true);
+};
+
 settings.backupBeforeUpdates = function() {
     const backupBeforeUpdates = getDataFromFile("/settings/backupBeforeUpdates");
     return backupBeforeUpdates != null ? backupBeforeUpdates : true;

--- a/gui/app/directives/settings/categories/backups-settings.js
+++ b/gui/app/directives/settings/categories/backups-settings.js
@@ -50,6 +50,19 @@
                             <div class="control__indicator"></div>
                         </label>
                         <label class="control-fb control--checkbox"
+                            >Include overlay resources folder
+                            <tooltip
+                                text="'If your overlay-resource folder has become quite large, and slowing down the backup system turn this off. Note: you will need to manually backup this folder.'"
+                            ></tooltip>
+                            <input
+                                type="checkbox"
+                                ng-click="settings.setBackupIncludeResources(!settings.backupIncludeResources())"
+                                ng-checked="settings.backupIncludeResources()"
+                                aria-label="..."
+                            />
+                            <div class="control__indicator"></div>
+                        </label>
+                        <label class="control-fb control--checkbox"
                             >Before viewer purges
                             <tooltip
                                 text="'Firebot will always backup before you do viewer purges (Database > View Purge Options)'"

--- a/gui/app/services/settings.service.js
+++ b/gui/app/services/settings.service.js
@@ -602,6 +602,15 @@
                 pushDataToFile("/settings/backupOnExit", backupOnExit === true);
             };
 
+            service.backupIncludeResources = function() {
+                const save = getDataFromFile("/settings/backupIncludeResources");
+                return save != null ? save : true;
+            };
+
+            service.setBackupIncludeResources = function(backupIncludeResources) {
+                pushDataToFile("/settings/backupIncludeResources", backupIncludeResources === true);
+            };
+
             service.backupBeforeUpdates = function() {
                 const backupBeforeUpdates = getDataFromFile(
                     "/settings/backupBeforeUpdates"


### PR DESCRIPTION
### Description of the Change
Add an option to include the overlay-resources folder in the backups.

Reason for this is:
I have been heavily using the overlay-resources folder for my rescoreses on my overlays and overlay instances. I keep a separate dev folder on a separate drive. over time this folder has become maybe 3 gig in size. this is due to images and textures and sound bits and models. it would be nice to be able to turn off backing this folder up or moveing it out of the root of firebot all together and asigninging within firebot. so i can point at my dev folder. when i exit firebot it takes a good bit maybe 10 min to a half hour to fully shut down because of all the assets that are in that folder.

due to CORS errors in the overlay scripts all assets have to be within the webserver folder structure.



a "checkbox" with the caption of "Include overlay resources folder" would be added to the backup settings option. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1807 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
With the checkbox checked the resources folder was included in the backup zip
With the checkbox unchecked the resources folder was not included in the backup zip

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://user-images.githubusercontent.com/8982158/178091954-24d21958-19f3-4b22-b9a2-fade748881d7.png)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
