### PR TITLE
feat: HTML/URL decode variables

### DIFF
--- a/backend/variables/builtin-variable-loader.js
+++ b/backend/variables/builtin-variable-loader.js
@@ -132,6 +132,8 @@ exports.loadReplaceVariables = () => {
         'text-uppercase',
         'text-capitalize',
         'text-contains',
+        'text-decode-from-html',
+        'text-decode-from-url',
         'text-encode-for-html',
         'text-encode-for-url',
         'text-split',

--- a/backend/variables/builtin/text-decode-from-html.js
+++ b/backend/variables/builtin/text-decode-from-html.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+const he = require('he');
+
+const model = {
+    definition: {
+        handle: "decodeFromHtml",
+        description: "Decodes input text from an HTML-encoded string",
+        usage: "decodeFromHtml[text]",
+        categories: [VariableCategory.TEXT],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (_, text) => {
+        return text ? he.decode(text) : "";
+    }
+};
+
+module.exports = model;

--- a/backend/variables/builtin/text-decode-from-url.js
+++ b/backend/variables/builtin/text-decode-from-url.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+
+const model = {
+    definition: {
+        handle: "decodeFromUrl",
+        description: "Decodes input text from a URL-encoded string",
+        usage: "decodeFromUrl[text]",
+        categories: [VariableCategory.TEXT],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (_, text) => {
+        return text ? decodeURIComponent(text) : "";
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
Adds new `$decodeFromHtml` and `$decodeFromUrl` variables. Same as their respective `encodeFor` versions, just in reverse.


### Applicable Issues
N/A


### Testing
Verified that new variables decoded text correctly


### Screenshots
N/A