### PR TITLE
feat: Add an option to not include the overlay-resources folder in the automatic backups.

### DIFF
--- a/backend/backupManager.js
+++ b/backend/backupManager.js
@@ -109,8 +109,16 @@ function startBackup(manualActivation = false, callback) {
     const folderPath = path.resolve(dataAccess.getPathInUserData("/"));
     //archive.directory(folderPath, "profiles");
 
+    const varIgnoreInArchive = ['backups/**', 'clips/**', 'logs/**', 'overlay.html'];
+    const ignoreResources = settings.backupIgnoreResources();
+
+    if (ignoreResources && !manualActivation) {
+        logger.info("Ignoring overlay-resources folder");
+        varIgnoreInArchive.push('overlay-resources/**');
+    }
+
     archive.glob('**/*', {
-        ignore: ['backups/**', 'clips/**', 'logs/**', 'overlay.html'],
+        ignore: varIgnoreInArchive,
         cwd: folderPath
     });
 

--- a/backend/common/settings-access.js
+++ b/backend/common/settings-access.js
@@ -146,6 +146,15 @@ settings.backupOnExit = function() {
     return backupOnExit != null ? backupOnExit : true;
 };
 
+settings.backupIgnoreResources = function() {
+    const save = getDataFromFile("/settings/backupIgnoreResources");
+    return save != null ? save : true;
+};
+
+settings.setBackupIgnoreResources = function(backupIgnoreResources) {
+    pushDataToFile("/settings/backupIgnoreResources", backupIgnoreResources === false);
+};
+
 settings.backupBeforeUpdates = function() {
     const backupBeforeUpdates = getDataFromFile("/settings/backupBeforeUpdates");
     return backupBeforeUpdates != null ? backupBeforeUpdates : true;

--- a/gui/app/directives/settings/categories/backups-settings.js
+++ b/gui/app/directives/settings/categories/backups-settings.js
@@ -23,7 +23,28 @@
                             on-update="settings.setMaxBackupCount(option)"
                         ></dropdown-select>
                     </firebot-setting>
-
+                    
+                    <firebot-setting
+                        name="Automatic Backup Options"
+                        description="Choose what Firebot should ignore in automatic backups."
+                    >
+                        <div>
+                        <label class="control-fb control--checkbox"
+                            >Don't include overlay resource folder
+                            <tooltip
+                                text="'If your overlay-resource folder has become quite large, and slowing down the backup system turn this on. Note: Manual backups are not affected .'"
+                            ></tooltip>
+                            <input
+                                type="checkbox"
+                                ng-click="settings.setBackupIgnoreResources(!settings.backupIgnoreResources())"
+                                ng-checked="settings.backupIgnoreResources()"
+                                aria-label="..."
+                            />
+                            <div class="control__indicator"></div>
+                        </label>
+                        </div>
+                    </firebot-setting>
+                    
                     <firebot-setting
                         name="Automatic Backups"
                         description="Choose when Firebot should make automatic backups."

--- a/gui/app/services/settings.service.js
+++ b/gui/app/services/settings.service.js
@@ -602,6 +602,15 @@
                 pushDataToFile("/settings/backupOnExit", backupOnExit === true);
             };
 
+            service.backupIgnoreResources = function() {
+                const save = getDataFromFile("/settings/backupIgnoreResources");
+                return save != null ? save : true;
+            };
+
+            service.setBackupIgnoreResources = function(backupIgnoreResources) {
+                pushDataToFile("/settings/backupIgnoreResources", backupIgnoreResources === true);
+            };
+
             service.backupBeforeUpdates = function() {
                 const backupBeforeUpdates = getDataFromFile(
                     "/settings/backupBeforeUpdates"


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->

Add an option to not include the overlay-resources folder in the automatic backups.

Reason for this is:
I have been heavily using the overlay-resources folder for my rescoreses on my overlays and overlay instances. I keep a separate dev folder on a separate drive. over time this folder has become maybe 3 gig in size. this is due to images and textures and sound bits and models. it would be nice to be able to turn off backing this folder up or moveing it out of the root of firebot all together and asigninging within firebot. so i can point at my dev folder. when i exit firebot it takes a good bit maybe 10 min to a half hour to fully shut down because of all the assets that are in that folder.

due to CORS errors in the overlay scripts all assets have to be within the webserver folder structure.

a "checkbox" with the caption of "ignore overlay resources folder" would be added to the backup settings option.

let me know if there are any other changes needed...

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1807

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->

With the checkbox checked the resources folder was not included in the backup zip
With the checkbox unchecked the resources folder was included in the backup zip

default is unchecked. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://user-images.githubusercontent.com/8982158/178624136-5fefde13-2224-44f0-b685-feac9ee4a8d8.png)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
