### PR TITLE
feat: Cooldown command radio buttons in the wrong place #1770

### DIFF
--- a/backend/effects/builtin/cooldown-command.js
+++ b/backend/effects/builtin/cooldown-command.js
@@ -39,7 +39,7 @@ const model = {
                 </ui-select-choices>
             </ui-select>
 
-            <div ng-show="subcommands && !!subcommands.length" class="mb-4 pl-4">
+            <div ng-show="subcommands && !!subcommands.length" class="mt-4 pl-4">
                 <label class="control-fb control--radio">Cooldown base command
                     <input type="radio" ng-model="showSubcommands" ng-value="false" ng-click="effect.subcommandId = null"/>
                     <div class="control__indicator"></div>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->

moved the Cooldown base command radio buttons down so they are not on top of the dropdown selection
by changing from margin-bottom to margin-top 
### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1770 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
before 
![image](https://user-images.githubusercontent.com/8982158/178685888-0431f974-b2cb-4408-9d0a-1bafaf300cdc.png)
after
![image](https://user-images.githubusercontent.com/8982158/178685969-c865531e-6a41-49c6-a571-099731c84752.png)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
