### PR TITLE
feat: add All Files to Run Program browse dialog (#1826)

### DIFF
--- a/backend/effects/builtin/run-program.js
+++ b/backend/effects/builtin/run-program.js
@@ -43,7 +43,7 @@ const model = {
     globalSettings: {},
     optionsTemplate: `
         <eos-container header="Program File Path">
-            <file-chooser model="effect.programPath" options="{ filters: [ {name:'Program',extensions:['exe', 'bat', 'cmd']} ]}"></file-chooser>
+            <file-chooser model="effect.programPath" options="{ filters: [ { name:'Program', extensions:['exe', 'bat', 'cmd'] }, { name:'All Files', extensions:['*'] } ] }"></file-chooser>
         </eos-container>
         <eos-container header="Program Arguments (Optional)" pad-top="true">
             <div class="input-group">


### PR DESCRIPTION
### Description of the Change
Adds an "All Files" option to the Run Program effect's browse dialog. This will be especially useful for Linux users, where executables don't typically use Windows extensions.


### Applicable Issues
#1826


### Testing
Verified that the Run Program browse dialog shows both the original "Programs" and the new "All Files" options.


### Screenshots
N/A