### PR TITLE
fix: clarify default slots maxWager message

### DIFF
--- a/backend/games/builtin/slots/slots.js
+++ b/backend/games/builtin/slots/slots.js
@@ -162,7 +162,7 @@ module.exports = {
                     title: "Amount Too High",
                     description: "When the wager amount is too high (leave empty for no message).",
                     useTextArea: true,
-                    default: "{username}, your wager amount must be at least {maxWager}.",
+                    default: "{username}, your wager amount can be no more than {maxWager}.",
                     tip: "Available variables: {username}, {maxWager}",
                     sortRank: 7
                 },


### PR DESCRIPTION
### Description of the Change
Updated the default maxWager message in the Slots game to read correctly, similar to the same message for other games


### Applicable Issues
N/A


### Testing
N/A


### Screenshots
N/A