### PR TITLE
feat: dynamic overlay URL support

### DIFF
--- a/backend/common/handlers/custom-scripts/script-types.d.ts
+++ b/backend/common/handlers/custom-scripts/script-types.d.ts
@@ -59,7 +59,7 @@ export type CustomScript = {
   getDefaultParameters(): ScriptParameters;
   run(
     runRequest: RunRequest
-  ): void | ScriptReturnObject | PromiseLike<ScriptReturnObject>;
+  ): void | PromiseLike<void> | ScriptReturnObject | PromiseLike<ScriptReturnObject>;
   parametersUpdated?: (parameters: Record<string, unknown>) => void | PromiseLike<void>;
   stop?: () => void | PromiseLike<void>;
 };

--- a/backend/effects/builtin/clips.js
+++ b/backend/effects/builtin/clips.js
@@ -260,9 +260,15 @@ const clip = {
                 const styles = (width ? `width: ${width}px;` : '') +
                     (height ? `height: ${height}px;` : '');
 
+                const muted = "false";
+                let clipUrl = `https://clips.twitch.tv/embed?clip=${clipSlug}&controls=false&autoplay=true&muted=${muted}&parent=localhost`;
+
+                if (location.hostname !== "localhost") {
+                    clipUrl += "&parent=" + location.hostname;
+                }
                 const videoElement = `
                     <iframe
-                        src="https://clips.twitch.tv/embed?clip=${clipSlug}&parent=localhost&autoplay=true&muted=false&controls=false"
+                        src="${clipUrl}"
                         height="${height || ""}"
                         width="${width || ""}"
                         style="border: none;${styles}"

--- a/resources/overlay/js/main.js
+++ b/resources/overlay/js/main.js
@@ -2,7 +2,7 @@ firebotOverlay = new EventEmitter();
 
 let params = new URL(location).searchParams;
 
-const OVERLAY_PORT = window.location.port;
+const OVERLAY_PORT = window.location.port || (window.location.protocol === 'https:' ? 443 : 80);
 
 startedVidCache = { test: true };
 

--- a/resources/overlay/js/main.js
+++ b/resources/overlay/js/main.js
@@ -2,7 +2,7 @@ firebotOverlay = new EventEmitter();
 
 let params = new URL(location).searchParams;
 
-OVERLAY_PORT = 7472;
+const OVERLAY_PORT = window.location.port;
 
 startedVidCache = { test: true };
 
@@ -11,15 +11,12 @@ startedVidCache = { test: true };
 function overlaySocketConnect(){
 	if ("WebSocket" in window){
 		// Let us open a web socket
-		let port = new URL(window.location.href).port;
-
 		const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 
-		ws = new ReconnectingWebSocket(`${websocketProtocol}//${window.location.hostname}:${port}`);
+		ws = new ReconnectingWebSocket(`${websocketProtocol}//${window.location.hostname}:${OVERLAY_PORT}`);
 		ws.onopen = function(){
-			OVERLAY_PORT = port;
 			notification('close');
-			console.log(`Connection is opened on port ${port}...`);
+			console.log(`Connection is opened on port ${OVERLAY_PORT}...`);
 		};
 
 		// When we get a message from the Firebot GUI...
@@ -57,11 +54,11 @@ function overlaySocketConnect(){
 
 		// Connection closed for some reason. Reconnecting Websocket will try to reconnect.
 		ws.onclose = function(){
-		  console.log(`Connection is closed on port ${port}...`);
+		  console.log(`Connection is closed on port ${OVERLAY_PORT}...`);
 		};
 
 		ws.onerror = function(){
-			notification('open', `Connecting to Firebot... (${port}).`);
+			notification('open', `Connecting to Firebot... (${OVERLAY_PORT}).`);
 		}
 
 	} else {
@@ -80,12 +77,12 @@ function sendWebsocketEvent(name, data) {
 
 
 function loadFonts() {
-	$.get(`${window.location.protocol}//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts`, (fonts) => {
+	$.get(`//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts`, (fonts) => {
 
 		let fontStyleBlock = `<style type="text/css">`;
 
 		fonts.forEach(font => {
-			let fontPath = `${window.location.protocol}//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts/${font.name}`
+			let fontPath = `//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts/${font.name}`
 			fontStyleBlock +=
                 `@font-face {
                     font-family: '${font.name}';

--- a/resources/overlay/js/main.js
+++ b/resources/overlay/js/main.js
@@ -2,7 +2,8 @@ firebotOverlay = new EventEmitter();
 
 let params = new URL(location).searchParams;
 
-const OVERLAY_PORT = window.location.port || (window.location.protocol === 'https:' ? 443 : 80);
+const overlayPort = window.location.port || (window.location.protocol === 'https:' ? 443 : 80);
+const baseUrl = window.location.hostname + (overlayPort ? `:${overlayPort}` : '');
 
 startedVidCache = { test: true };
 
@@ -13,10 +14,10 @@ function overlaySocketConnect(){
 		// Let us open a web socket
 		const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 
-		ws = new ReconnectingWebSocket(`${websocketProtocol}//${window.location.hostname}:${OVERLAY_PORT}`);
+		ws = new ReconnectingWebSocket(`${websocketProtocol}//${baseUrl}`);
 		ws.onopen = function(){
 			notification('close');
-			console.log(`Connection is opened on port ${OVERLAY_PORT}...`);
+			console.log(`Connection is opened on port ${overlayPort}...`);
 		};
 
 		// When we get a message from the Firebot GUI...
@@ -54,11 +55,11 @@ function overlaySocketConnect(){
 
 		// Connection closed for some reason. Reconnecting Websocket will try to reconnect.
 		ws.onclose = function(){
-		  console.log(`Connection is closed on port ${OVERLAY_PORT}...`);
+		  console.log(`Connection is closed on port ${overlayPort}...`);
 		};
 
 		ws.onerror = function(){
-			notification('open', `Connecting to Firebot... (${OVERLAY_PORT}).`);
+			notification('open', `Connecting to Firebot... (${overlayPort}).`);
 		}
 
 	} else {
@@ -77,12 +78,12 @@ function sendWebsocketEvent(name, data) {
 
 
 function loadFonts() {
-	$.get(`//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts`, (fonts) => {
+	$.get(`//${baseUrl}/api/v1/fonts`, (fonts) => {
 
 		let fontStyleBlock = `<style type="text/css">`;
 
 		fonts.forEach(font => {
-			let fontPath = `//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts/${font.name}`
+			let fontPath = `//${baseUrl}/api/v1/fonts/${font.name}`
 			fontStyleBlock +=
                 `@font-face {
                     font-family: '${font.name}';

--- a/resources/overlay/js/main.js
+++ b/resources/overlay/js/main.js
@@ -13,7 +13,9 @@ function overlaySocketConnect(){
 		// Let us open a web socket
 		let port = new URL(window.location.href).port;
 
-		ws = new ReconnectingWebSocket(`ws://${window.location.hostname}:${port}`);
+		const websocketProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+
+		ws = new ReconnectingWebSocket(`${websocketProtocol}//${window.location.hostname}:${port}`);
 		ws.onopen = function(){
 			OVERLAY_PORT = port;
 			notification('close');
@@ -78,12 +80,12 @@ function sendWebsocketEvent(name, data) {
 
 
 function loadFonts() {
-	$.get(`http://${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts`, (fonts) => {
+	$.get(`${window.location.protocol}//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts`, (fonts) => {
 
 		let fontStyleBlock = `<style type="text/css">`;
 
 		fonts.forEach(font => {
-			let fontPath = `http://${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts/${font.name}`
+			let fontPath = `${window.location.protocol}//${window.location.hostname}:${OVERLAY_PORT}/api/v1/fonts/${font.name}`
 			fontStyleBlock +=
                 `@font-face {
                     font-family: '${font.name}';


### PR DESCRIPTION
### Description of the Change
Adds dynamic URL support for overlays, including support for Twitch clips.

NOTE: Twitch clips require HTTPS for anything that isn't `localhost`. Also, local media will NOT play over a remote overlay URL.


### Applicable Issues
N/A


### Testing
Created a localtunnel instance pointing to my default Firebot web server running on `http://localhost:7472`. Loaded the localtunnel URL from another device and send a Twitch clip to the overlay, which played as expected on the remote device.


### Screenshots
N/A