### PR TITLE
fix: update deprecated Twurple call

### DIFF
--- a/backend/twitch-api/resource/channels.js
+++ b/backend/twitch-api/resource/channels.js
@@ -18,7 +18,7 @@ const getChannelInformation = async (broadcasterId) => {
 
     const client = twitchApi.getClient();
     try {
-        const response = await client.channels.getChannelInfo(broadcasterId);
+        const response = await client.channels.getChannelInfoById(broadcasterId);
         return response;
     } catch (error) {
         logger.error("Failed to get twitch channel info", error);


### PR DESCRIPTION
### Description of the Change
Updates a deprecated Twurple call to get channel info


### Applicable Issues
#1802


### Testing
Verified that channel info is still able to be queried using new call (`$category` variable used to test)


### Screenshots
N/A