### PR TITLE
feat: add volume support for Twitch clips

### DIFF
--- a/backend/effects/builtin/clips.js
+++ b/backend/effects/builtin/clips.js
@@ -180,9 +180,7 @@ const clip = {
         const { effect } = event;
         const clip = await clipProcessor.createClip(effect);
         if (clip != null) {
-
-            const rawDataSymbol = Object.getOwnPropertySymbols(clip)[0];
-            const clipDuration = clip[rawDataSymbol].duration;
+            const clipDuration = clip.duration;
 
             if (effect.showInOverlay) {
 
@@ -241,7 +239,8 @@ const clip = {
             name: "playTwitchClip",
             onOverlayEvent: event => {
                 const {
-                    clipSlug,
+                    clipVideoUrl,
+                    volume,
                     width,
                     height,
                     duration,
@@ -260,20 +259,14 @@ const clip = {
                 const styles = (width ? `width: ${width}px;` : '') +
                     (height ? `height: ${height}px;` : '');
 
-                const muted = "false";
-                let clipUrl = `https://clips.twitch.tv/embed?clip=${clipSlug}&controls=false&autoplay=true&muted=${muted}&parent=localhost`;
-
-                if (location.hostname !== "localhost") {
-                    clipUrl += "&parent=" + location.hostname;
-                }
                 const videoElement = `
-                    <iframe
-                        src="${clipUrl}"
+                    <video autoplay
+                        src="${clipVideoUrl}"
                         height="${height || ""}"
                         width="${width || ""}"
                         style="border: none;${styles}"
-                        allowfullscreen="false">
-                    </iframe>
+                        onloadstart="this.volume=${volume}"
+                        allowfullscreen="false" />
                 `;
 
                 const positionData = {

--- a/backend/effects/builtin/play-video.js
+++ b/backend/effects/builtin/play-video.js
@@ -162,7 +162,7 @@ const playVideo = {
             </label>
         </eos-container>
 
-        <eos-container header="Volume" pad-top="true" ng-if="effect.videoType != 'Random Twitch Clip' && effect.videoType != 'Twitch Clip'">
+        <eos-container header="Volume" pad-top="true">
             <div class="volume-slider-wrapper">
                 <i class="fal fa-volume-down volume-low"></i>
                 <rzslider rz-slider-model="effect.volume" rz-slider-options="{floor: 0, ceil: 10, hideLimitLabels: true}"></rzslider>
@@ -393,8 +393,9 @@ const playVideo = {
                 }
             }
 
-            const rawDataSymbol = Object.getOwnPropertySymbols(clip)[0];
-            const clipDuration = clip[rawDataSymbol].duration;
+            const clipVideoUrl = clip.thumbnailUrl.split("-preview-")[0] + ".mp4";
+            const clipDuration = clip.duration;
+            const volume = parseInt(effect.volume) / 10;
 
             let effectDuration = effect.length || clipDuration;
             if (effectDuration < 1) {
@@ -405,7 +406,8 @@ const playVideo = {
             }
 
             webServer.sendToOverlay("playTwitchClip", {
-                clipSlug: clipId,
+                clipVideoUrl: clipVideoUrl,
+                volume: volume,
                 width: effect.width,
                 height: effect.height,
                 duration: effectDuration,


### PR DESCRIPTION
### Description of the Change
Adds volume support to Twitch clips played in overlay. Also rewrites Twitch clips in the overlay to play the raw video URL in a `<video>` element instead of a Twitch player embedded in an `<iframe>`.

**NOTE:** Users may have to adjust volume settings for any **Play Video** effects they have that are set to either **Twitch Clip** or **Random Twitch Clip**, as they will now play at the effect's default volume of 50%, whereas before they were all playing at 100%.


### Applicable Issues
#1833


### Testing
Verified that both specific and random Twitch clips play in the overlay at the specified volume.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/182448510-4900226c-06f4-4676-81c1-7b1b02fb6587.png)
