### PR TITLE
fix: null twitchRoles in currency add

### DIFF
--- a/backend/database/currencyDatabase.js
+++ b/backend/database/currencyDatabase.js
@@ -177,8 +177,10 @@ function addCurrencyToUserGroupOnlineUsers(roleIds = [], currencyId, value, igno
 
         const userIdsInRoles = onlineUsers
             .map(u => {
+                const twitchRoles = u.twitchRoles ?? [];
+
                 u.allRoles = [
-                    ...u.twitchRoles.map(tr => twitchRolesManager.mapTwitchRole(tr)),
+                    ...twitchRoles.map(tr => twitchRolesManager.mapTwitchRole(tr)),
                     ...customRolesManager.getAllCustomRolesForViewer(u.username),
                     ...teamRoles[u.username],
                     ...firebotRolesManager.getAllFirebotRolesForViewer(u.username)


### PR DESCRIPTION
### Description of the Change
Added a null check for user `twitchRoles` when adding currency to all online users in a group.


### Applicable Issues
#1832


### Testing
N/A


### Screenshots
N/A