### PR TITLE
feat: new FIle menu, reorg other menus

### DIFF
--- a/backend/app-management/electron/window-management.js
+++ b/backend/app-management/electron/window-management.js
@@ -82,45 +82,19 @@ function createMainWindow() {
     const dataAccess = require("../../common/data-access");
     const menuTemplate = [
         {
-            label: 'Edit',
+            label: 'File',
             submenu: [
                 {
-                    role: 'cut'
+                    label: 'Import Firebot Setup...',
+                    click: () => {
+                        frontendCommunicator.send("open-modal", {
+                            component: "importSetupModal"
+                        });
+                    }
                 },
                 {
-                    role: 'copy'
+                    type: 'separator'
                 },
-                {
-                    role: 'paste'
-                },
-                {
-                    role: "undo"
-                },
-                {
-                    role: "redo"
-                },
-                {
-                    role: "selectAll"
-                }
-            ]
-        },
-        {
-            label: 'Window',
-            submenu: [
-                {
-                    role: 'minimize'
-                },
-                {
-                    role: 'close'
-                },
-                {
-                    role: 'quit'
-                }
-            ]
-        },
-        {
-            label: 'Tools',
-            submenu: [
                 {
                     label: 'Open Data Folder',
                     toolTip: "Open the folder where Firebot data is stored",
@@ -151,6 +125,51 @@ function createMainWindow() {
                         shell.openPath(backupFolder);
                     }
                 },
+                {
+                    type: 'separator'
+                },
+                {
+                    role: 'quit'
+                }
+            ]
+        },
+        {
+            label: 'Edit',
+            submenu: [
+                {
+                    role: 'cut'
+                },
+                {
+                    role: 'copy'
+                },
+                {
+                    role: 'paste'
+                },
+                {
+                    role: "undo"
+                },
+                {
+                    role: "redo"
+                },
+                {
+                    role: "selectAll"
+                }
+            ]
+        },
+        {
+            label: 'Window',
+            submenu: [
+                {
+                    role: 'minimize'
+                },
+                {
+                    role: 'close'
+                }
+            ]
+        },
+        {
+            label: 'Tools',
+            submenu: [
                 {
                     label: 'Setup Wizard',
                     toolTip: "Run the setup wizard again",


### PR DESCRIPTION
### Description of the Change
Adds new **File** menu and reorganizes some options under the new menu. Also adds **Import Firebot Setup...** option to new menu.


### Applicable Issues
N/A


### Testing
Verified new menu option works correctly and all moved menu options still work as before.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/182510508-507434fe-f66d-42da-8f69-5888ee64d5dc.png)
![image](https://user-images.githubusercontent.com/1764877/182510519-4b46d97b-de9c-42c0-8fc6-79530961a43b.png)
![image](https://user-images.githubusercontent.com/1764877/182510522-2e30bfb2-ab61-4562-9d03-777de1da08e7.png)
