### PR TITLE
fix: HttpServerManager custom route registration

### DIFF
--- a/src/server/http-server-manager.js
+++ b/src/server/http-server-manager.js
@@ -293,7 +293,7 @@ class HttpServerManager extends EventEmitter {
             fullRoute
         } = this.buildCustomRouteParameters(prefix, route, method);
 
-        if (this.customRoutes.findIndex((cr) => cr.fullRoute === fullRoute) > -1) {
+        if (this.customRoutes.findIndex((cr) => cr.fullRoute === fullRoute && cr.method === normalizedMethod) > -1) {
             logger.error(`Failed to register custom route: Custom route already registered at "${fullRoute}"`);
             return false;
         }


### PR DESCRIPTION
### Description of the Change
Fixes a bug with custom route registration in HttpServerManager. Previously, it would not allow custom routes with the same name but different verbs.


### Applicable Issues
N/A


### Testing
Verified that custom routes with the same name could be registered with different verbs (e.g. GET, POST, DELETE).


### Screenshots
N/A