### PR TITLE
feat: update whispers to use new API endpoint

### DIFF
--- a/src/backend/auth/twitch-auth.js
+++ b/src/backend/auth/twitch-auth.js
@@ -49,6 +49,7 @@ const STREAMER_ACCOUNT_PROVIDER = {
         'clips:edit',
         'user:manage:blocked_users',
         'user:read:broadcast',
+        'user:manage:whispers',
         'whispers:read',
         'whispers:edit',
         'moderation:read',
@@ -71,7 +72,14 @@ const BOT_ACCOUNT_PROVIDER = {
         tokenPath: TOKEN_PATH,
         authorizePath: AUTHORIZE_PATH
     },
-    scopes: 'channel:moderate chat:edit chat:read whispers:edit channel_read'
+    scopes: [
+        'channel:moderate',
+        'chat:edit',
+        'chat:read',
+        'user:manage:whispers',
+        'whispers:edit',
+        'channel_read'
+    ].join(' ')
 };
 
 exports.registerTwitchAuthProviders = () => {

--- a/src/backend/chat/twitch-chat.js
+++ b/src/backend/chat/twitch-chat.js
@@ -191,14 +191,12 @@ class TwitchChat extends EventEmitter {
      * @param {string} accountType The type of account to whisper with ('streamer' or 'bot')
      */
     async _whisper(message, username = "", accountType) {
-        const chatClient = accountType === 'bot' ? this._botChatClient : this._streamerChatClient;
+        const client = twitchApi.getClient();
         try {
             logger.debug(`Sending whisper as ${accountType} to ${username}.`);
 
-            const streamer = accountAccess.getAccounts().streamer;
-            const whisperMessage = `/w @${username.replace("@", "")} ${message}`;
-            chatClient.say(streamer.username, whisperMessage);
-            //chatClient.whisper(username, message);
+            const recipient = await client.users.getUserByName(username);
+            await twitchApi.whispers.sendWhisper(recipient.id, message, accountType === 'bot');
         } catch (error) {
             logger.error(`Error attempting to send whisper with ${accountType}`, error);
         }

--- a/src/backend/twitch-api/api.js
+++ b/src/backend/twitch-api/api.js
@@ -43,3 +43,4 @@ exports.users = require("./resource/users");
 exports.teams = require("./resource/teams");
 exports.categories = require("./resource/categories");
 exports.streamTags = require("./resource/stream-tags");
+exports.whispers = require("./resource/whispers");

--- a/src/backend/twitch-api/resource/whispers.ts
+++ b/src/backend/twitch-api/resource/whispers.ts
@@ -1,0 +1,19 @@
+import { ApiClient, HelixUser, UserIdResolvable } from "@twurple/api";
+const twitchApi = require("../api");
+const accountAccess = require("../../common/account-access");
+const logger = require('../../logwrapper');
+
+export async function sendWhisper(recipientUserId: UserIdResolvable, message: string, sendAsBot: boolean = false): Promise<boolean> {
+    const client: ApiClient = sendAsBot === true ? twitchApi.getBotClient() : twitchApi.getClient();
+    const senderUserId: number = sendAsBot === true ? accountAccess.getAccounts().bot.userId : accountAccess.getAccounts().streamer.userId;
+
+    try {
+        await client.whispers.sendWhisper(senderUserId, recipientUserId, message);
+        
+        return true;
+    } catch (error) {
+        logger.error("Error sending whisper", error);
+    }
+    
+    return false;
+}


### PR DESCRIPTION
### Description of the Change
Sending whispers now uses the new REST API endpoint. NOTE: This will require users to reauthenticate to Twitch.


### Applicable Issues
N/A


### Testing
Verified sending whispers works using new endpoint


### Screenshots
N/A