### PR TITLE
fix: banned RegEx validation

### DIFF
--- a/src/backend/chat/moderation/chat-moderation-manager.js
+++ b/src/backend/chat/moderation/chat-moderation-manager.js
@@ -108,6 +108,10 @@ function startModerationService() {
             }
             break;
         }
+        case "logWarn": {
+            logger.warn(event.logMessage, event.meta);
+            break;
+        }
         }
     });
 

--- a/src/backend/chat/moderation/moderation-service.js
+++ b/src/backend/chat/moderation/moderation-service.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { parentPort } = require("worker_threads");
+const logger = require("../../logwrapper");
 
 let bannedWords = [];
 let regularExpressions = [];
@@ -14,7 +15,13 @@ function hasBannedWord(input) {
 }
 
 function matchesBannedRegex(input) {
-    const expressions = regularExpressions.map(regex => new RegExp(regex, "gi"));
+    const expressions = regularExpressions.map(regex => {
+        try {
+            return new RegExp(regex, "gi");
+        } catch (error) {
+            logger.warn(`Unable to parse banned RegEx: ${regex}`, error);
+        }
+    });
     const inputWords = input.split(" ");
 
     for (const exp of expressions) {

--- a/src/backend/chat/moderation/moderation-service.js
+++ b/src/backend/chat/moderation/moderation-service.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const { parentPort } = require("worker_threads");
-const logger = require("../../logwrapper");
 
 let bannedWords = [];
 let regularExpressions = [];
@@ -15,13 +14,15 @@ function hasBannedWord(input) {
 }
 
 function matchesBannedRegex(input) {
-    const expressions = regularExpressions.map(regex => {
+    const expressions = regularExpressions.reduce(function(newArray, regex) {
         try {
-            return new RegExp(regex, "gi");
+            newArray.push(new RegExp(regex, "gi"));
         } catch (error) {
-            logger.warn(`Unable to parse banned RegEx: ${regex}`, error);
+            parentPort.postMessage({ type: "logWarn", logMessage: `Unable to parse banned RegEx: ${regex}`, meta: error });
         }
-    });
+
+        return newArray;
+    }, []);
     const inputWords = input.split(" ");
 
     for (const exp of expressions) {

--- a/src/gui/app/directives/modals/misc/editBannedWordsModal.js
+++ b/src/gui/app/directives/modals/misc/editBannedWordsModal.js
@@ -181,6 +181,15 @@
                                             reason: `Regex already exists.`
                                         });
                                     }
+                                    try {
+                                        new RegExp(value, "gi");
+                                    } catch (error) {
+                                        logger.warn(`Invalid RegEx entered: ${value}`, error);
+                                        return resolve({
+                                            success: false,
+                                            reason: `Please enter a valid RegEx.`
+                                        });
+                                    }
                                     resolve(true);
                                 });
                             }


### PR DESCRIPTION
### Description of the Change
Adds additional verification around banned RegEx adding and checking to prevent moderation service from crashing.


### Applicable Issues
N/A


### Testing
Verified that invalid RegEx can no longer be added via moderation Edit Banned Words dialog. Verified existing invalid RegEx is skipped and does not crash moderation service.


### Screenshots
N/A