### PR TITLE
feat: make the URL allowlist discern on the path component of a URL

### DIFF
--- a/src/backend/utility.js
+++ b/src/backend/utility.js
@@ -17,7 +17,7 @@ const escapeRegExp = (str) => {
 };
 
 const getUrlRegex = () => {
-    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/]|\w?)/gi;
+    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/]|\w?)+/gi;
 };
 
 /**


### PR DESCRIPTION
**Issue:**
Currently the bot's allowlist for URL moderation doesn't work for the path component of a domain. I'd like to also filter not just on the domain, but also path part. For example for multistreams I'd love to allow the urls to the channels of my costreamers only, but not all twitch links in general.

For example allowing just `https://twitch.tv/good_streamer` won't work since the current regex only picks up the `https://twitch.tv/` part and everything after gets ignored.

![image](https://user-images.githubusercontent.com/68741472/184317824-aa074b1a-c457-4e23-b361-d9b853f8aa49.png)

leaving me the choice to whitelist twitch as a whole or not at all.

**Fix:**

Changing

```js
const getUrlRegex = () => {
    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/]|\w?)/gi;
};
```

and adding a single `+` to the last group will make the path component part of the url and allow discerning on it for the allowlist:

```js
const getUrlRegex = () => {
    return /\b(?:https?:(?:\/\/)?)?(?:[a-z\d](?:[a-z\d-]{0,253}[a-z\d])?\.)+[a-z][a-z\d-]{0,60}[a-z\d](?:$|[\\/]|\w?)+/gi;
};
```

![image](https://user-images.githubusercontent.com/68741472/184318361-2885b00d-8fa8-4ac2-a5ee-b3cb11bf0d9f.png)