### PR TITLE
fix: resolve some SSML issues with Amazon Polly

### DIFF
--- a/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
+++ b/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
@@ -422,6 +422,11 @@ const playSound = {
             region: awsIntegration.userSettings.iamCredentials.region || 'us-east-1'
         });
 
+        if (effect.isSsml) {
+            effect.text = "<speak>"+effect.text+"</speak>";
+            effect.text = effect.text.replace("&", "&amp;");
+        }
+
         const synthSpeechCommand = new SynthesizeSpeechCommand({
             Engine: effect.engine,
             OutputFormat: "mp3",


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Introduce 2 fixes for Amazon Polly SSML.
Introduce `<speak></speak>` when SSML is selected, fixes some SSML tags not working.
Escape `&` character to make it work in an SSML message.
Note: a fix for the `<` character is NOT included, more work needs to be put into filtering so genuine SSML tags aren't escaped/encoded

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1866 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
When testing the fix, every example text in the reproduction steps, except for the one with a `<` character now works. See the note above for clarification.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

Thanks to @Nikoheartttv (Nikoheart#0001) for helping with this issue.
