### PR TITLE
fix: streamloots chest is a gift and is not a gift streamloots chest event #1872

### DIFF
--- a/src/backend/integrations/builtin/streamloots/filters/chest-gift.js
+++ b/src/backend/integrations/builtin/streamloots/filters/chest-gift.js
@@ -29,11 +29,7 @@ module.exports = {
             return "[Not set]";
         }
 
-        if (filterSettings.value) {
-            return "A Gift";
-        }
-
-        return "Not A Gift";
+        return filterSettings.value === "true" ? "A Gift" : "Not A Gift";
     },
     predicate: (filterSettings, eventData) => {
 


### PR DESCRIPTION
### Description of the Change
Fixed the logic for the the selection of the "A Gift" "Not A Gift" on the streamloots chest event 


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1871

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested using the simulate event to create chest purchase of a gift and non gift chest 
this is now working as intended. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
