### PR TITLE
#1797 Add time limit to Polly and native TTS

### DIFF
--- a/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
+++ b/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
@@ -146,6 +146,13 @@ const playSound = {
             </div>
         </eos-container>
 
+        <eos-container header="Maximum Duration" pad-top="true">
+            <div class="input-group">
+                <span class="input-group-addon" id="delay-length-effect-type">Seconds</span>
+                <input ng-model="effect.maxSoundLength" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
+            </div>
+        </eos-container>
+
         <eos-container header="Sound" pad-top="true">
             <label class="control-fb control--checkbox"> Wait for sound to finish <tooltip text="'Wait for the sound to finish before letting the next effect play.'"></tooltip>
                 <input type="checkbox" ng-model="effect.waitForSound">
@@ -462,7 +469,8 @@ const playSound = {
         const data = {
             filepath: mp3Path,
             volume: effect.volume,
-            overlayInstance: effect.overlayInstance
+            overlayInstance: effect.overlayInstance,
+            maxSoundLength: effect.maxSoundLength
         };
 
         // Set output device.

--- a/src/gui/app/services/sound.service.js
+++ b/src/gui/app/services/sound.service.js
@@ -98,7 +98,7 @@
             };
 
 
-            service.playSound = function(path, volume, outputDevice, fileType = null) {
+            service.playSound = function(path, volume, outputDevice, fileType = null, maxSoundLength = null) {
 
                 if (outputDevice == null) {
                     outputDevice = settingsService.getAudioOutputDevice();
@@ -107,14 +107,24 @@
                 $q.when(service.getHowlSound(path, volume, outputDevice, fileType))
                     .then(sound => {
 
+                        let maxSoundLengthTimeout
                         // Clear listener after first call.
                         sound.once('load', function() {
                             sound.play();
+
+                            const intMaxSoundLength = parseInt(maxSoundLength);
+                            if (intMaxSoundLength > 0) {
+                                maxSoundLengthTimeout = setTimeout(function() {
+                                    sound.stop();
+                                    sound.unload();
+                                }, maxSoundLength * 1000)
+                            }
                         });
 
                         // Fires when the sound finishes playing.
                         sound.once('end', function() {
                             sound.unload();
+                            clearInterval(maxSoundLengthTimeout)
                         });
 
                         sound.load();
@@ -193,11 +203,12 @@
                             format: data.format,
                             volume: volume,
                             resourceToken: data.resourceToken,
-                            overlayInstance: data.overlayInstance
+                            overlayInstance: data.overlayInstance,
+                            maxSoundLength: data.maxSoundLength
                         });
 
                     } else {
-                        service.playSound(data.isUrl ? data.url : data.filepath, volume, selectedOutputDevice, data.format);
+                        service.playSound(data.isUrl ? data.url : data.filepath, volume, selectedOutputDevice, data.format, data.maxSoundLength);
                     }
                 }
             );


### PR DESCRIPTION

### Description of the Change
Added a maximum duration parameter to help curb overly long winded Polly and native TTS messages. 


### Applicable Issues
https://github.com/crowbartools/Firebot/issues/1797


### Testing
- Added new chat !command trigger
- Added Polly TTS effect
  - Set text to the Shungite copypasta (it takes about 30 seconds for built-in TTS to read)
- Did not set new maximum duration property
- Tested event. Observed that the whole message was read out
- Edited event and set maximum duration to 7 seconds
- Tested event. Observed that only the first 7 seconds were read, approximately one sentence
- Edited event again and set maximum duration to -1
- Tested event. Observed that the whole message was read out

Repeated the above tests but with the built-in text to speech effect instead of Polly

### Screenshots
![image](https://user-images.githubusercontent.com/556514/186320941-cf6c89fa-22f5-4866-a7ca-5854cd0ff0df.png)

