### PR TITLE
feat(api): custom role mgmt, counters, timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "ws": "^8.2.2"
       },
       "devDependencies": {
+        "@types/express": "^4.17.1",
         "@typescript-eslint/eslint-plugin": "^5.32.0",
         "@typescript-eslint/parser": "^5.32.0",
         "copyfiles": "^2.4.1",
@@ -1668,10 +1669,57 @@
         "@twurple/auth": "^5.0.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1699,6 +1747,28 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -14046,10 +14116,57 @@
         "tslib": "^2.0.3"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
     },
     "@types/node": {
@@ -14076,6 +14193,28 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "The Streaming Community",
   "license": "GPL-3.0",
   "devDependencies": {
+    "@types/express": "^4.17.1",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "copyfiles": "^2.4.1",

--- a/src/server/api/v1/controllers/countersApiController.ts
+++ b/src/server/api/v1/controllers/countersApiController.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+const counterManager = require("../../../../backend/counters/counter-manager");
+
+exports.getCounters = async function(req: Request, res: Response) {
+    const counters = counterManager.getAllItems()
+        .map((c: any) => {
+            return {
+                id: c.id,
+                name: c.name,
+                value: c.value
+            };
+        });
+    
+    return res.json(counters);
+};
+
+exports.getCounterById = async function(req: Request, res: Response) {
+    const counterId: string = req.params.counterId;
+
+    if (!(counterId.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No counterId provided"
+        });
+    }
+
+    const counter = counterManager.getItem(counterId);
+
+    if (counter == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Counter '${counterId}' not found`
+        });
+    }
+
+    return res.json(counter);
+};

--- a/src/server/api/v1/controllers/customRolesApiController.ts
+++ b/src/server/api/v1/controllers/customRolesApiController.ts
@@ -1,0 +1,136 @@
+import { Request, Response } from "express";
+const customRolesManager = require("../../../../backend/roles/custom-roles-manager");
+const userDb = require("../../../../backend/database/userDatabase");
+
+exports.getCustomRoles = async function(req: Request, res: Response) {
+    const customRoles = customRolesManager.getCustomRoles()
+        .map((cr: any) => {
+            return {
+                id: cr.id,
+                name: cr.name,
+                viewers: cr.viewers ?? []
+            };
+        });
+
+    return res.json(customRoles);
+};
+
+exports.getCustomRoleById = async function(req: Request, res: Response) {
+    const customRoleId: string = req.params.customRoleId;
+
+    if (!(customRoleId.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No customRoleId provided"
+        });
+    }
+
+    const customRole = customRolesManager.getItem(customRoleId);
+
+    if (customRole == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Custom role '${customRoleId}' not found`
+        });
+    }
+
+    const formattedCustomRole = {
+        id: customRole.id,
+        name: customRole.name,
+        viewers: customRole.viewers ?? []
+    };
+
+    return res.json(formattedCustomRole);
+};
+
+exports.addUserToCustomRole = async function(req: Request, res: Response) {
+    const { userId, customRoleId } = req.params;
+    const { username } = req.query;
+
+    if (userId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No viewerIdOrName provided`
+        });
+    }
+
+    if (customRoleId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No customRoleId provided`
+        });
+    }
+
+    let metadata;
+    if (username === "true") {
+        metadata = await userDb.getUserByUsername(userId);
+    } else {
+        metadata = await userDb.getUserById(userId);
+    }
+
+    if (metadata === null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified viewer does not exist`
+        });
+    }
+
+    const customRole = customRolesManager.getCustomRoles().find((cr: any) => cr.id.toLowerCase() === customRoleId.toLowerCase());
+
+    if (customRole == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified custom role does not exist`
+        });
+    }
+
+    customRolesManager.addViewerToRole(customRole.id, metadata.username);
+
+    return res.status(201).send();
+};
+
+exports.removeUserFromCustomRole = async function(req: Request, res: Response) {
+    const { userId, customRoleId } = req.params;
+    const { username } = req.query;
+
+    if (userId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No viewerIdOrName provided`
+        });
+    }
+
+    if (customRoleId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No customRoleId provided`
+        });
+    }
+
+    let metadata;
+    if (username === "true") {
+        metadata = await userDb.getUserByUsername(userId);
+    } else {
+        metadata = await userDb.getUserById(userId);
+    }
+
+    if (metadata === null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified viewer does not exist`
+        });
+    }
+
+    const customRole = customRolesManager.getCustomRoles().find((cr: any) => cr.id.toLowerCase() === customRoleId.toLowerCase());
+
+    if (customRole == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified custom role does not exist`
+        });
+    }
+
+    customRolesManager.removeViewerFromRole(customRole.id, metadata.username);
+
+    return res.status(204).send();
+};

--- a/src/server/api/v1/controllers/timersApiController.ts
+++ b/src/server/api/v1/controllers/timersApiController.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+const timersManager = require("../../../../backend/timers/timer-manager");
+
+exports.getTimers = async function(req: Request, res: Response) {
+    const timers = timersManager.getAllItems()
+        .map((c: any) => {
+            return {
+                id: c.id,
+                name: c.name,
+                active: c.active
+            };
+        });
+    
+    return res.json(timers);
+};
+
+exports.getTimerById = async function(req: Request, res: Response) {
+    const timerId: string = req.params.timerId;
+
+    if (!(timerId.length > 0)) {
+        return res.status(400).send({
+            status: "error",
+            message: "No timerId provided"
+        });
+    }
+
+    const timer = timersManager.getItem(timerId);
+
+    if (timer == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Timer '${timerId}' not found`
+        });
+    }
+
+    return res.json(timer);
+};

--- a/src/server/api/v1/controllers/viewersApiController.js
+++ b/src/server/api/v1/controllers/viewersApiController.js
@@ -3,6 +3,7 @@
 const userDb = require("../../../../backend/database/userDatabase");
 const customRolesManager = require("../../../../backend/roles/custom-roles-manager");
 const currencyDb = require("../../../../backend/database/currencyDatabase");
+const customRolesApiController = require("./customRolesApiController");
 
 exports.getAllUsers = async function(req, res) {
     return res.json(await userDb.getAllUsernamesWithIds());
@@ -79,4 +80,42 @@ exports.setUserCurrency = async function(req, res) {
     }
 
     res.status(204).send();
+};
+
+exports.getUserCustomRoles = async function(req, res) {
+    const { userId } = req.params;
+    const { username } = req.query;
+
+    if (userId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No viewerIdOrName provided`
+        });
+    }
+
+    let metadata;
+    if (username === "true") {
+        metadata = await userDb.getUserByUsername(userId);
+    } else {
+        metadata = await userDb.getUserById(userId);
+    }
+
+    if (metadata === null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified viewer does not exist`
+        });
+    }
+
+    const customRoles = customRolesManager.getAllCustomRolesForViewer(metadata.username) ?? [];
+
+    return res.json(customRoles);
+};
+
+exports.addUserToCustomRole = async function(req, res) {
+    return customRolesApiController.addUserToCustomRole(req, res);
+};
+
+exports.removeUserFromCustomRole = async function(req, res) {
+    return customRolesApiController.removeUserFromCustomRole(req, res);
 };

--- a/src/server/api/v1/v1Router.js
+++ b/src/server/api/v1/v1Router.js
@@ -111,6 +111,30 @@ router
     .get(viewers.getUserCurrency)
     .post(viewers.setUserCurrency);
 
+router
+    .route("/viewers/:userId/customRoles")
+    .get(viewers.getUserCustomRoles);
+
+router
+    .route("/viewers/:userId/customRoles/:customRoleId")
+    .post(viewers.addUserToCustomRole)
+    .delete(viewers.removeUserFromCustomRole);
+
+// Custom Roles
+const customRoles = require("./controllers/customRolesApiController");
+
+router
+    .route("/customRoles")
+    .get(customRoles.getCustomRoles);
+
+router
+    .route("/customRoles/:customRoleId")
+    .get(customRoles.getCustomRoleById);
+
+router
+    .route("/customRoles/:customRoleId/viewer/:userId")
+    .post(customRoles.addUserToCustomRole)
+    .delete(customRoles.removeUserFromCustomRole);
 
 // currencies
 const currency = require("./controllers/currencyApiController");
@@ -141,5 +165,27 @@ router
     .put(quotes.putQuote)
     .patch(quotes.patchQuote)
     .delete(quotes.deleteQuote);
+
+// Counters
+const counters = require("./controllers/countersApiController");
+
+router
+    .route("/counters")
+    .get(counters.getCounters);
+
+router
+    .route("/counters/:counterId")
+    .get(counters.getCounterById);
+
+// Timers
+const timers = require("./controllers/timersApiController");
+
+router
+    .route("/timers")
+    .get(timers.getTimers);
+
+router
+    .route("/timers/:timerId")
+    .get(timers.getTimerById);
 
 module.exports = router;


### PR DESCRIPTION
### Description of the Change
Adds the following API endpoints:

#### Custom Roles
`GET /customRoles` - Lists a summary of all custom roles (`id`, `name`, `viewers`)
`GET /customRoles/:customRoleId` - Get info about a specific custom role
`POST /customRoles/:customRoleId/viewer/:userId` - Adds the specified user to the specified custom role. Can specify user ID, or username with `username=true` query parameter
`DELETE /customRoles/:customRoleId/viewer/:userId` - Removes the specified user from the specified custom role. Can specify user ID, or username with `username=true` query parameter

Also added corresponding viewer endpoints:

`GET /viewers/:userId/customRoles` - Lists all custom roles for the specified user
`POST /viewers/:userId/customRoles/:customRoleId` - same as `POST /customRoles/:customRoleId/viewer/:userId`
`DELETE /viewers/:userId/customRoles/:customRoleId` - same as `DELETE /customRoles/:customRoleId/viewer/:userId`


#### Counters
`GET /counters` - Lists a summary of all counters (`id`, `name`, `value`)
`GET /counters/:counterId` - Get detailed info about a specific counter (including event sets)


#### Timers
`GET /timers` - Lists a summary of all timers (`id`, `name`, `active`)
`GET /timers/:timerId` - Get detailed info about a specific timer (including events)



### Applicable Issues
Mostly covers #1876


### Testing
Verified all new endpoints work as described


### Screenshots
N/A