### PR TITLE
feat: Restore from backup in Tools menu

### DIFF
--- a/src/backend/app-management/electron/window-management.js
+++ b/src/backend/app-management/electron/window-management.js
@@ -183,6 +183,13 @@ function createMainWindow() {
                     }
                 },
                 {
+                    label: 'Restore from backup...',
+                    toolTip: "Restores Firebot from a backup",
+                    click: async () => {
+                        frontendCommunicator.send("restore-backup");
+                    }
+                },
+                {
                     label: 'Custom Variable Inspector',
                     toolTip: "Open the custom variable inspector",
                     click: () => {

--- a/src/gui/app/app-main.js
+++ b/src/gui/app/app-main.js
@@ -179,7 +179,7 @@
     });
 
     app.controller("MainController", function($scope, $rootScope, $timeout, connectionService, utilityService,
-        settingsService, sidebarManager, logger, backendCommunicator) {
+        settingsService, backupService, sidebarManager, logger, backendCommunicator) {
         $rootScope.showSpinner = true;
 
         $scope.fontAwesome5KitUrl = `https://kit.fontawesome.com/${secrets.fontAwesome5KitId}.js`;
@@ -437,6 +437,25 @@
                     setupFilePath: () => path
                 }
             });
+        });
+
+        backendCommunicator.on("restore-backup", () => {
+            backupService.openBackupZipFilePicker()
+                .then(backupFilePath => {
+                    if (backupFilePath != null) {
+                        utilityService
+                            .showConfirmationModal({
+                                title: "Restore From Backup",
+                                question: "Are you sure you'd like to restore from this backup?",
+                                confirmLabel: "Restore"
+                            })
+                            .then(confirmed => {
+                                if (confirmed) {
+                                    backupService.initiateBackupRestore(backupFilePath);
+                                }
+                            });
+                    }
+                });
         });
 
         backendCommunicator.onAsync("takeScreenshot", async (data) => {


### PR DESCRIPTION
### Description of the Change
Adds a **Restore from backup...** option to the **Tools** menu, with a confirmation modal.


### Applicable Issues
N/A


### Testing
Restored backup from new menu option


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/188044580-4a9a33bc-9724-47aa-a60d-3b6d02a85e70.png)
![image](https://user-images.githubusercontent.com/1764877/188044603-0cd5bbbc-1f15-4e90-a3e5-3b0df158f08e.png)



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
