### PR TITLE
feat: prevent dev/non-Windows auto-updates

### DIFF
--- a/src/gui/app/services/updates.service.js
+++ b/src/gui/app/services/updates.service.js
@@ -17,7 +17,11 @@
 
             const FIREBOT_RELEASES_URL = "https://api.github.com/repos/crowbartools/Firebot/releases";
 
-            const APP_VERSION = require('electron').remote.app.getVersion();
+            const electron = require('electron');
+
+            const APP_VERSION = electron.remote.app.getVersion();
+            const isDev = !electron.remote.app.isPackaged;
+            const isWindows = process.platform === "win32";
 
             service.updateData = null;
 
@@ -34,6 +38,11 @@
             function shouldAutoUpdate(autoUpdateLevel, updateType) {
                 // if auto updating is completely disabled
                 if (autoUpdateLevel === 0) {
+                    return false;
+                }
+
+                // Skip auto update if this is dev build or is not running on Windows
+                if (isDev || !isWindows) {
                     return false;
                 }
 


### PR DESCRIPTION
### Description of the Change
Auto update no longer runs in dev environments or non-Windows OSes.


### Applicable Issues
#1824, #1825


### Testing
Verified that auto-updates do not attempt to run for dev builds, but still run for packaged builds.


### Screenshots
N/A