### PR TITLE
feat: allow simulated events to force run

### DIFF
--- a/src/backend/events/EventManager.js
+++ b/src/backend/events/EventManager.js
@@ -139,9 +139,9 @@ ipcMain.on("triggerManualEvent", function(_, data) {
 
 frontendCommunicator.on("simulateEvent", (eventData) => {
     if (Object.keys(eventData.metadata).length > 0) {
-        manager.triggerEvent(eventData.sourceId, eventData.eventId, eventData.metadata, true, false, true);
+        manager.triggerEvent(eventData.sourceId, eventData.eventId, eventData.metadata, true, eventData.forceRetrigger, true);
     } else {
-        manager.triggerEvent(eventData.sourceId, eventData.eventId, null, true, false, true);
+        manager.triggerEvent(eventData.sourceId, eventData.eventId, null, true, eventData.forceRetrigger, true);
     }
 });
 

--- a/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
+++ b/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
@@ -21,6 +21,13 @@
                         ></searchable-event-dropdown>
                     </div>
 
+                    <div>
+                        <label class="control-fb control--checkbox"> Force event to run <tooltip text="'This will ensure that the simulated event will run, even if a similar event was recently triggered.'"></tooltip>
+                            <input type="checkbox" ng-model="$ctrl.eventData.forceRetrigger">
+                            <div class="control__indicator"></div>
+                        </label>
+                    </div>
+
                     <div ng-if="$ctrl.metadata">
                         <command-option
                             ng-repeat="data in $ctrl.metadata"
@@ -46,7 +53,8 @@
                 $ctrl.eventData = {
                     eventId: null,
                     sourceId: null,
-                    metadata: {}
+                    metadata: {},
+                    forceRetrigger: false
                 };
                 $ctrl.eventError = false;
 


### PR DESCRIPTION
### Description of the Change
Add a new option to the Simulate Event dialog to force an event to run, even if a similar event was recently run and is in the cache.


### Applicable Issues
#1782


### Testing
Verified simulated events will bypass cache when new option is selected, but still honor cache when it is NOT selected (default behavior).


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/188281049-93f729f7-22cc-4835-8a44-c1590f258fb9.png)

