### PR TITLE
feat: overlay elements now use uuid

### DIFF
--- a/src/backend/effects/builtin/celebration.js
+++ b/src/backend/effects/builtin/celebration.js
@@ -129,9 +129,8 @@ const celebration = {
                 const type = data.celebrationType;
                 const duration = parseFloat(data.celebrationDuration) * 1000; //convert to milliseconds.
 
-                // Get time in milliseconds to use as class name.
-                const d = new Date();
-                const divClass = d.getTime();
+                // Generate UUID to use as class name.
+                const divClass = uuidv4();
 
                 if (type === "Fireworks") {
                     const canvas = '<canvas id="fireworks" class="' + divClass + '-fireworks celebration ' + type + '" style="display:none; z-index: 99;"></canvas>';

--- a/src/backend/effects/builtin/play-sound.js
+++ b/src/backend/effects/builtin/play-sound.js
@@ -185,9 +185,8 @@ const playSound = {
                     window.location.hostname
                 }:7472/resource/${token}`;
 
-                // Get time in milliseconds to use as class name.
-                const d = new Date();
-                const uuid = d.getTime().toString();
+                // Generate UUID to use as class name.
+                const uuid = uuidv4();
 
                 const filepath = data.isUrl ? data.url : data.filepath.toLowerCase();
                 let mediaType;

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -497,9 +497,9 @@ const playVideo = {
                 const token = encodeURIComponent(data.resourceToken);
                 const filepathNew = `http://${window.location.hostname}:7472/resource/${token}`;
 
-                // Get time in milliseconds to use as id
-                const time = new Date().getTime();
-                const videoPlayerId = `${time}-video`;
+                // Generate UUID to use as id
+                const uuid = uuidv4();
+                const videoPlayerId = `${uuid}-video`;
 
                 const enterAnimation = data.enterAnimation ? data.enterAnimation : "fadeIn";
                 const exitAnimation = data.exitAnimation ? data.exitAnimation : "fadeIn";
@@ -529,7 +529,7 @@ const playVideo = {
                         </video>
                     `;
 
-                    const wrapperId = new Date().getTime();
+                    const wrapperId = uuidv4();
                     const wrappedHtml = getPositionWrappedHTML(wrapperId, positionData, videoElement); // eslint-disable-line no-undef
 
                     $(".wrapper").append(wrappedHtml);
@@ -590,11 +590,11 @@ const playVideo = {
                         }
                     };
                 } else {
-                    const ytPlayerId = `yt-${new Date().getTime()}`;
+                    const ytPlayerId = `yt-${uuidv4()}`;
 
                     const youtubeElement = `<div id="${ytPlayerId}" style="display:none;${sizeStyles}"></div>`;
 
-                    const wrapperId = new Date().getTime();
+                    const wrapperId = uuidv4();
                     const wrappedHtml = getPositionWrappedHTML(wrapperId, positionData, youtubeElement); // eslint-disable-line no-undef
 
                     $(".wrapper").append(wrappedHtml);

--- a/src/backend/effects/builtin/shoutout.js
+++ b/src/backend/effects/builtin/shoutout.js
@@ -305,7 +305,7 @@ const effect = {
 
                 const scale = data.scale == null ? 1.0 : data.scale;
 
-                const uniqueId = new Date().getTime();
+                const uniqueId = uuidv4();
 
                 const fittyId = `fit-text-${uniqueId}`;
 

--- a/src/resources/overlay/js/util.js
+++ b/src/resources/overlay/js/util.js
@@ -1,6 +1,13 @@
 // Global
 notificationShown = false;
 
+// https://stackoverflow.com/questions/105034/how-do-i-create-a-guid-uuid
+function uuidv4() {
+	return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+	  	(c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+	);
+}
+
 // Handle notifications
 function notification(status, text){
 	var divStatus = $('.notification').is(':visible');
@@ -142,7 +149,7 @@ function showElement(
 	positionData,
 	animationData
 ){
-	let uniqueId = new Date().getTime();
+	let uniqueId = uuidv4();
 
 	let positionWrappedHtml = getPositionWrappedHTML(uniqueId, positionData, effectHTML);
 


### PR DESCRIPTION
### Description of the Change
Overlay elements now use UUIDs instead of the current time to uniquely name elements


### Applicable Issues
#1600


### Testing
Verified that overlay elements now generate UUIDs for IDs instead of timestamps


### Screenshots
N/A