### PR TITLE
chore: add grunt prep debug prelaunch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,37 +1,37 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Electron: Main",
-          "protocol": "inspector",
-          "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
-          "runtimeArgs": [
-              "--remote-debugging-port=9223",
-              "."
-          ],
-          "windows": {
-              "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
-          },
-          "outputCapture": "std",
-      },
-      {
-          "name": "Electron: Renderer",
-          "type": "chrome",
-          "request": "attach",
-          "port": 9223,
-          "webRoot": "${workspaceFolder}",
-          "timeout": 30000
-      }
-  ],
-  "compounds": [
-      {
-          "name": "Electron: All",
-          "configurations": [
-              "Electron: Main",
-              "Electron: Renderer"
-          ]
-      }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Electron: Main",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+            "runtimeArgs": [
+                "--remote-debugging-port=9223",
+                "."
+            ],
+            "windows": {
+                "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+            },
+            "outputCapture": "std",
+            "preLaunchTask": "grunt-prep"
+        },
+        {
+            "name": "Electron: Renderer",
+            "type": "chrome",
+            "request": "attach",
+            "port": 9223,
+            "webRoot": "${workspaceFolder}",
+            "timeout": 30000
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Electron: All",
+            "configurations": [
+                "Electron: Main",
+                "Electron: Renderer"
+            ]
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "grunt-prep",
+            "type": "shell",
+            "command": "grunt",
+            "args": [ "prep" ],
+            "group": "build",
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
### Description of the Change
Add `grunt prep` task to VSCode debug launch


### Applicable Issues
N/A


### Testing
Verified `grunt prep` runs when starting debugging


### Screenshots
N/A