### PR TITLE
Fix: #1981 follow age

### DIFF
--- a/src/backend/twitch-api/resource/users.js
+++ b/src/backend/twitch-api/resource/users.js
@@ -12,8 +12,14 @@ const getFollowDateForUser = async (username) => {
     const streamerData = accountAccess.getAccounts().streamer;
 
     const userId = (await client.users.getUserByName(username)).id;
+    const user = await client.users.getUserByName(username);
+    let followerDate;
 
-    const followerDate = (await client.users.getFollowFromUserToBroadcaster(userId, streamerData.userId)).followDate;
+    if (username.toLowerCase() !== streamerData.username) {
+        followerDate = (await client.users.getFollowFromUserToBroadcaster(userId, streamerData.userId)).followDate;
+    } else {
+        followerDate = user.creationDate;
+    }
 
     if (followerDate == null || followerDate.length < 1) {
         return null;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Make follow command honer streamer account by supplying the streamers creation date.
when running !followage from the streamer account it will return the streamers creation date. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1981

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
All test where completed with a follower and myself follow age is returning proper for both. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

![image](https://user-images.githubusercontent.com/8982158/203942441-933b52a7-26d2-4786-89a9-87252861bb49.png)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
