### PR TITLE
feat: allow effect outputs to be bubbled to parent lists, update http request effect to use outputs

### DIFF
--- a/src/backend/common/effect-runner.js
+++ b/src/backend/common/effect-runner.js
@@ -148,7 +148,8 @@ async function runEffects(runEffectsContext) {
                         logger.info(`Stop effect execution triggered for effect list id ${runEffectsContext.effects.id}`);
                         return {
                             success: true,
-                            stopEffectExecution: execution.bubbleStop
+                            stopEffectExecution: execution.bubbleStop,
+                            outputs: runEffectsContext.outputs ?? {}
                         };
                     }
                 }
@@ -160,7 +161,8 @@ async function runEffects(runEffectsContext) {
 
     return {
         success: true,
-        stopEffectExecution: false
+        stopEffectExecution: false,
+        outputs: runEffectsContext.outputs ?? {}
     };
 }
 

--- a/src/backend/effects/builtin/conditional-effects/conditional-effects.js
+++ b/src/backend/effects/builtin/conditional-effects/conditional-effects.js
@@ -55,6 +55,14 @@ const model = {
 
             </div>
         </eos-container>
+
+        <eos-container header="Options" pad-top="true">
+            <firebot-checkbox
+                model="effect.bubbleOutputs"
+                label="Apply effect outputs to parent list"
+                tooltip="Whether or not you want any effect outputs to be made available to the parent effect list."
+            />
+        </eos-container>
     `,
     optionsController: ($scope, utilityService) => {
 
@@ -143,6 +151,7 @@ const model = {
                             if (result.stopEffectExecution) {
                                 return resolve({
                                     success: true,
+                                    outputs: effect.bubbleOutputs ? result.outputs : undefined,
                                     execution: {
                                         stop: true,
                                         bubbleStop: true
@@ -150,7 +159,10 @@ const model = {
                                 });
                             }
                         }
-                        resolve(true);
+                        resolve({
+                            success: true,
+                            outputs: effect.bubbleOutputs ? result?.outputs : undefined
+                        });
                     });
             } else {
                 resolve(true);

--- a/src/backend/effects/builtin/effect-group.js
+++ b/src/backend/effects/builtin/effect-group.js
@@ -57,10 +57,19 @@ const effectGroup = {
         </eos-container>
 
         <eos-container header="Options" pad-top="true">
-            <label class="control-fb control--checkbox"> Don't wait for effects to finish <tooltip text="'Check this if you want the root effect list that triggers this list to continue its effect execution instead of waiting for these effects to complete.'"></tooltip>
-                <input type="checkbox" ng-model="effect.dontWait">
-                <div class="control__indicator"></div>
-            </label>
+            <firebot-checkbox
+                model="effect.dontWait"
+                label="Don't wait for effects to finish"
+                tooltip="Check this if you want the root effect list that triggers this list to continue its effect execution instead of waiting for these effects to complete."
+            />
+
+            <firebot-checkbox
+                ng-if="!effect.dontWait"
+                style="margin-top: 10px"
+                model="effect.bubbleOutputs"
+                label="Apply effect outputs to parent list"
+                tooltip="Whether or not you want any effect outputs to be made available to the parent effect list."
+            />
         </eos-container>
 
     `,
@@ -166,9 +175,11 @@ const effectGroup = {
             } else {
                 effectExecutionPromise.then(result => {
                     if (result != null && result.success === true) {
+
                         if (result.stopEffectExecution) {
                             return resolve({
                                 success: true,
+                                outputs: effect.bubbleOutputs ? result.outputs : undefined,
                                 execution: {
                                     stop: true,
                                     bubbleStop: true
@@ -176,7 +187,10 @@ const effectGroup = {
                             });
                         }
                     }
-                    resolve(true);
+                    resolve({
+                        success: true,
+                        outputs: effect.bubbleOutputs ? result?.outputs : undefined
+                    });
                 });
             }
         });

--- a/src/backend/effects/builtin/http-request.js
+++ b/src/backend/effects/builtin/http-request.js
@@ -26,7 +26,14 @@ const effect = {
         description: "Send an HTTP request to a given url",
         icon: "fad fa-terminal",
         categories: [EffectCategory.ADVANCED, EffectCategory.SCRIPTING],
-        dependencies: []
+        dependencies: [],
+        outputs: [
+            {
+                label: "Response Body",
+                description: "The raw response from the request",
+                defaultName: "httpResponse"
+            }
+        ]
     },
     globalSettings: {},
     optionsTemplate: `
@@ -75,7 +82,7 @@ const effect = {
                 <div class="control__indicator"></div>
             </label>
         </div>
-        <label class="control-fb control--checkbox"> Put response body in a variable <tooltip text="'Put the response body into a variable so you can use it later'"></tooltip>
+        <label ng-show="effect.options.putResponseInVariable" class="control-fb control--checkbox"> Put response body in a variable <tooltip text="'Put the response body into a variable so you can use it later'"></tooltip>
             <input type="checkbox" ng-model="effect.options.putResponseInVariable">
             <div class="control__indicator"></div>
         </label>
@@ -245,6 +252,8 @@ const effect = {
             effect.method.toLowerCase() === "put" ||
             effect.method.toLowerCase() === "patch";
 
+        let responseData;
+
         try {
             const response = await axios({
                 method: effect.method.toLowerCase(),
@@ -253,6 +262,11 @@ const effect = {
                 data: sendBodyData === true ? bodyData : null
             });
 
+            responseData = response.data;
+
+            /**
+             * Deprecated
+             */
             if (effect.options.putResponseInVariable) {
                 customVariableManager.addCustomVariable(
                     effect.options.variableName,
@@ -285,7 +299,12 @@ const effect = {
             }
         }
 
-        return true;
+        return {
+            success: true,
+            outputs: {
+                httpResponse: responseData
+            }
+        };
     },
     overlayExtension: {
         dependencies: {

--- a/src/backend/effects/builtin/random-effect.js
+++ b/src/backend/effects/builtin/random-effect.js
@@ -53,7 +53,13 @@ const randomEffect = {
             hide-numbers="true"></effect-list>
     </eos-container>
 
-
+    <eos-container header="Options" pad-top="true">
+        <firebot-checkbox
+            model="effect.bubbleOutputs"
+            label="Apply effect outputs to parent list"
+            tooltip="Whether or not you want any effect outputs to be made available to the parent effect list."
+        />
+    </eos-container>
     `,
     /**
    * The controller for the front end Options
@@ -165,6 +171,7 @@ const randomEffect = {
                         if (result.stopEffectExecution) {
                             return resolve({
                                 success: true,
+                                outputs: effect.bubbleOutputs ? result.outputs : undefined,
                                 execution: {
                                     stop: true,
                                     bubbleStop: true
@@ -172,7 +179,10 @@ const randomEffect = {
                             });
                         }
                     }
-                    resolve(true);
+                    resolve({
+                        success: true,
+                        outputs: effect.bubbleOutputs ? result?.outputs : undefined
+                    });
                 });
         });
     }

--- a/src/gui/app/directives/controls/firebot-checkbox.js
+++ b/src/gui/app/directives/controls/firebot-checkbox.js
@@ -1,0 +1,20 @@
+"use strict";
+
+(function() {
+    angular
+        .module('firebotApp')
+        .component("firebotCheckbox", {
+            bindings: {
+                label: "@",
+                tooltip: "@?",
+                model: "=",
+                style: "@?"
+            },
+            template: `
+            <label class="control-fb control--checkbox" style="{{$ctrl.style}}"> {{$ctrl.label}} <tooltip ng-if="$ctrl.tooltip" text="$ctrl.tooltip"></tooltip>
+                <input type="checkbox" ng-model="$ctrl.model">
+                <div class="control__indicator"></div>
+            </label>
+            `
+        });
+}());


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Adds option to have effect outputs be applied to parent lists (run effect list, random effect, and conditional effects)
- Update HTTP Request effect to use outputs