### PR TITLE
chore: refactor chatter poll, use official API

### DIFF
--- a/src/backend/auth/twitch-auth.js
+++ b/src/backend/auth/twitch-auth.js
@@ -73,6 +73,7 @@ const STREAMER_ACCOUNT_PROVIDER = {
         'moderator:read:automod_settings',
         'moderator:read:blocked_terms',
         'moderator:read:chat_settings',
+        'moderator:read:chatters',
         'user:edit:broadcast',
         'user:manage:blocked_users',
         'user:manage:blocked_users',

--- a/src/backend/twitch-api/resource/chat.ts
+++ b/src/backend/twitch-api/resource/chat.ts
@@ -4,6 +4,30 @@ import accountAccess from "../../common/account-access";
 import { ApiClient, HelixChatAnnouncementColor, HelixSendChatAnnouncementParams, HelixUpdateChatSettingsParams } from "@twurple/api";
 
 /**
+ * Gets the list of all chatters in the channel.
+ */
+export async function getAllChatters(): Promise<string[]> {
+    const chatters: string[] = [];
+
+    try {
+        const client: ApiClient = twitchApi.getClient();
+        const streamerUserId: number = accountAccess.getAccounts().streamer.userId;
+
+        let result = await client.chat.getChatters(streamerUserId, streamerUserId);
+        chatters.push(...result.data.map(c => c.userDisplayName));
+
+        while (result.cursor) {
+            result = await client.chat.getChatters(streamerUserId, streamerUserId, { after: result.cursor });
+            chatters.push(...result.data.map(c => c.userDisplayName));
+        }
+    } catch (error) {
+        logger.error("Error getting chatter list", error);
+    }
+
+    return chatters;
+};
+
+/**
  * Sends an announcement to the streamer's chat.
  * 
  * @param message The announcement to send


### PR DESCRIPTION
### Description of the Change
Refactor the online chatter poll to be in TS, use official Twitch chatters API instead of deprecated unofficial endpoint.


### Applicable Issues
N/A


### Testing
Validated both initial load and refresh.


### Screenshots
N/A