### PR TITLE
fix: Enable use-text-area on relevant textboxes

### DIFF
--- a/src/backend/effects/builtin/file-writer.js
+++ b/src/backend/effects/builtin/file-writer.js
@@ -93,7 +93,7 @@ const fileWriter = {
         </eos-container>
 
         <eos-container header="Text" pad-top="true" ng-if="effect.writeMode === 'replace' || effect.writeMode === 'suffix' || effect.writeMode === 'append' || (effect.writeMode === 'delete' && effect.deleteLineMode === 'text') || (effect.writeMode === 'replace-line' && effect.replaceLineMode === 'text')">
-            <input ng-model="effect.text" type="text" class="form-control" id="chat-text-setting" placeholder="Enter text" ng-trim="false" replace-variables>
+            <firebot-input ng-model="effect.text" type="text" placeholder-text="Enter text" use-text-area="true"></firebot-input>
         </eos-container>
 
         <eos-container header="Line Number(s)" pad-top="true" ng-if="(effect.writeMode === 'delete' && effect.deleteLineMode === 'lines') || (effect.writeMode === 'replace-line' && effect.replaceLineMode === 'lineNumbers')">
@@ -102,7 +102,7 @@ const fileWriter = {
         </eos-container>
 
         <eos-container header="Replacement Text" pad-top="true" ng-if="effect.writeMode === 'replace-line'">
-            <input ng-model="effect.replacementText" type="text" class="form-control" id="chat-text-setting" placeholder="Enter text" replace-variables>
+            <firebot-input ng-model="effect.replacementText" type="text" placeholder-text="Enter text" use-text-area="true"></firebot-input>
         </eos-container>
     `,
     /**

--- a/src/backend/integrations/builtin/obs/effects/set-obs-source-text.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-source-text.ts
@@ -41,7 +41,7 @@ export const SetOBSSourceTextEffectType: EffectType<{
             <input type="checkbox" ng-click="toggleSource()" ng-checked="effect.textSource === 'file'"  aria-label="..." >
             <div class="control__indicator"></div>
         </label>
-        <firebot-input ng-if="effect.textSource === 'static'" model="effect.text"></firebot-input>
+        <firebot-input ng-if="effect.textSource === 'static'" model="effect.text" use-text-area="true"></firebot-input>
         <file-chooser ng-if="effect.textSource === 'file'" model="effect.file" options="{ filters: [ {name: 'Text File', extensions: ['txt']}, {name: 'All Files', extensions: ['*']} ]}" on-update="textFileUpdated(filepath)"></file-chooser>
     </eos-container>
   `,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This PR enables larger multi-line textboxes on the **Text** and **Replacement Text** inputs for the **Write To File** effect, as well as the input for **Set OBS Source Text**

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
I've tested and verified that text is still properly written to file (with multiline/newline support) and that previously created effects still work properly.
For the OBS Source Text, I've tested that text properly gets set on the text source (with multiline/newline support) and that previously created effects still work properly.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
