### PR TITLE
fix: long videos resourceToken expires before video finish

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -438,7 +438,31 @@ const playVideo = {
             return true;
         }
 
-        const resourceToken = resourceTokenManager.storeResourcePath(data.filepath, effect.length);
+        const durationToken = resourceTokenManager.storeResourcePath(data.filepath, 5);
+
+        const durationPromise = new Promise(async (resolve, reject) => {
+            const listener = (event) => {
+                try {
+                    if (event.name === "video-duration" && event.data.resourceToken === durationToken) {
+                        webServer.removeListener("overlay-event", listener);
+                        resolve(event.data.duration);
+                    }
+                } catch (err) {
+                    logger.error("Error while trying to process overlay-event for getVideoDuration: ", err);
+                    reject(err);
+                }
+            };
+            webServer.on("overlay-event", listener);
+        });
+
+        webServer.sendToOverlay("getVideoDuration", {
+            resourceToken: durationToken
+        });
+
+        const duration = await durationPromise;
+
+        const resourceToken = resourceTokenManager.storeResourcePath(data.filepath, duration + 5);
+        logger.info(`Retrieved duration for video: ${duration}`);
         data.resourceToken = resourceToken;
 
         webServer.sendToOverlay("video", data);
@@ -452,6 +476,7 @@ const playVideo = {
                         }
                     } catch (err) {
                         logger.error("Error while trying to process overlay-event for play-video: ", err);
+                        reject(err);
                     }
                 };
                 webServer.on("overlay-event", listener);

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -456,7 +456,8 @@ const playVideo = {
         });
 
         webServer.sendToOverlay("getVideoDuration", {
-            resourceToken: durationToken
+            resourceToken: durationToken,
+            overlayInstance: data.overlayInstance
         });
 
         const duration = await durationPromise;

--- a/src/resources/overlay/js/main.js
+++ b/src/resources/overlay/js/main.js
@@ -49,6 +49,21 @@ function overlaySocketConnect(){
 				return;
 			}
 
+            if(event == "getVideoDuration") {
+                const token = encodeURIComponent(data.meta.resourceToken);
+                const url = `http://${window.location.hostname}:7472/resource/${token}`;
+                const videoElement = `
+                        <video id="${token}" class="player" style="display:none;">
+                            <source src="${url}">
+                        </video>
+                    `;
+                $(".wrapper").append(videoElement);
+                const video = document.getElementById(token);
+                video.oncanplay = () => {
+                    sendWebsocketEvent("video-duration", {resourceToken: token, duration: Math.ceil(video.duration)});
+                    video.remove();
+                }
+            }
 
 			firebotOverlay.emit(event, data.meta);
 		};


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Resource token length for videos is now dynamically fetched from the overlay instead of relying on being set as video duration by the user.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2058 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
I've tested to make sure that there's no noticeable delay on video start, and the video would complete fully.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
