### PR TITLE
feat: Discord Timestamps Variable

### DIFF
--- a/src/backend/variables/builtin-variable-loader.js
+++ b/src/backend/variables/builtin-variable-loader.js
@@ -56,6 +56,7 @@ exports.loadReplaceVariables = () => {
         'custom-variable-expired-data',
         'custom-variable-expired-name',
         'date',
+        'discord-timestamp',
         'donation-amount-formatted',
         'donation-amount',
         'donation-from',

--- a/src/backend/variables/builtin/discord-timestamp.js
+++ b/src/backend/variables/builtin/discord-timestamp.js
@@ -78,7 +78,7 @@ const model = {
             'R'
         ];
 
-        // Create dateString using current time if no dateString provided.
+        // Create dateString using current time if no dateString provided. 
         if (dateString == null || dateString === 'now') {
             dateString = moment().format('YYYY-MM-DD HH:mm:ss');
         }

--- a/src/backend/variables/builtin/discord-timestamp.js
+++ b/src/backend/variables/builtin/discord-timestamp.js
@@ -103,8 +103,6 @@ const model = {
         // Convert dateString to unix for discord.
         timestamp = moment(dateString, 'YYYY-MM-DD HH:mm:ss').unix();
 
-        console.log(timestamp);
-
         // If no format given, use discord default.
         if (format == null || format === '') {
             return `<t:${timestamp}>`;

--- a/src/backend/variables/builtin/discord-timestamp.js
+++ b/src/backend/variables/builtin/discord-timestamp.js
@@ -78,7 +78,7 @@ const model = {
             'R'
         ];
 
-        // Create dateString using current time if no dateString provided. 
+        // Create dateString using current time if no dateString provided.
         if (dateString == null || dateString === 'now') {
             dateString = moment().format('YYYY-MM-DD HH:mm:ss');
         }

--- a/src/backend/variables/builtin/discord-timestamp.js
+++ b/src/backend/variables/builtin/discord-timestamp.js
@@ -1,0 +1,125 @@
+// Migration: info needed
+"use strict";
+const moment = require("moment");
+const logger = require("../../logwrapper");
+const { EffectTrigger } = require("../../../shared/effect-constants");
+const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
+const triggers = {};
+triggers[EffectTrigger.COMMAND] = true;
+triggers[EffectTrigger.EVENT] = true;
+triggers[EffectTrigger.MANUAL] = true;
+triggers[EffectTrigger.CUSTOM_SCRIPT] = true;
+triggers[EffectTrigger.PRESET_LIST] = true;
+triggers[EffectTrigger.CHANNEL_REWARD] = true;
+const model = {
+    definition: {
+        handle: "discordTimestamp",
+        description: "Outputs a discord timestamp that shows the appropriate time for all users in their own timezone.",
+        usage: "discordTimestamp[]",
+        examples: [
+            {
+                usage: "discordTimestamp[]",
+                description: "Create discord timestamp using your current time."
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00]",
+                description: "Create discord timestamp using specified time, in default discord format."
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:t]",
+                description: "Create a 'short time' discord timestamp. EX: 01:00 | 1:00 PM"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:T]",
+                description: "Create a 'long time' discord timestamp. EX: 01:00:00 | 01:00:00 PM"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:d]",
+                description: "Create a 'short date' discord timestamp. EX: 1/26/2076 | 26/01/2076"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:D]",
+                description: "Create a 'long date' discord timestamp. EX: January 26, 2076 | 26 January 2076"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:f]",
+                description: "Create a 'short date/time' discord timestamp. EX: January 26, 2076 1:00 PM | 26 January 2076 13:00"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:F]",
+                description: "Create a 'long date/time' discord timestamp. EX: Sunday, January 26, 2076 1:00 PM | Sunday, 26 January 2076, 13:00"
+            },
+            {
+                usage: "discordTimestamp[2076-01-26 13:00:00:R]",
+                description: "Create a 'relative' discord timestamp. EX: 'in 53 years' | 'in 23 minutes'"
+            },
+            {
+                usage: "discordTimestamp[13:00:00]",
+                description: "Create discord timestamp using a specified time on the current date."
+            },
+            {
+                usage: "discordTimestamp[now, R]",
+                description: "Create discord timestamp using current date and time in a specified format."
+            }
+        ],
+        triggers: triggers,
+        categories: [VariableCategory.TEXT],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (_, dateString, format) => {
+        let timestamp = moment().unix();
+        const validFormats = [
+            't',
+            'T',
+            'd',
+            'D',
+            'f*',
+            'F',
+            'R'
+        ];
+
+        // Create dateString using current time if no dateString provided.
+        if (dateString == null || dateString === 'now') {
+            dateString = moment().format('YYYY-MM-DD HH:mm:ss');
+        }
+
+        dateString = dateString.trim();
+
+        // If user only includes time, assume they want that time on the current day.
+        if (!dateString.includes('-')) {
+            let userDate = new Date();
+            const offset = userDate.getTimezoneOffset();
+            userDate = new Date(userDate.getTime() - (offset * 60 * 1000));
+            userDate = userDate.toISOString().split('T')[0];
+            dateString = `${userDate} ${dateString}`;
+        }
+
+        // Now, validate dateString format.
+        if (!moment(dateString, 'YYYY-MM-DD HH:mm:ss', true).isValid()) {
+            logger.error(`Incorrect date format provided to discord timestamp.`);
+            return '[Incorrect date format]';
+        }
+
+        // Convert dateString to unix for discord.
+        timestamp = moment(dateString, 'YYYY-MM-DD HH:mm:ss').unix();
+
+        console.log(timestamp);
+
+        // If no format given, use discord default.
+        if (format == null || format === '') {
+            return `<t:${timestamp}>`;
+        }
+
+        format = format.trim();
+
+        // Validate format is a valid discord format. If not, log error and use discord default format.
+        if (!validFormats.includes(format)) {
+            logger.error(`Incorrect format passed to discord timestamp, using discord defaults.`);
+            return `<t:${timestamp}>`;
+        }
+
+        // Otherwise, use the given format.
+        return `<t:${timestamp}:${format}>`;
+    }
+};
+module.exports = model;


### PR DESCRIPTION
### Description of the Change
This adds in a new variable that generates discord timestamps. This is meant to really only ever be used with the "send discord message" effect.  This will generate text similar to "<t:1543392060:R>". It supports all of the formats that discord supports. I've also tried to make it flexible as possible so that people can use it to announce stream times and other things.

- Can exclude the date to use the current date at the specified time.
- Can use 'now' instead of a time to use the current date and time. This allows people to use the current time in whatever format they want.
- Can use any discord timestamp format.

https://discord.com/developers/docs/reference#message-formatting-timestamp-styles

### Applicable Issues
- No issues, but it is important to note that discord will change the output format based on if the end user has 12 hour or 24 hour time set. I've tried to include both in the examples. This doesn't change how the user enters time into firebot.


### Testing
-  $discordTimestamp[2076-01-26 13:00:00]
-  $discordTimestamp[13:00:00]
-  $discordTimestamp[2076-01-26 13:00:00, R]
-  $discordTimestamp[13:00:00, R]
-  $discordTimestamp[now, R]
-  $discordTimestamp[]
-  $discordTimestamp[blahblahblah] (will output [Incorrect date format])
- $discordTimestamp[now, LOL] (will fallback to discord default format)

### Screenshots
None

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
