### PR TITLE
feat: auto logout for outdated Twitch accounts

### DIFF
--- a/src/backend/auth/twitch-auth.js
+++ b/src/backend/auth/twitch-auth.js
@@ -2,6 +2,7 @@
 
 const authManager = require("./auth-manager");
 const accountAccess = require("../common/account-access");
+const frontendCommunicator = require("../common/frontend-communicator");
 const logger = require("../logwrapper");
 const axios = require("axios").default;
 
@@ -16,6 +17,28 @@ const AUTHORIZE_PATH = "/oauth2/authorize";
 
 const STREAMER_ACCOUNT_PROVIDER_ID = "twitch:streamer-account";
 const BOT_ACCOUNT_PROVIDER_ID = "twitch:bot-account";
+
+/**
+ * @param {import("./auth").AuthProviderDefinition} definition
+ * @param {import("./auth").AuthDetails} authDetails
+ * @returns boolean
+ */
+const validator = function(definition, authDetails) {
+    return (
+        // Ensure authDetails exist
+        authDetails &&
+
+        // Check for old auth code flow token
+        !authDetails.refresh_token &&
+
+        // Make sure there's at least some scopes
+        authDetails.scope &&
+        authDetails.scope.length > 0 &&
+
+        // check all required scopes are present
+        definition.scopes.every(scope => authDetails.scope.includes(scope))
+    );
+};
 
 /** @type {import("./auth").AuthProviderDefinition} */
 const STREAMER_ACCOUNT_PROVIDER = {
@@ -168,4 +191,27 @@ authManager.on("auth-success", async authData => {
 
         accountAccess.updateAccount(accountType, accountObject);
     }
+});
+
+frontendCommunicator.on("validate-twitch-account", ({ accountType, authDetails }) => {
+    let definition;
+
+    switch (accountType) {
+    case "streamer":
+        definition = STREAMER_ACCOUNT_PROVIDER;
+        break;
+
+    case "bot":
+        definition = BOT_ACCOUNT_PROVIDER;
+        break;
+
+    default:
+        break;
+    }
+
+    if (definition) {
+        return validator(definition, authDetails);
+    }
+
+    return true;
 });

--- a/src/gui/app/app-main.js
+++ b/src/gui/app/app-main.js
@@ -171,6 +171,9 @@
             updatesService.checkForUpdate();
         }
 
+        // Validate Twitch accounts
+        connectionService.validateAccounts();
+
         ttsService.obtainVoices().then(() => {
             if (settingsService.getDefaultTtsVoiceId() == null) {
                 settingsService.setDefaultTtsVoiceId(ttsService.getOsDefaultVoiceId());

--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -470,6 +470,13 @@
         <h4 class="modal-title" aria-label="Manage Logins">{{'MAIN.MANAGE_LOGINS' | translate }}</h4>
       </div>
       <div class="modal-body">
+            <div ng-if="invalidAccounts && invalidAccounts.length > 0" class="row mb-8" style="text-align: center;">
+              The following account(s) have been logged out because they are out of date:
+              <br />
+              <strong>{{ invalidAccounts.join(", ") }}</strong>
+              <br /><br />
+              Please log back in to continue.
+            </div>
             <div class="row" style="text-align: center;">
               <div class="col-sm-6 streamer-login top-padding">
                 <img class="login-pic" ng-src="{{getAccountAvatar('streamer')}}">


### PR DESCRIPTION
### Description of the Change
Auto logout Twitch accounts that are out of date (missing OAuth scopes, has legacy `refresh_token`)


### Applicable Issues
N/A


### Testing
Verified valid accounts do not logout, and out of date accounts both logout and show the Manage Logins dialog with the applicable messaging.


### Screenshots
![image](https://user-images.githubusercontent.com/1764877/223177170-c974e23f-6017-4bf6-bb57-97a40b0242ef.png)