### PR TITLE
fix: Loopeffects being initialized as int but expecting string

### DIFF
--- a/src/backend/effects/builtin/loop-effects.js
+++ b/src/backend/effects/builtin/loop-effects.js
@@ -81,9 +81,9 @@ const model = {
 
         $scope.loopModeChanged = () => {
             if ($scope.effect.loopMode === "count") {
-                $scope.effect.loopCount = 5;
+                $scope.effect.loopCount = "5";
             } else if ($scope.effect.loopMode === "conditional") {
-                $scope.effect.loopCount = 25;
+                $scope.effect.loopCount = "25";
             }
         };
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
changes the loop initialization of count to string to prevent the trim() error 


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2165

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->

i tested both loop count and loop conditional by creating a new loop and by changing the loop count

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
