### PR TITLE
fix: null/undefined itemId for queue manager

### DIFF
--- a/src/backend/effects/queues/effect-queue-manager.js
+++ b/src/backend/effects/queues/effect-queue-manager.js
@@ -94,6 +94,10 @@ class EffectQueueManager extends JsonDbManager {
      * @returns {T|null}
      */
     getItem(itemId) {
+        if (itemId == null) {
+            return null;
+        }
+        
         const item = JSON.parse(JSON.stringify(super.getItem(itemId)));
 
         item.queue = effectQueueRunner.getQueue(itemId);


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Add null-checking for effectQueueManager.getItem as effectRunner still requests null queues.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
