### PR TITLE
Youtube Video Fix

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -464,24 +464,7 @@ const playVideo = {
         data.resourceToken = resourceToken;
 
         webServer.sendToOverlay("video", data);
-        if (effect.wait && effect.videoType === "YouTube Video") {
-            // Use overlay callback for youtube video, needs local way to get duration for production.
-            // If effect is ran with "Wait for video to finish" while overlay is not open, it may freeze an effect queue.
-            await new Promise(async (resolve, reject) => {
-                const listener = (event) => {
-                    try {
-                        if (event.name === "video-end" && event.data.resourceToken === resourceToken) {
-                            webServer.removeListener("overlay-event", listener);
-                            resolve();
-                        }
-                    } catch (err) {
-                        logger.error("Error while trying to process overlay-event for play-video: ", err);
-                        reject(err);
-                    }
-                };
-                webServer.on("overlay-event", listener);
-            });
-        } else if (effect.wait && data.videoType === "Local Video") {
+        if (effect.wait) {
             let internalDuration = data.videoDuration;
             if (internalDuration == null || internalDuration === 0 || internalDuration === "") {
                 internalDuration = duration;
@@ -544,7 +527,7 @@ const playVideo = {
                 const data = event;
 
                 const videoType = data.videoType;
-                const filepath = data.filepath;
+                const filepath = data.filepath ?? "";
                 let fileExt = filepath.split(".").pop();
                 if (fileExt === "ogv") {
                     fileExt = "ogg";

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -449,6 +449,10 @@ const playVideo = {
             const result = await frontendCommunicator.fireEventAsync("getYoutubeVideoDuration", data.youtubeId);
             if (!isNaN(result)) {
                 duration = result;
+            } else {
+                // Error
+                logger.error("Play Video Effect: Unable to retrieve Youtube Video Duration", result);
+                return;
             }
             if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
                 data.videoStarttime = youtubeData.startTime;

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -443,7 +443,9 @@ const playVideo = {
 
         let resourceToken;
         let duration;
-        if (effect.videoType === "YouTube Video") {
+        if (effect.videoType === "YouTube Video" && !effect.wait) {
+            logger.debug("Play Video Effect: Proceeding without Youtube Video Duration because wait is false");
+        } else if (effect.videoType === "YouTube Video" && effect.wait) {
             const youtubeData = parseYoutubeId(data.youtubeId);
             data.youtubeId = youtubeData.id;
             const result = await frontendCommunicator.fireEventAsync("getYoutubeVideoDuration", data.youtubeId);
@@ -457,7 +459,7 @@ const playVideo = {
             if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
                 data.videoStarttime = youtubeData.startTime;
             }
-        } else {
+        } else if (effect.videoType === "Local Video") {
             const result = await frontendCommunicator.fireEventAsync("getVideoDuration", data.filepath);
             if (!isNaN(result)) {
                 duration = result;

--- a/src/gui/app/services/video.service.js
+++ b/src/gui/app/services/video.service.js
@@ -46,6 +46,9 @@
                             onReady: (event) => {
                                 event.target.setVolume(0);
                                 event.target.playVideo();
+                                if (player.getDuration() === 0) {
+                                    return;
+                                }
                                 resolve(player.getDuration());
                                 document.getElementById(id).remove();
                             },
@@ -54,16 +57,16 @@
                                     code: event.data,
                                     youtubeId: videoId
                                 };
-                                if (event.data === 2) {
+                                if (event.data === "2") {
                                     error.error = "The request contains an invalid parameter value.";
                                 }
-                                if (event.data === 5) {
+                                if (event.data === "5") {
                                     error.error = "The requested content cannot be played in an HTML5 player or another error related to the HTML5 player has occurred.";
                                 }
-                                if (event.data === 100) {
+                                if (event.data === "100") {
                                     error.error = "The video requested was not found. This error occurs when a video has been removed (for any reason) or has been marked as private.";
                                 }
-                                if (event.data === 101 || event.data === 150) {
+                                if (event.data === "101" || event.data === "150") {
                                     error.error = "The owner of the requested video does not allow it to be played in embedded players.";
                                 }
                                 resolve(error);
@@ -75,11 +78,11 @@
             };
 
             backendCommunicator.onAsync("getVideoDuration", async (path) => {
-                return service.getVideoDuration(path);
+                return await service.getVideoDuration(path);
             });
 
             backendCommunicator.onAsync("getYoutubeVideoDuration", async (youtubeId) => {
-                return service.getYoutubeVideoDuration(youtubeId);
+                return await service.getYoutubeVideoDuration(youtubeId);
             });
 
             return service;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes Youtube Video duration fetching. Youtube may reject requests to load the video, which means we can't fetch the duration. If this happened previously, the youtube video would load in the overlay (and sometimes succeed to play) while the backend would wait for 0 seconds. This could create situations where multiple videos would play, or setups would otherwise break.

With these changes, if the video effect is set to wait and there's an error retrieving the video duration, the effect logs an error message and stops without playing the video. If the effect is not set to wait, it'll continue to send the youtube video to the overlay. During testing, Youtube was more likely to block the iframe API in electron than the iframe API in the overlay, so this can help some videos to still play.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
These changes were extensively tested for issues, and pre-existing setups relying on wait for video duration work properly again.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
