### PR TITLE
Quotes: Use "Quote Date Format" setting for date output.

### DIFF
--- a/src/backend/chat/commands/builtin/quotes.js
+++ b/src/backend/chat/commands/builtin/quotes.js
@@ -31,7 +31,7 @@ const quotesManagement = {
             quoteDateFormat: {
                 type: "enum",
                 title: "Quote Date Format",
-                description: "How dates should be formatted for the 'editdate' mod command.",
+                description: "How dates should be formatted for the '!quote' and '!quote editdate' commands.",
                 options: [
                     "MM/DD/YYYY",
                     "DD/MM/YYYY"
@@ -210,7 +210,7 @@ const quotesManagement = {
             const args = event.userCommand.args;
 
             const getFormattedQuoteString = (quote) => {
-                const prettyDate = quote.createdAt != null ? moment(quote.createdAt).format('L') : "No Date";
+                const prettyDate = quote.createdAt != null ? moment(quote.createdAt).format(commandOptions.quoteDateFormat) : "No Date";
                 return commandOptions.quoteDisplayTemplate
                     .replace("{id}", quote._id)
                     .replace("{text}", quote.text)

--- a/src/backend/variables/builtin/quote-as-object.js
+++ b/src/backend/variables/builtin/quote-as-object.js
@@ -2,6 +2,8 @@
 
 "use strict";
 const quoteManager = require("../../quotes/quotes-manager");
+const commandsManager = require("../../chat/commands/CommandManager");
+const moment = require("moment");
 const logger = require("../../logwrapper");
 
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
@@ -28,6 +30,8 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: async (_, quoteId, property) => {
+        const quoteCommand = commandsManager.getSystemCommandById("firebot:quotesmanagement");
+        const quoteDateFormat = quoteCommand.definition.options.quoteDateFormat.value;
         let quote;
         quoteId = parseInt(quoteId);
 
@@ -41,10 +45,9 @@ const model = {
 
         if (quote != null) {
             logger.debug("Found a quote!");
-            const ts = new Date(quote.createdAt);
             const quoteObject = {
                 id: quote._id,
-                createdAt: ts.toLocaleString(),
+                createdAt: moment(quote.createdAt).format(quoteDateFormat),
                 creator: quote.creator,
                 originator: quote.originator,
                 text: quote.text,

--- a/src/backend/variables/builtin/quote-as-raw-object.js
+++ b/src/backend/variables/builtin/quote-as-raw-object.js
@@ -2,6 +2,8 @@
 
 "use strict";
 const quoteManager = require("../../quotes/quotes-manager");
+const commandsManager = require("../../chat/commands/CommandManager");
+const moment = require("moment");
 const logger = require("../../logwrapper");
 
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
@@ -28,6 +30,8 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: async (_, quoteId, property) => {
+        const quoteCommand = commandsManager.getSystemCommandById("firebot:quotesmanagement");
+        const quoteDateFormat = quoteCommand.definition.options.quoteDateFormat.value;
         let quote;
         quoteId = parseInt(quoteId);
 
@@ -41,10 +45,9 @@ const model = {
 
         if (quote != null) {
             logger.debug("Found a quote!");
-            const ts = new Date(quote.createdAt);
             const quoteObject = {
                 id: quote._id,
-                createdAt: ts.toLocaleString(),
+                createdAt: moment(quote.createdAt).format(quoteDateFormat),
                 creator: quote.creator,
                 originator: quote.originator,
                 text: quote.text,

--- a/src/backend/variables/builtin/quote.js
+++ b/src/backend/variables/builtin/quote.js
@@ -2,6 +2,8 @@
 
 "use strict";
 const quoteManager = require("../../quotes/quotes-manager");
+const commandsManager = require("../../chat/commands/CommandManager");
+const moment = require("moment");
 const logger = require("../../logwrapper");
 
 const { OutputDataType, VariableCategory } = require("../../../shared/variable-constants");
@@ -20,6 +22,8 @@ const model = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: async (_, quoteId) => {
+        const quoteCommand = commandsManager.getSystemCommandById("firebot:quotesmanagement");
+        const quoteDateFormat = quoteCommand.definition.options.quoteDateFormat.value;
         let quote;
         quoteId = parseInt(quoteId);
 
@@ -32,10 +36,9 @@ const model = {
         }
 
         if (quote != null) {
-            const ts = new Date(quote.createdAt);
-            const timestamp = ts.toLocaleString();
+            const date = moment(quote.createdAt).format(quoteDateFormat);
             const quoteText = decodeURIComponent(quote.text);
-            const quoteString = quoteText + ' - ' + quote.originator + '. [' + quote.game + '] - ' + timestamp;
+            const quoteString = quoteText + ' - ' + quote.originator + '. [' + quote.game + '] - ' + date;
             logger.debug("Found a quote!");
             return quoteString;
         }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Updated quotes to use "Quote Date Format" setting.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1954

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
!quote command and $quote, $quoteAsObject and $rawQuoteAsObject were tested before and after the change. before, they all returned MM/DD/YYYY regardless of setting. Now, they all follow the setting. When the setting is changed, the output is the new format.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
