### PR TITLE
Fix: play random video

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -459,14 +459,14 @@ const playVideo = {
             if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
                 data.videoStarttime = youtubeData.startTime;
             }
-        } else if (effect.videoType === "Local Video") {
+        } else if (effect.videoType = "Local Video" || effect.videoType === "Random From Folder") {
             const result = await frontendCommunicator.fireEventAsync("getVideoDuration", data.filepath);
             if (!isNaN(result)) {
                 duration = result;
             }
             resourceToken = resourceTokenManager.storeResourcePath(data.filepath, duration);
         }
-
+        data.videoDuration = duration;
         data.resourceToken = resourceToken;
 
         webServer.sendToOverlay("video", data);

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -459,7 +459,7 @@ const playVideo = {
             if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
                 data.videoStarttime = youtubeData.startTime;
             }
-        } else if (effect.videoType = "Local Video" || effect.videoType === "Random From Folder") {
+        } else if (effect.videoType === "Local Video" || effect.videoType === "Random From Folder") {
             const result = await frontendCommunicator.fireEventAsync("getVideoDuration", data.filepath);
             if (!isNaN(result)) {
                 duration = result;


### PR DESCRIPTION
I have tested this local and it works to play randomly videos from file.

### Description of the Change
should fix play random video not working 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2238

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
was able to play 5 random video's from a folder 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
