### PR TITLE
Queues: Move null check, fixes invalid queue ID causing error

### DIFF
--- a/src/backend/effects/queues/effect-queue-manager.js
+++ b/src/backend/effects/queues/effect-queue-manager.js
@@ -94,11 +94,11 @@ class EffectQueueManager extends JsonDbManager {
      * @returns {T|null}
      */
     getItem(itemId) {
-        if (itemId == null) {
+        const item = JSON.parse(JSON.stringify(super.getItem(itemId)));
+
+        if (item == null) {
             return null;
         }
-        
-        const item = JSON.parse(JSON.stringify(super.getItem(itemId)));
 
         item.queue = effectQueueRunner.getQueue(itemId);
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Move null check in queue manager to catch both invalid and null queue IDs.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that both null (never assigned a queue) and invalid (queue assigned, later deleted) queue IDs return null instead of trying to create a queue object.


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
