### PR TITLE
fix: video duration regression

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -443,11 +443,16 @@ const playVideo = {
 
         let resourceToken;
         let duration;
+        if (effect.videoType === "YouTube Video") {
+            const youtubeData = parseYoutubeId(data.youtubeId);
+            data.youtubeId = youtubeData.id;
+            if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
+                data.videoStarttime = youtubeData.startTime;
+            }
+        }
         if (effect.videoType === "YouTube Video" && !effect.wait) {
             logger.debug("Play Video Effect: Proceeding without Youtube Video Duration because wait is false");
         } else if (effect.videoType === "YouTube Video" && effect.wait) {
-            const youtubeData = parseYoutubeId(data.youtubeId);
-            data.youtubeId = youtubeData.id;
             const result = await frontendCommunicator.fireEventAsync("getYoutubeVideoDuration", data.youtubeId);
             if (!isNaN(result)) {
                 duration = result;
@@ -455,9 +460,6 @@ const playVideo = {
                 // Error
                 logger.error("Play Video Effect: Unable to retrieve Youtube Video Duration", result);
                 return;
-            }
-            if (data.videoStarttime == null || data.videoStarttime == "" || data.videoStarttime == 0) {
-                data.videoStarttime = youtubeData.startTime;
             }
         } else if (effect.videoType === "Local Video" || effect.videoType === "Random From Folder") {
             const result = await frontendCommunicator.fireEventAsync("getVideoDuration", data.filepath);

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -475,11 +475,7 @@ const playVideo = {
 
         webServer.sendToOverlay("video", data);
         if (effect.wait) {
-            let internalDuration = data.videoDuration;
-            if (internalDuration == null || internalDuration === 0 || internalDuration === "") {
-                internalDuration = duration;
-            }
-            await wait(internalDuration * 1000);
+            await wait(data.videoDuration * 1000);
         }
         return true;
     },

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -468,7 +468,9 @@ const playVideo = {
             }
             resourceToken = resourceTokenManager.storeResourcePath(data.filepath, duration);
         }
-        data.videoDuration = duration;
+        if ((data.videoDuration == null || data.videoDuration == "" || data.videoDuration == 0) && duration != null) {
+            data.videoDuration = duration;
+        }
         data.resourceToken = resourceToken;
 
         webServer.sendToOverlay("video", data);


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Fix issue with youtube videos not passing properties properly when wait is disabled.
- Fix issue with user entered video duration being overwritten by resolved duration from duration check.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Testing done by CKY, looking for more testing from affected users in Discord

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
