### PR TITLE
fix: amazon polly effects from before update not working

### DIFF
--- a/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
+++ b/src/backend/integrations/builtin/aws/text-to-speech-polly-effect.js
@@ -515,30 +515,36 @@ const playSound = {
             effect.text = effect.text.replace("&", "&amp;");
         }
 
-        let listLexiconsResponse = null;
-        let lexicons = [];
-        let lexiconError;
-
-        do {
-            try {
-                const listLexiconsCommand = new ListLexiconsCommand({
-                    NextToken: listLexiconsResponse ? listLexiconsResponse.NextToken : undefined
-                });
-                listLexiconsResponse = await polly.send(listLexiconsCommand);
-                listLexiconsResponse.Lexicons.forEach(lexicon => lexicons.push(lexicon.Name));
-            } catch (e) {
-                lexicons = [];
-                lexiconError = e;
-                listLexiconsResponse = null;
-                break;
-            }
-        } while (listLexiconsResponse && listLexiconsResponse.NextToken);
-
-        if (lexiconError) {
-            logger.error("Error while trying to fetch lexicons before speech synthesis, proceeding without lexicons.");
+        if (effect.lexicons == null) {
             effect.lexicons = [];
-        } else {
-            effect.lexicons = effect.lexicons.filter(lexicon => lexicons.includes(lexicon));
+        }
+
+        if (effect.lexicons.length !== 0) {
+            let listLexiconsResponse = null;
+            let lexicons = [];
+            let lexiconError;
+
+            do {
+                try {
+                    const listLexiconsCommand = new ListLexiconsCommand({
+                        NextToken: listLexiconsResponse ? listLexiconsResponse.NextToken : undefined
+                    });
+                    listLexiconsResponse = await polly.send(listLexiconsCommand);
+                    listLexiconsResponse.Lexicons.forEach(lexicon => lexicons.push(lexicon.Name));
+                } catch (e) {
+                    lexicons = [];
+                    lexiconError = e;
+                    listLexiconsResponse = null;
+                    break;
+                }
+            } while (listLexiconsResponse && listLexiconsResponse.NextToken);
+
+            if (lexiconError) {
+                logger.error("Error while trying to fetch lexicons before speech synthesis, proceeding without lexicons.");
+                effect.lexicons = [];
+            } else {
+                effect.lexicons = effect.lexicons.filter(lexicon => lexicons.includes(lexicon));
+            }
         }
 
         const synthSpeechCommand = new SynthesizeSpeechCommand({


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Add null check for lexicons when running AWS Polly effect

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2244 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that effects without the lexicons property still play.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
