### PR TITLE
fix userid and useridname variables & fix multi-month gifted subscription 

### DIFF
--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -180,8 +180,10 @@ exports.setupChatListeners = (streamerChatClient) => {
         );
     });
 
-    streamerChatClient.onRaid((_channel, _username, raidInfo) => {
+    streamerChatClient.onRaid((_channel, _username, raidInfo, msg) => {
         twitchEventsHandler.raid.triggerRaid(
+            msg.userInfo.userName,
+            msg.userInfo.userId,
             raidInfo.displayName,
             raidInfo.viewerCount
         );

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -109,6 +109,24 @@ exports.setupChatListeners = (streamerChatClient) => {
 
     streamerChatClient.onResub(async (_channel, _user, subInfo, msg) => {
         try {
+            if (subInfo.originalGiftInfo != null) {
+                twitchEventsHandler.sub.triggerSub(
+                    msg.userInfo.userName,
+                    subInfo.userId,
+                    subInfo.displayName,
+                    subInfo.plan,
+                    subInfo.months || 1,
+                    subInfo.message ?? "",
+                    subInfo.streak || 1,
+                    false,
+                    true
+                );
+            }
+        } catch (error) {
+            logger.error("Failed to parse resub message (multi-month gifted sub)", error);
+        }
+
+        try {
             if (subInfo.message != null && subInfo.message.length > 0) {
                 const firebotChatMessage = await chatHelpers.buildFirebotChatMessage(msg, subInfo.message);
 

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -37,6 +37,7 @@ exports.setupChatListeners = (streamerChatClient) => {
 
         twitchEventsHandler.announcement.triggerAnnouncement(
             firebotChatMessage.useridname,
+            firebotChatMessage.userId,
             firebotChatMessage.username,
             firebotChatMessage.roles,
             firebotChatMessage.rawText

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -146,6 +146,7 @@ exports.setupChatListeners = (streamerChatClient) => {
     streamerChatClient.onGiftPaidUpgrade((_channel, _user, subInfo) => {
         twitchEventsHandler.giftSub.triggerSubGiftUpgrade(
             subInfo.displayName,
+            subInfo.userId,
             subInfo.gifterDisplayName,
             subInfo.plan
         );

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -171,8 +171,9 @@ exports.setupChatListeners = (streamerChatClient) => {
         );
     });
 
-    streamerChatClient.onPrimePaidUpgrade((_channel, _user, subInfo) => {
+    streamerChatClient.onPrimePaidUpgrade((_channel, _user, subInfo, msg) => {
         twitchEventsHandler.sub.triggerPrimeUpgrade(
+            msg.userInfo.userName,
             subInfo.displayName,
             subInfo.userId,
             subInfo.plan

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -155,6 +155,7 @@ exports.setupChatListeners = (streamerChatClient) => {
     streamerChatClient.onPrimePaidUpgrade((_channel, _user, subInfo) => {
         twitchEventsHandler.sub.triggerPrimeUpgrade(
             subInfo.displayName,
+            subInfo.userId,
             subInfo.plan
         );
     });

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -132,6 +132,8 @@ exports.setupChatListeners = (streamerChatClient) => {
     streamerChatClient.onSubGift((_channel, _user, subInfo) => {
         twitchEventsHandler.giftSub.triggerSubGift(
             subInfo.gifterDisplayName ?? "An Anonymous Gifter",
+            subInfo.gifter,
+            subInfo.gifterUserId,
             !subInfo.gifterUserId,
             subInfo.displayName,
             subInfo.plan,

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -73,7 +73,7 @@ exports.setupChatListeners = (streamerChatClient) => {
 
         activeUserHandler.addActiveUser(msg.userInfo, true);
 
-        twitchEventsHandler.viewerArrived.triggerViewerArrived(msg.userInfo.displayName, messageText);
+        twitchEventsHandler.viewerArrived.triggerViewerArrived(msg.userInfo.displayName, msg.userInfo.userName, msg.userInfo.userId, messageText);
 
         const { streamer, bot } = accountAccess.getAccounts();
         if (user !== streamer.username && user !== bot.username) {
@@ -99,7 +99,7 @@ exports.setupChatListeners = (streamerChatClient) => {
 
         twitchEventsHandler.chatMessage.triggerChatMessage(firebotChatMessage);
 
-        twitchEventsHandler.viewerArrived.triggerViewerArrived(msg.userInfo.displayName, messageText);
+        twitchEventsHandler.viewerArrived.triggerViewerArrived(msg.userInfo.displayName, msg.userInfo.userName, msg.userInfo.userId, messageText);
     });
 
     streamerChatClient.onMessageRemove((_channel, messageId) => {

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -161,8 +161,9 @@ exports.setupChatListeners = (streamerChatClient) => {
         );
     });
 
-    streamerChatClient.onGiftPaidUpgrade((_channel, _user, subInfo) => {
+    streamerChatClient.onGiftPaidUpgrade((_channel, _user, subInfo, msg) => {
         twitchEventsHandler.giftSub.triggerSubGiftUpgrade(
+            msg.userInfo.userName,
             subInfo.displayName,
             subInfo.userId,
             subInfo.gifterDisplayName,

--- a/src/backend/chat/commands/command-executor.js
+++ b/src/backend/chat/commands/command-executor.js
@@ -29,6 +29,12 @@ exports.execute = function(command, userCommand, firebotChatMessage, manual = fa
         },
         effects: effects
     };
+
+    if (firebotChatMessage != null) {
+        processEffectsRequest.trigger.metadata.userId = firebotChatMessage.userId;
+        processEffectsRequest.trigger.metadata.userIdName = firebotChatMessage.useridname;
+    }
+
     return effectRunner.processEffects(processEffectsRequest).catch(reason => {
         console.log("error when running effects: " + reason);
     });

--- a/src/backend/database/userDatabase.js
+++ b/src/backend/database/userDatabase.js
@@ -440,7 +440,9 @@ function createNewUser(userId, username, displayName, profilePicUrl, twitchRoles
                 resolve(null);
             } else {
                 eventManager.triggerEvent("firebot", "viewer-created", {
-                    username: displayName
+                    username: displayName,
+                    userIdName: username,
+                    userId
                 });
                 resolve(user);
             }

--- a/src/backend/events/twitch-events/announcement.ts
+++ b/src/backend/events/twitch-events/announcement.ts
@@ -2,12 +2,14 @@ import eventManager from "../EventManager";
 
 export function triggerAnnouncement(
     userName: string,
+    userId: string,
     userDisplayName: string,
     twitchUserRoles: string[],
     messageText: string
 ): void {
     eventManager.triggerEvent("twitch", "announcement", {
         userIdName: userName,
+        userId,
         username: userDisplayName,
         twitchUserRoles,
         messageText

--- a/src/backend/events/twitch-events/chat-message.ts
+++ b/src/backend/events/twitch-events/chat-message.ts
@@ -3,6 +3,7 @@ import eventManager from "../../events/EventManager";
 
 export function triggerChatMessage(firebotChatMessage: FirebotChatMessage): void {
     eventManager.triggerEvent("twitch", "chat-message", {
+        userId: firebotChatMessage.userId,
         userIdName: firebotChatMessage.useridname,
         username: firebotChatMessage.username,
         twitchUserRoles: firebotChatMessage.roles,

--- a/src/backend/events/twitch-events/cheer.ts
+++ b/src/backend/events/twitch-events/cheer.ts
@@ -2,6 +2,7 @@ import eventManager from "../../events/EventManager";
 
 export function triggerCheer(
     userName: string,
+    userId: string,
     isAnonymous: boolean,
     bits: number,
     totalBits: number,
@@ -9,6 +10,7 @@ export function triggerCheer(
 ): void {
     eventManager.triggerEvent("twitch", "cheer", {
         username: userName,
+        userId,
         isAnonymous,
         bits,
         totalBits,

--- a/src/backend/events/twitch-events/gift-sub.ts
+++ b/src/backend/events/twitch-events/gift-sub.ts
@@ -93,6 +93,7 @@ export function triggerSubGift(
 };
 
 export function triggerSubGiftUpgrade(
+    gifteeUserName: string,
     gifteeDisplayName: string,
     gifteeUserId: string,
     gifterDisplayName: string,
@@ -100,6 +101,7 @@ export function triggerSubGiftUpgrade(
 ): void {
     eventManager.triggerEvent("twitch", "gift-sub-upgraded", {
         username: gifteeDisplayName,
+        userIdName: gifteeUserName,
         userId: gifteeUserId,
         gifterUsername: gifterDisplayName,
         gifteeUsername: gifteeDisplayName,

--- a/src/backend/events/twitch-events/gift-sub.ts
+++ b/src/backend/events/twitch-events/gift-sub.ts
@@ -94,11 +94,13 @@ export function triggerSubGift(
 
 export function triggerSubGiftUpgrade(
     gifteeDisplayName: string,
+    gifteeUserId: string,
     gifterDisplayName: string,
     subPlan: string
 ): void {
     eventManager.triggerEvent("twitch", "gift-sub-upgraded", {
         username: gifteeDisplayName,
+        userId: gifteeUserId,
         gifterUsername: gifterDisplayName,
         gifteeUsername: gifteeDisplayName,
         subPlan

--- a/src/backend/events/twitch-events/gift-sub.ts
+++ b/src/backend/events/twitch-events/gift-sub.ts
@@ -27,6 +27,8 @@ export function triggerCommunitySubGift(
 
 export function triggerSubGift(
     gifterDisplayName: string,
+    gifterUserName: string,
+    gifterUserId: string,
     isAnonymous: boolean,
     gifteeDisplayName: string,
     subPlan: string,
@@ -53,6 +55,8 @@ export function triggerSubGift(
                     } else {
                         eventManager.triggerEvent("twitch", "community-subs-gifted", {
                             username: gifterDisplayName,
+                            userIdName: gifterUserName,
+                            userId: gifterUserId,
                             subCount: giftReceivers.length,
                             subPlan,
                             isAnonymous,
@@ -76,6 +80,8 @@ export function triggerSubGift(
 
     eventManager.triggerEvent("twitch", "subs-gifted", {
         username: gifterDisplayName,
+        userIdName: gifterUserName,
+        userId: gifterUserId,
         giftSubMonths,
         gifteeUsername: gifteeDisplayName,
         gifterUsername: gifterDisplayName,

--- a/src/backend/events/twitch-events/raid.ts
+++ b/src/backend/events/twitch-events/raid.ts
@@ -1,11 +1,15 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerRaid(
+    username: string,
+    userId: string,
     userDisplayName: string,
     viewerCount: number = 0
 ): void {
     eventManager.triggerEvent("twitch", "raid", {
         username: userDisplayName,
+        userIdName: username,
+        userId,
         viewerCount
     });
 };

--- a/src/backend/events/twitch-events/reward-redemption.ts
+++ b/src/backend/events/twitch-events/reward-redemption.ts
@@ -36,6 +36,8 @@ export function handleRewardRedemption(
     setTimeout(() => {
         const redemptionMeta = {
             username: userDisplayName,
+            userIdName: userName,
+            userId: userId,
             messageText,
             redemptionId,
             rewardId,

--- a/src/backend/events/twitch-events/sub.ts
+++ b/src/backend/events/twitch-events/sub.ts
@@ -2,6 +2,7 @@ import eventManager from "../../events/EventManager";
 
 export function triggerSub(
     userName: string,
+    userId: string,
     userDisplayName: string,
     subPlan: string,
     totalMonths: number,
@@ -13,6 +14,7 @@ export function triggerSub(
     eventManager.triggerEvent("twitch", "sub", {
         userIdName: userName,
         username: userDisplayName,
+        userId,
         subPlan,
         totalMonths,
         subMessage,

--- a/src/backend/events/twitch-events/sub.ts
+++ b/src/backend/events/twitch-events/sub.ts
@@ -26,10 +26,12 @@ export function triggerSub(
 
 export function triggerPrimeUpgrade(
     userDisplayName: string,
+    userId: string,
     subPlan: string
  ): void {
     eventManager.triggerEvent("twitch", "prime-sub-upgraded", {
         username: userDisplayName,
+        userId,
         subPlan
     });
 };

--- a/src/backend/events/twitch-events/sub.ts
+++ b/src/backend/events/twitch-events/sub.ts
@@ -25,12 +25,14 @@ export function triggerSub(
 };
 
 export function triggerPrimeUpgrade(
+    username: string,
     userDisplayName: string,
     userId: string,
     subPlan: string
  ): void {
     eventManager.triggerEvent("twitch", "prime-sub-upgraded", {
         username: userDisplayName,
+        userIdName: username,
         userId,
         subPlan
     });

--- a/src/backend/events/twitch-events/viewer-arrived.ts
+++ b/src/backend/events/twitch-events/viewer-arrived.ts
@@ -2,10 +2,14 @@ import eventManager from "../../events/EventManager";
 
 export function triggerViewerArrived(
     userDisplayName: string,
+    userName: string,
+    userId: string,
     messageText: string
 ) {
     eventManager.triggerEvent("twitch", "viewer-arrived", {
         username: userDisplayName,
+        userIdName: userName,
+        userId,
         messageText
     });
 }

--- a/src/backend/twitch-api/pubsub/pubsub-client.js
+++ b/src/backend/twitch-api/pubsub/pubsub-client.js
@@ -133,6 +133,7 @@ async function createClient() {
             if (!subInfo.isGift) {
                 twitchEventsHandler.sub.triggerSub(
                     subInfo.userName,
+                    subInfo.userId,
                     subInfo.userDisplayName,
                     subInfo.subPlan,
                     subInfo.cumulativeMonths || 1,

--- a/src/backend/twitch-api/pubsub/pubsub-client.js
+++ b/src/backend/twitch-api/pubsub/pubsub-client.js
@@ -112,6 +112,7 @@ async function createClient() {
         const bitsListener = pubSubClient.onBits(streamer.userId, (message) => {
             twitchEventsHandler.cheer.triggerCheer(
                 message.userName ?? "An Anonymous Cheerer",
+                message.userId,
                 message.isAnonymous,
                 message.bits,
                 message.totalBits,

--- a/src/backend/variables/builtin/user-id.js
+++ b/src/backend/variables/builtin/user-id.js
@@ -19,6 +19,10 @@ const model = {
     },
     evaluator: async (trigger, username) => {
         if (username == null) {
+            const userId = trigger.metadata.userid ?? trigger.metadata.userId;
+            if (userId != null) {
+                return userId;
+            }
             username = trigger.metadata.username;
             if (username == null) {
                 return "[No username available]";


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
These changes make $userId and $useridname pull data from more events where applicable.
Additionally, this PR supersedes #2258 to also add the userId into the event trigger when a multi-month gifted resub happens.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1819 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that an existing setup using these variables doesn't break. In some cases, functionality is more reliable than it was before this PR.
Tested that Multi-Month Gifted Resub fix only triggers on Multi-Month Gifted Resubs, and not on regular resubs.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
