### PR TITLE
feat: Update can now be deferred until restart

### DIFF
--- a/src/gui/app/directives/controls/update-indicator.js
+++ b/src/gui/app/directives/controls/update-indicator.js
@@ -22,7 +22,7 @@
                 ctrl.tooltip = "<b>Firebot Update Ready:</b> Update will be installed next time you close/reopen Firebot.";
 
                 ctrl.updateIsAvailable = () => {
-                    return updatesService.updateIsAvailable();
+                    return updatesService.updateIsDownloaded;
                 };
             }
         });

--- a/src/gui/app/directives/controls/update-indicator.js
+++ b/src/gui/app/directives/controls/update-indicator.js
@@ -1,0 +1,29 @@
+"use strict";
+(function() {
+    //This a wrapped dropdown element that automatically handles the particulars
+
+    angular
+        .module("firebotApp")
+        .component("updateIndicator", {
+            bindings: {},
+            template: `
+        <div class="update-indicator-wrapper">
+            <div aria-label="Update Available" ng-if="$ctrl.updateIsAvailable()" uib-tooltip-html="$ctrl.tooltip" tooltip-append-to-body="true" tooltip-placement="bottom-right">
+                <i class="far fa-download" style="cursor:pointer;"></i>
+            </div>
+        </div>
+            `,
+            controller: function(
+                $scope,
+                updatesService
+            ) {
+                const ctrl = this;
+
+                ctrl.tooltip = "<b>Firebot Update Ready:</b> Update will be installed next time you close/reopen Firebot.";
+
+                ctrl.updateIsAvailable = () => {
+                    return updatesService.updateIsAvailable();
+                };
+            }
+        });
+}());

--- a/src/gui/app/directives/sidebar/navLink.js
+++ b/src/gui/app/directives/sidebar/navLink.js
@@ -19,7 +19,7 @@
                     </span>
                     </div>
                     <div class="nav-link-title" ng-class="{'contracted': !$ctrl.sbm.navExpanded}">{{$ctrl.name}}</div>
-                    <div ng-show="$ctrl.hasBadge" class="nav-update-badge" ng-class="{'contracted': !$ctrl.sbm.navExpanded}">
+                    <div ng-show="$ctrl.hasBadge()" class="nav-update-badge" ng-class="{'contracted': !$ctrl.sbm.navExpanded}">
                         <span class="label label-danger">{{$ctrl.badgeText}}</span>
                     </div>
                 </a>
@@ -31,10 +31,13 @@
             ctrl.sbm = sidebarManager;
 
             ctrl.$onInit = function() {
-                ctrl.hasBadge = ctrl.badgeText != null && ctrl.badgeText !== "";
                 ctrl.href = ctrl.isIndex
                     ? "#"
                     : "#!" + ctrl.page.toLowerCase().replace(/\W/g, "-");
+            };
+
+            ctrl.hasBadge = function () {
+                return ctrl.badgeText != null && ctrl.badgeText !== "";
             };
 
             ctrl.getClass = function() {

--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -364,9 +364,8 @@
               justify-content: center;
             "
           >
-            <notification-center
-              style="margin-left: auto"
-            ></notification-center>
+            <update-indicator style="margin-left: auto"></update-indicator>
+            <notification-center></notification-center>
             <div
               class="logins-wrapper noselect"
               uib-dropdown
@@ -684,20 +683,22 @@
     <!-- Download Modal -->
     <script type="text/ng-template" id="downloadModal.html">
       <div class="modal-header">
-        <h4 class="modal-title"></h4>
+        <h2 ng-if="!installing">{{downloadComplete ? 'Download complete!' : 'Downloading update...'}}</h2>
+        <h2 ng-if="installing">Installing update...</h2>
       </div>
       <div class="modal-body" style="text-align:center;">
-        <h1>{{downloadComplete ? 'Download complete!' : 'Downloading update...'}}</h1>
-        <h3 ng-if="downloadComplete" style="color:darkgray;">Firebot will restart shortly and install the update...</h3>
-        <div style="overflow: hidden;">
+        <div ng-if="(!downloadComplete && !downloadHasError) || installing" style="overflow: hidden;">
           <div class="loader">Loading...</div>
         </div>
+        <p ng-if="downloadComplete && !installing" style="color:darkgray;">Firebot has downloaded an update. Would you like to install it now, or when you exit?</p>
         <p ng-if="downloadHasError" style="color:red;">
           {{errorMessage}}
         </p>
-        <button ng-if="downloadHasError" class="btn btn-primary" ng-click="dismiss()">Close</button>
       </div>
       <div class="modal-footer">
+        <button ng-if="downloadHasError" class="btn btn-primary" ng-click="dismiss()">Close</button>
+        <button ng-if="!downloadHasError && downloadComplete && !installing" class="btn btn-primary" ng-click="installUpdate()">Install Now</button>
+        <button ng-if="!downloadHasError && downloadComplete && !installing" class="btn btn-default" ng-click="dismiss()">Install On Exit</button>
       </div>
     </script>
 

--- a/src/gui/app/services/listener.service.js
+++ b/src/gui/app/services/listener.service.js
@@ -20,6 +20,7 @@
             error: {},
             updateError: {},
             updateDownloaded: {},
+            installingUpdate: {},
             showEvents: {},
             playSound: {},
             showImage: {},
@@ -61,6 +62,7 @@
             ERROR: "error",
             UPDATE_ERROR: "updateError",
             UPDATE_DOWNLOADED: "updateDownloaded",
+            INSTALLING_UPDATE: "installingUpdate",
             API_BUTTON: "apiButton",
             SHOW_EVENTS: "showEvents",
             PLAY_SOUND: "playSound",
@@ -182,6 +184,7 @@
     */
         const EventType = {
             DOWNLOAD_UPDATE: "downloadUpdate",
+            INSTALL_UPDATE: "installUpdate",
             OPEN_ROOT: "openRootFolder",
             GET_IMAGE: "getImagePath",
             GET_SOUND: "getSoundPath",
@@ -325,6 +328,13 @@
      */
         ipcRenderer.on("updateDownloaded", function() {
             _.forEach(registeredListeners.updateDownloaded, listener => {
+                runListener(listener);
+            });
+        });
+
+        // Installing update listener
+        ipcRenderer.on(ListenerType.INSTALLING_UPDATE, function () {
+            _.forEach(registeredListeners[ListenerType.INSTALLING_UPDATE], listener => {
                 runListener(listener);
             });
         });

--- a/src/gui/app/services/updates.service.js
+++ b/src/gui/app/services/updates.service.js
@@ -35,6 +35,8 @@
                 return service.hasCheckedForUpdates ? (service.updateData?.updateIsAvailable || service.majorUpdate != null) : false;
             };
 
+            service.updateIsDownloaded = false;
+
             function shouldAutoUpdate(autoUpdateLevel, updateType) {
                 // if auto updating is completely disabled
                 if (autoUpdateLevel === 0) {

--- a/src/gui/app/services/updates.service.js
+++ b/src/gui/app/services/updates.service.js
@@ -32,7 +32,7 @@
             service.hasReleaseData = false;
 
             service.updateIsAvailable = function() {
-                return service.hasCheckedForUpdates ? ((service.updateData && service.updateData.updateIsAvailable) || service.majorUpdate != null) : false;
+                return service.hasCheckedForUpdates ? (service.updateData?.updateIsAvailable || service.majorUpdate != null) : false;
             };
 
             function shouldAutoUpdate(autoUpdateLevel, updateType) {
@@ -116,15 +116,13 @@
 
                             let updateIsAvailable = false;
                             if (latestUpdateType !== UpdateType.NONE) {
+                                updateIsAvailable = true;
                                 const autoUpdateLevel = settingsService.getAutoUpdateLevel();
 
                                 // Check if we should auto update based on the users setting
                                 if (shouldAutoUpdate(autoUpdateLevel, latestUpdateType)) {
                                     utilityService.showDownloadModal();
                                     listenerService.fireEvent(listenerService.EventType.DOWNLOAD_UPDATE);
-                                } else {
-                                    // Dont autoupdate, just notify the user
-                                    updateIsAvailable = true;
                                 }
                             }
 
@@ -152,11 +150,23 @@
                 });
             };
 
-            service.downloadAndInstallUpdate = function() {
+            service.downloadUpdate = function() {
                 if (service.updateIsAvailable()) {
                     utilityService.showDownloadModal();
                     listenerService.fireEvent(listenerService.EventType.DOWNLOAD_UPDATE);
                 }
+            };
+
+            service.installUpdate = function() {
+                if (service.updateIsAvailable()) {
+                    utilityService.showDownloadModal();
+                    listenerService.fireEvent(listenerService.EventType.INSTALL_UPDATE);
+                }
+            };
+
+            service.downloadAndInstallUpdate = function() {
+                service.downloadUpdate();
+                service.installUpdate();
             };
 
             return service;

--- a/src/gui/app/services/utility.service.js
+++ b/src/gui/app/services/utility.service.js
@@ -511,6 +511,7 @@
                             () => {
                                 // the autoupdater has downloaded the update
                                 $scope.downloadComplete = true;
+                                updatesService.updateIsDownloaded = true;
                             }
                         );
 

--- a/src/gui/app/services/utility.service.js
+++ b/src/gui/app/services/utility.service.js
@@ -482,7 +482,8 @@
                         $scope,
                         $uibModalInstance,
                         $timeout,
-                        listenerService
+                        listenerService,
+                        updatesService
                     ) => {
                         $scope.downloadHasError = false;
                         $scope.errorMessage = "";
@@ -508,8 +509,22 @@
                         listenerService.registerListener(
                             updateDownloadedListenerRequest,
                             () => {
-                                // the autoupdater has downloaded the update and restart shortly
+                                // the autoupdater has downloaded the update
                                 $scope.downloadComplete = true;
+                            }
+                        );
+
+                        // Install update listener
+                        const installUpdateListenerRequest = {
+                            type: listenerService.ListenerType.INSTALLING_UPDATE,
+                            runOnce: true
+                        };
+                        listenerService.registerListener(
+                            installUpdateListenerRequest,
+                            () => {
+                                // the autoupdater is installing the update
+                                $scope.downloadComplete = true;
+                                $scope.installing = true;
                             }
                         );
 
@@ -523,6 +538,10 @@
                   "Download is taking longer than normal. There may have been an error. You can keep waiting or close this and try again later.";
                             }
                         }, 180 * 1000);
+
+                        $scope.installUpdate = function() {
+                            updatesService.installUpdate();
+                        };
 
                         $scope.dismiss = function() {
                             $uibModalInstance.dismiss("cancel");

--- a/src/gui/scss/core/_global.scss
+++ b/src/gui/scss/core/_global.scss
@@ -452,7 +452,7 @@ body {
   position: absolute;
   opacity: 1;
   visibility: visible;
-  top: 12px;
+  top: 9px;
   right: 15px;
   display: inline-block;
   transition: 0.4s;
@@ -1275,6 +1275,11 @@ thead th{
 
 /* notification center */
 
+.update-indicator-wrapper {
+  margin: 0 10px 0 0px;
+  font-size: 24px;
+  position: relative;
+}
 .notifications-wrapper {
   margin: 0 40px 0 0px;
   font-size: 24px;


### PR DESCRIPTION
### Description of the Change
When Firebot detects a new update, the update can now be deferred until the next time Firebot is closed and reopened, or optionally installed immediately as it does today.


### Applicable Issues
Partially resolves #1930


### Testing
- Validated that new UI appears when there is an update and not when Firebot is running latest releast
- Validated that "Install Now" installs update and restarts Firebot immediately
- Validated that "Install On Exit" closes the download dialog box and does not install immediately
- Validated that pending update icon on the top bar and "NEW" badge on the "Updates" item on the sidebar appear when there is a pending update, but not when there is no pending update
- Validated that pending update icon does NOT appear on the top bar until download is complete, which should never occur on Linux (thanks, Dennis!)


### Screenshots
![image](https://github.com/crowbartools/Firebot/assets/1764877/44e2f569-e75f-4c9b-b96c-79a0bb45de79)
![image](https://github.com/crowbartools/Firebot/assets/1764877/da85ef3a-d53a-4a69-86cb-0f2a2af2580a)
![image](https://github.com/crowbartools/Firebot/assets/1764877/1ce5542d-62cc-4c62-8713-492b9d71ba01)
