### PR TITLE
feat: add firebot:// custom URI scheme, viewer-card endpoints

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,8 @@
             "name": "Electron: Main",
             "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
             "runtimeArgs": [
-                "--remote-debugging-port=9223",
-                "."
+                ".",
+                "--remote-debugging-port=9223"
             ],
             "windows": {
                 "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"

--- a/grunt/pack.js
+++ b/grunt/pack.js
@@ -61,6 +61,8 @@ module.exports = function (grunt) {
         '--version-string.ProductName="Firebot v5"',
         '--executable-name="Firebot v5"',
         '--icon="./build/gui/images/icon_transparent.ico"',
+        '--protocol=firebot',
+        '--protocol-name="Firebot"',
         ...ignoreFlags
     ].join(' ');
 

--- a/src/backend/app-management/electron/electron-events.js
+++ b/src/backend/app-management/electron/electron-events.js
@@ -4,10 +4,12 @@ const { whenReady } = require("./events/when-ready");
 const { windowsAllClosed } = require("./events/windows-all-closed");
 const { willQuit } = require("./events/will-quit");
 const { secondInstance } = require("./events/second-instance");
+const { openUrl } = require("./events/open-url");
 
 module.exports = {
     whenReady,
     windowsAllClosed,
     willQuit,
-    secondInstance
+    secondInstance,
+    openUrl
 };

--- a/src/backend/app-management/electron/events/open-url.js
+++ b/src/backend/app-management/electron/events/open-url.js
@@ -1,0 +1,4 @@
+exports.openUrl = (event, url) => {
+    const logger = require("../../../logwrapper");
+    logger.debug(`Received Firebot URL request: ${url}`);
+};

--- a/src/backend/app-management/electron/events/open-url.js
+++ b/src/backend/app-management/electron/events/open-url.js
@@ -1,4 +1,41 @@
-exports.openUrl = (event, url) => {
+"use strict";
+
+exports.openUrl = async (event, url) => {
     const logger = require("../../../logwrapper");
+    const frontendCommunicator = require("../../../common/frontend-communicator");
+    const TwitchApi = require("../../../twitch-api/api");
+
+    url = url.toLowerCase();
     logger.debug(`Received Firebot URL request: ${url}`);
+
+    if (url.startsWith("firebot://")) {
+        url = url.substring(10);
+    }
+
+    const urlParams = url.split("/");
+
+    switch (urlParams[0]) {
+    case "viewer-card":
+        logger.debug("Received Firebot URL request to load viewer card");
+
+        switch (urlParams[1]) {
+        case "id":
+            logger.debug(`Opening viewer card for user ID ${urlParams[2]}`);
+            frontendCommunicator.send("showViewerCard", urlParams[2]);
+            break;
+
+        case "name":
+            logger.debug(`Opening viewer card for username ${urlParams[2]}`);
+            frontendCommunicator.send("showViewerCard", (await TwitchApi.users.getUserByName(urlParams[2]))?.id);
+            break;
+
+        default:
+            logger.debug(`Invalid viewer card method specified (${urlParams[1]})`);
+        }
+        break;
+
+    default:
+        logger.debug("No matching URL commands found");
+        break;
+    }
 };

--- a/src/backend/app-management/electron/events/second-instance.js
+++ b/src/backend/app-management/electron/events/second-instance.js
@@ -1,12 +1,13 @@
 "use strict";
 
 const fileOpenHelpers = require("../../file-open-helpers");
+const { openUrl } = require("./open-url");
 
 /**
  * @param {Electron.Event} event
  * @param {string[]} argv
  */
-exports.secondInstance = (_, argv) => {
+exports.secondInstance = (event, argv) => {
     // Someone tried to run a second instance, we should focus our window.
     const logger = require("../../../logwrapper");
     try {
@@ -22,6 +23,8 @@ exports.secondInstance = (_, argv) => {
             mainWindow.focus();
 
             fileOpenHelpers.checkForFirebotSetupPath(argv);
+
+            openUrl(event, argv.pop().slice(0, -1));
         }
     } catch (error) {
         logger.debug("Error focusing", error);

--- a/src/backend/app-management/electron/events/second-instance.js
+++ b/src/backend/app-management/electron/events/second-instance.js
@@ -24,7 +24,7 @@ exports.secondInstance = (event, argv) => {
 
             fileOpenHelpers.checkForFirebotSetupPath(argv);
 
-            openUrl(event, argv.pop().slice(0, -1));
+            openUrl(event, argv.pop());
         }
     } catch (error) {
         logger.debug("Error focusing", error);

--- a/src/gui/app/services/utility.service.js
+++ b/src/gui/app/services/utility.service.js
@@ -34,6 +34,18 @@
                 });
             });
 
+            backendCommunicator.on("showViewerCard", (userId) => {
+                service.showModal({
+                    component: "viewerDetailsModal",
+                    backdrop: true,
+                    resolveObj: {
+                        userId: () => userId
+                    },
+                    closeCallback: () => {},
+                    dismissCallback: () => {}
+                });
+            });
+
             service.openGetIdEntyModal = function(options, callback) {
                 service.showModal({
                     component: "idEntryModal",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 "use strict";
 const { app } = require("electron");
+const path = require('node:path');
 
 const logger = require("./backend/logwrapper");
 const secretsManager = require("./backend/secrets-manager");
@@ -39,22 +40,14 @@ if (process.defaultApp) {
     app.setAsDefaultProtocolClient("firebot");
 }
 
+logger.debug("...Registered Firebot URI handler");
+
 // ensure only a single instance of the app runs
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
     logger.debug("...Failed to get single instance lock");
     app.quit();
     return;
-} else {
-    app.on('second-instance', (event, commandLine, workingDirectory) => {
-        // Someone tried to run a second instance, we should focus our window.
-        if (mainWindow) {
-            if (mainWindow.isMinimized()) mainWindow.restore()
-            mainWindow.focus()
-        }
-    
-        openUrl(event, commandLine.pop().slice(0, -1));
-    });
 }
 
 logger.debug("...Single instance lock acquired");


### PR DESCRIPTION
### Description of the Change
Adds support for the `firebot://` custom URI scheme. The initial hander implements the following URLs:
- `firebot://viewer-card/name/:username` - displays the viewer card for a given Twitch username
- `firebot://viewer-card/id/:userId` - displays the viewer card for a given Twitch user ID

### Applicable Issues
N/A

### Testing
Validated URI handler works in Windows in both a dev environment and installed in a sandbox

### Screenshots
N/A