### PR TITLE
Fix Howler issue related to caching for getSoundDuration (#2287)

### DIFF
--- a/src/gui/app/services/sound.service.js
+++ b/src/gui/app/services/sound.service.js
@@ -159,17 +159,14 @@
 
                     const sound = new Howl({
                         src: [path],
-                        format: format || []
-                    });
-
-                    sound.on("loaderror", () => {
-                        resolve(0);
-                    });
-
-                    // Clear listener after first call.
-                    sound.once('load', function() {
-                        resolve(sound.duration());
-                        sound.unload();
+                        format: format || [],
+                        onload: () => {
+                            resolve(sound.duration());
+                            sound.unload();
+                        },
+                        onloaderror: () => {
+                            resolve(0);
+                        }
                     });
                 });
             };

--- a/src/gui/app/services/sound.service.js
+++ b/src/gui/app/services/sound.service.js
@@ -107,7 +107,7 @@
                 $q.when(service.getHowlSound(path, volume, outputDevice, fileType))
                     .then(sound => {
 
-                        let maxSoundLengthTimeout
+                        let maxSoundLengthTimeout;
                         // Clear listener after first call.
                         sound.once('load', function() {
                             sound.play();
@@ -117,14 +117,14 @@
                                 maxSoundLengthTimeout = setTimeout(function() {
                                     sound.stop();
                                     sound.unload();
-                                }, maxSoundLength * 1000)
+                                }, maxSoundLength * 1000);
                             }
                         });
 
                         // Fires when the sound finishes playing.
                         sound.once('end', function() {
                             sound.unload();
-                            clearInterval(maxSoundLengthTimeout)
+                            clearInterval(maxSoundLengthTimeout);
                         });
 
                         sound.load();


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This PR moves the load and loaderror event listeners into the Howl constructor, mitigating audio caching issues that cause the sound to load before we can subscribe to the event listener.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2287

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Running the same test on both builds, I confirm the issue only happens pre-changes.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
