### PR TITLE
fix(events): Any filter not triggering with no filters. (#2306)

### DIFF
--- a/src/backend/events/filters/filter-manager.js
+++ b/src/backend/events/filters/filter-manager.js
@@ -54,7 +54,7 @@ class FilterManager extends EventEmitter {
         if (filterData != null) {
             const filterSettings = filterData.filters;
 
-            let didPass = filterData.mode !== "inclusive";
+            let didPass = filterData.mode !== "inclusive" || filterSettings.length === 0;
             for (const filterSetting of filterSettings) {
                 const filter = this.getFilterById(filterSetting.type);
                 if (filter) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes an issue with events where events would not trigger if set to **any filter passes** and no filters were set.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2306 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that both **any filter passes** and **all filters pass** now work properly when no filters are set. Also ensured that both options still handle filters appropriately.
