### PR TITLE
fix(effects): move clipping variable fields

### DIFF
--- a/src/backend/effects/builtin/add-quote.js
+++ b/src/backend/effects/builtin/add-quote.js
@@ -15,10 +15,10 @@ const addQuoteEffect = {
         dependencies: []
     },
     globalSettings: {},
-    optionsTemplate: `    
+    optionsTemplate: `
         <eos-container header="Quote Creator">
             <p class="muted">This is the name of the person who is creating the quote entry.</p>
-            <input ng-model="effect.creator" type="text" class="form-control" id="chat-text-setting" placeholder="Enter quote creator" replace-variables/>
+            <input ng-model="effect.creator" type="text" class="form-control" id="chat-text-setting" placeholder="Enter quote creator" menu-position="under" replace-variables/>
         </eos-container>
 
         <eos-container header="Quote Originator" pad-top="true">

--- a/src/backend/effects/builtin/delay.js
+++ b/src/backend/effects/builtin/delay.js
@@ -16,7 +16,7 @@ const model = {
         <eos-container header="Duration">
             <div class="input-group">
                 <span class="input-group-addon" id="delay-length-effect-type">Seconds</span>
-                <input ng-model="effect.delay" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
+                <input ng-model="effect.delay" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" menu-position="under" replace-variables="number">
             </div>
         </eos-container>
     `,

--- a/src/backend/effects/builtin/dice.js
+++ b/src/backend/effects/builtin/dice.js
@@ -18,6 +18,7 @@ const model = {
                 input-title="Dice"
                 model="effect.dice"
                 placeholder-text="2d20 or 2d10+1d12 or 1d10+3"
+                menu-position="under"
             />
         </eos-container>
 

--- a/src/backend/effects/builtin/log-message.js
+++ b/src/backend/effects/builtin/log-message.js
@@ -16,7 +16,7 @@ const addFirebotLogMessage = {
     optionsTemplate: `
         <eos-container header="Message Text">
             <p class="muted">Enter the message you would like to write to the Firebot log file.</p>
-            <input ng-model="effect.logMessage" id="log-message-text" type="text" class="form-control" placeholder="Enter log message text" replace-variables>
+            <input ng-model="effect.logMessage" id="log-message-text" type="text" class="form-control" placeholder="Enter log message text" menu-position="under" replace-variables>
         </eos-container>
 
         <eos-container header="Log Level" pad-top="true">

--- a/src/backend/effects/builtin/twitch/create-poll.ts
+++ b/src/backend/effects/builtin/twitch/create-poll.ts
@@ -22,7 +22,7 @@ const model: EffectType<{
     },
     optionsTemplate: `
         <eos-container header="Poll Title">
-            <firebot-input input-title="Title" model="effect.title" placeholder-text="Enter poll title" />
+            <firebot-input input-title="Title" model="effect.title" placeholder-text="Enter poll title" menu-position="under" />
         </eos-container>
 
         <eos-container header="Poll Duration" pad-top="true">

--- a/src/backend/effects/builtin/twitch/create-prediction.ts
+++ b/src/backend/effects/builtin/twitch/create-prediction.ts
@@ -20,7 +20,7 @@ const model: EffectType<{
     },
     optionsTemplate: `
         <eos-container header="Prediction Title">
-            <firebot-input input-title="Title" model="effect.title" placeholder-text="Enter prediction title" />
+            <firebot-input input-title="Title" model="effect.title" placeholder-text="Enter prediction title" menu-position="under" />
         </eos-container>
 
         <eos-container header="Prediction Duration" pad-top="true">

--- a/src/backend/effects/builtin/twitch/create-stream-marker.ts
+++ b/src/backend/effects/builtin/twitch/create-stream-marker.ts
@@ -17,7 +17,7 @@ const model: EffectType<{
     },
     optionsTemplate: `
         <eos-container header="Create Stream Marker">
-            <firebot-input input-title="Description" model="effect.description" placeholder-text="Enter description" />
+            <firebot-input input-title="Description" model="effect.description" placeholder-text="Enter description" menu-position="under" />
         </eos-container>
 
         <eos-container>

--- a/src/backend/integrations/builtin/obs/effects/toggle-obs-source-muted.ts
+++ b/src/backend/integrations/builtin/obs/effects/toggle-obs-source-muted.ts
@@ -26,7 +26,7 @@ export const ToggleSourceMutedEffectType: EffectType<EffectProperties> =
       },
       optionsTemplate: `
     <eos-container header="Audio Sources">
-      <firebot-input model="searchText" input-title="Filter"></firebot-input>
+      <firebot-input model="searchText" input-title="Filter" disable-variables="true"></firebot-input>
       <div>
           <button class="btn btn-link" ng-click="getSourceList()">Refresh Sources</button>
       </div>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Move multiple clipping variable fields to under and remove unneeded variables button from filter in OBS Source Mute effect

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2313

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured variable menus no longer clip, and variables button is removed from OBS Source Mute

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
