### PR TITLE
Fix: Discord Webhook (#2314)

### DIFF
--- a/src/gui/app/directives/modals/integrations/addOrEditDiscordWebhookModal.js
+++ b/src/gui/app/directives/modals/integrations/addOrEditDiscordWebhookModal.js
@@ -88,11 +88,9 @@
                 }
 
                 function validateWebhookUrl() {
-                    // const webhookRegex = /^https:\/\/discord(?:app)?\.com\/api\/webhooks\/[^/\s]+\/[^/\s]+$/i; // Old Discord Regex
                     const discordWebhookRegex = /^https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/[^/\s]+\/[^/\s]+$/i;
                     const guildedWebhookRegex = /^https:\/\/media\.guilded?\.gg\/webhooks\/[^/\s]+\/[^/\s]+$/i;
                     const webhookUrl = $ctrl.channel.webhookUrl;
-                    // return webhookUrl != null && webhookUrl.length > 0 && webhookRegex.test(webhookUrl); // Old Return
                     return webhookUrl != null && webhookUrl.length > 0 && (discordWebhookRegex.test(webhookUrl) || guildedWebhookRegex.test(webhookUrl));
                 }
 

--- a/src/gui/app/directives/modals/integrations/addOrEditDiscordWebhookModal.js
+++ b/src/gui/app/directives/modals/integrations/addOrEditDiscordWebhookModal.js
@@ -88,9 +88,12 @@
                 }
 
                 function validateWebhookUrl() {
-                    const webhookRegex = /^https:\/\/discord(?:app)?\.com\/api\/webhooks\/[^/\s]+\/[^/\s]+$/i;
+                    // const webhookRegex = /^https:\/\/discord(?:app)?\.com\/api\/webhooks\/[^/\s]+\/[^/\s]+$/i; // Old Discord Regex
+                    const discordWebhookRegex = /^https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/[^/\s]+\/[^/\s]+$/i;
+                    const guildedWebhookRegex = /^https:\/\/media\.guilded?\.gg\/webhooks\/[^/\s]+\/[^/\s]+$/i;
                     const webhookUrl = $ctrl.channel.webhookUrl;
-                    return webhookUrl != null && webhookUrl.length > 0 && webhookRegex.test(webhookUrl);
+                    // return webhookUrl != null && webhookUrl.length > 0 && webhookRegex.test(webhookUrl); // Old Return
+                    return webhookUrl != null && webhookUrl.length > 0 && (discordWebhookRegex.test(webhookUrl) || guildedWebhookRegex.test(webhookUrl));
                 }
 
                 $ctrl.save = function() {


### PR DESCRIPTION
Changed the RegEx to allow for Canary/PTB Discord and Guilded WebHooks

### Applicable Issues
#2314 


### Testing
Tested with Discord Canary Webhook URL's and Guilded URL's.