### PR TITLE
fix(effects): effect outputs now bubble down into nested effect lists (#2273)

### DIFF
--- a/src/backend/common/effect-runner.js
+++ b/src/backend/common/effect-runner.js
@@ -74,7 +74,7 @@ function validateEffectCanRun(effectId, triggerType) {
 
 }
 
-async function triggerEffect(effect, trigger) {
+async function triggerEffect(effect, trigger, outputs) {
     // For each effect, send it off to the appropriate handler.
     logger.debug(`Running ${effect.type}(${effect.id}) effect...`);
 
@@ -87,7 +87,7 @@ async function triggerEffect(effect, trigger) {
         }
     };
 
-    return effectDef.onTriggerEvent({ effect, trigger, sendDataToOverlay });
+    return effectDef.onTriggerEvent({ effect, trigger, sendDataToOverlay, outputs });
 }
 
 async function runEffects(runEffectsContext) {
@@ -115,7 +115,7 @@ async function runEffects(runEffectsContext) {
         }));
 
         try {
-            const response = await triggerEffect(effect, trigger);
+            const response = await triggerEffect(effect, trigger, runEffectsContext.outputs);
             if (!response) {
                 continue;
             }

--- a/src/backend/effects/builtin/conditional-effects/conditional-effects.js
+++ b/src/backend/effects/builtin/conditional-effects/conditional-effects.js
@@ -118,7 +118,7 @@ const model = {
     onTriggerEvent: event => {
         return new Promise(async (resolve) => {
             // What should this do when triggered.
-            const { effect, trigger } = event;
+            const { effect, trigger, outputs } = event;
 
             let effectsToRun = null;
             if (effect.ifs != null) {
@@ -142,7 +142,8 @@ const model = {
             if (effectsToRun != null) {
                 const processEffectsRequest = {
                     trigger: event.trigger,
-                    effects: effectsToRun
+                    effects: effectsToRun,
+                    outputs: outputs
                 };
 
                 effectRunner.processEffects(processEffectsRequest)

--- a/src/backend/effects/builtin/effect-group.js
+++ b/src/backend/effects/builtin/effect-group.js
@@ -133,7 +133,7 @@ const effectGroup = {
     onTriggerEvent: event => {
         return new Promise(resolve => {
 
-            const { effect, trigger } = event;
+            const { effect, trigger, outputs } = event;
 
             let processEffectsRequest = {};
 
@@ -153,7 +153,8 @@ const effectGroup = {
 
                 processEffectsRequest = {
                     trigger: newTrigger,
-                    effects: presetList.effects
+                    effects: presetList.effects,
+                    outputs: outputs
                 };
             } else {
                 const effectList = effect.effectList;
@@ -164,7 +165,8 @@ const effectGroup = {
 
                 processEffectsRequest = {
                     trigger: trigger,
-                    effects: effectList
+                    effects: effectList,
+                    outputs: outputs
                 };
             }
 

--- a/src/backend/effects/builtin/http-request.js
+++ b/src/backend/effects/builtin/http-request.js
@@ -223,7 +223,7 @@ const effect = {
         const customVariableManager = require("../../common/custom-variable-manager");
         const effectRunner = require("../../common/effect-runner");
 
-        const { effect, trigger } = event;
+        const { effect, trigger, outputs } = event;
 
         let headers = effect.headers.reduce((acc, next) => {
             acc[next.key] = next.value;
@@ -281,7 +281,8 @@ const effect = {
             if (effect.options.runEffectsOnError) {
                 const processEffectsRequest = {
                     trigger,
-                    effects: effect.errorEffects
+                    effects: effect.errorEffects,
+                    outputs: outputs
                 };
 
                 const effectResult = await effectRunner.processEffects(processEffectsRequest);

--- a/src/backend/effects/builtin/random-effect.js
+++ b/src/backend/effects/builtin/random-effect.js
@@ -78,6 +78,7 @@ const randomEffect = {
 
             const effect = event.effect;
             const effectList = effect.effectList;
+            const outputs = effect.outputs;
 
             if (!effectList || !effectList.list) {
                 return resolve(true);
@@ -162,7 +163,8 @@ const randomEffect = {
                     id: effectList.id,
                     list: [chosenEffect],
                     queue: effectList.queue
-                }
+                },
+                outputs: outputs
             };
 
             effectRunner.processEffects(processEffectsRequest)

--- a/src/backend/effects/builtin/sequential-effect.js
+++ b/src/backend/effects/builtin/sequential-effect.js
@@ -62,6 +62,7 @@ const model = {
 
             const effect = event.effect;
             const effectList = effect.effectList;
+            const outputs = effect.outputs;
 
             if (!effectList || !effectList.list) {
                 return resolve(true);
@@ -122,7 +123,8 @@ const model = {
                     id: effectList.id,
                     list: [chosenEffect],
                     queue: effectList.queue
-                }
+                },
+                outputs: outputs
             };
 
             effectRunner.processEffects(processEffectsRequest)


### PR DESCRIPTION
### Description of the Change
Effect outputs now bubble down into nested effect lists, including the **Run Effect List**, **Loop Effects**, **Run Random Effect**, and **Run Sequential Effect** effects.

### Applicable Issues
#2273

### Testing
Verified effect outputs bubbled down into a nested effect list via **Run Effect List** and that loops in **Loop Effects** persisted outputs between runs

### Screenshots
N/A