### PR TITLE
fix OBS Source Screenshot regression

### DIFF
--- a/src/backend/integrations/builtin/obs/effects/take-obs-source-screenshot.ts
+++ b/src/backend/integrations/builtin/obs/effects/take-obs-source-screenshot.ts
@@ -113,6 +113,18 @@ export const TakeOBSSourceScreenshotEffectType: EffectType<{
         if (!effect.useActiveScene && effect.source == null) {
             errors.push("You need to select a source!");
         }
+        if (!(effect.saveLocally || effect.overwriteExisting || effect.postInDiscord || effect.showInOverlay)) {
+            errors.push("You need to select an output option!");
+        }
+        if (effect.saveLocally && !effect.folderPath) {
+            errors.push("You need to select a folder path!");
+        }
+        if (effect.overwriteExisting && !effect.file) {
+            errors.push("You need to select a file!");
+        }
+        if (effect.postInDiscord && !effect.discordChannelId) {
+            errors.push("You need to select a discord channel!");
+        }
         return errors;
     },
     onTriggerEvent: async ({ effect }) => {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This PR fixes a regression introduced into the OBS Source Screenshot effect in commit [3f5d04f](https://github.com/crowbartools/Firebot/commit/3f5d04fe871d7fa617e6cf18a49e2c6311873076) where effects created prior to this commit would no longer create screenshots.
It also adds validation to the effect model, ensuring at least one output is selected and applicable outputs aren't selected, but unconfigured.

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
- Ensured an effect created before 3f5d04f saves the image to file again.
- Ensured effect model errors when no outputs are selected
- Ensured effect model errors when Folder, File or Discord are selected, but not filled in properly

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
