### PR TITLE
Fix: pronouns to return fallbacks correctly

### DIFF
--- a/src/backend/variables/builtin/twitch/subs/sub-users.ts
+++ b/src/backend/variables/builtin/twitch/subs/sub-users.ts
@@ -13,7 +13,7 @@ const model : ReplaceVariable = {
         examples: [
             {
                 usage: "subNames",
-                description: "Returns: [{username:Firebottle,tier:2000,isGift:false},{username:ebiggz,tier:1000,isGift:true},{username:SReject,tier:3000,isGift:false},{username:Perry,tier:1000,isGift:false}] To be used with array or custom variables"
+                description: "Returns: [{username:firebottle, displayname: FireBottle, tier:2000, isGift:false}, {username:ebiggz, displayname: EBiggz, tier:1000,isGift:true},{username:sreject, displayname:SReject, tier:3000, isGift:false},{username:perry, displayname:Perry, tier:1000, isGift:false}] To be used with array or custom variables"
             }
         ],
         possibleDataOutput: [OutputDataType.TEXT]
@@ -27,6 +27,7 @@ const model : ReplaceVariable = {
             if (response && response.length) {
                 viewers = response.map(sub => ({
                     username: sub.userName,
+                    displayname: sub.userDisplayName,
                     tier: sub.tier,
                     isGift: sub.isGift
                 }));

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -66,7 +66,7 @@ const PronounVariable: ReplaceVariable = {
             try {
                 let pronounArray = [];
                 if (userPronounData == null || userPronounData === undefined) {
-                    userPronounData = { "pronoun_id": "theythem" };
+                    userPronounData = { "pronoun_id": `${fallback.replace("/", "")}` };
                 }
 
                 const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -56,7 +56,7 @@ const PronounVariable: ReplaceVariable = {
         }
 
         if (!Number.isFinite(<number>pronounNumber)) {
-            logger.warn("Pronoun index not a number using they/them");
+            logger.warn(`Pronoun index not a number using ${fallback}`);
             return fallback;
         }
         try {
@@ -68,18 +68,16 @@ const PronounVariable: ReplaceVariable = {
                 userPronounData = { "pronoun_id": `${fallback.replace("/", "")}` };
             }
 
-            const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
+            let pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
             if (pronoun != null) {
                 pronounArray = pronoun.display.split('/');
             } else {
+                pronoun = { "display": `${fallback}` };
                 pronounArray = fallback.split('/');
             }
 
             if (pronounNumber === 0) {
-                if (pronoun != null) {
-                    return pronoun.display;
-                }
-                return fallback;
+                return pronoun.display;
             }
 
             if (pronounArray.length === 1) {

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -45,41 +45,58 @@ const PronounVariable: ReplaceVariable = {
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.TEXT]
     },
-    evaluator: async (trigger, username: string, pronounNumber: number, fallback: string) => {
+    evaluator: async (trigger,
+        username: string,
+        pronounNumber: number | string = 0,
+        // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+        fallback : string = "they/them") => {
         try {
+            if (typeof pronounNumber === 'string' || <unknown>pronounNumber instanceof String) {
+                pronounNumber = Number(`${pronounNumber}`);
+            }
+
+            if (!Number.isFinite(<number>pronounNumber)) {
+                logger.warn("Pronoun index not a number using they/them");
+                return fallback;
+            }
+
             const pronouns = (await callUrl('https://pronouns.alejo.io/api/pronouns')).data;
-            const userPronounData = (await callUrl(`https://pronouns.alejo.io/api/users/${username}`)).data[0];
+            let userPronounData = (await callUrl(`https://pronouns.alejo.io/api/users/${username}`)).data[0];
 
-            if (pronouns != null && userPronounData != null) {
-                try {
-                    const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
-                    if (pronoun != null) {
-                        if (pronounNumber === 0) {
-                            return pronoun.display;
-                        }
-
-                        const pronounArray = pronoun.display.split('/');
-
-                        if (pronounArray.length === 1) {
-                            return pronounArray[0];
-                        }
-
-                        if (pronounArray.length >= pronounNumber) {
-                            return pronounArray[pronounNumber - 1];
-                        }
-                        return fallback || "them/they";
-                    }
-
-                    return fallback;
-                } catch (err) {
-                    logger.warn("error when parsing pronoun api", err);
-                    return fallback || "they/them";
+            try {
+                let pronounArray = [];
+                if (userPronounData == null || userPronounData === undefined) {
+                    userPronounData = { "pronoun_id": "theythem" };
                 }
+
+                const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
+                if (pronoun != null) {
+                    pronounArray = pronoun.display.split('/');
+                } else {
+                    pronounArray = fallback.split('/');
+                }
+
+                if (pronounNumber === 0) {
+                    return pronoun.display;
+                }
+
+                if (pronounArray.length === 1) {
+                    return pronounArray[0];
+                }
+
+                if (pronounArray.length >= pronounNumber) {
+                    return pronounArray[pronounNumber - 1];
+                }
+                return fallback;
+
+            } catch (err) {
+                logger.warn("error when parsing pronoun api", err);
+                return fallback;
             }
 
         } catch (err) {
             logger.warn("error when parsing pronoun api", err);
-            return fallback || "they/them";
+            return fallback;
         }
     }
 };

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -66,7 +66,7 @@ const PronounVariable: ReplaceVariable = {
             try {
                 let pronounArray = [];
                 if (userPronounData == null || userPronounData === undefined) {
-                    userPronounData = { "pronoun_id": `${fallback.replace("/", "")}` };
+                    userPronounData = { "pronoun_id": `${fallback.replace("/", "").toLowerCase()}` };
                 }
 
                 const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);


### PR DESCRIPTION
### Description of the Change
Pronoun variable would return blank on fallback and unknown user

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2373

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
tested with my account and my bot account that has no pronoun 
everything as documented supplies the expected data 

$pronouns[username, 0, they/them] 
Returns 'she/her' if available, otherwise uses they/them.

$pronouns[username, 1, they] 
Returns 'she' pronoun in she/her set if available, otherwise uses they.

$pronouns[username, 2, them] 
Returns 'her' pronoun in she/her set if available, otherwise uses them.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
