### PR TITLE
Fix: pronouns to return fallbacks correctly

### DIFF
--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -45,11 +45,13 @@ const PronounVariable: ReplaceVariable = {
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.TEXT]
     },
-    evaluator: async (trigger,
+    evaluator: async (
+        trigger,
         username: string,
         pronounNumber: number | string = 0,
         // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-        fallback : string = "they/them") => {
+        fallback : string = "they/them"
+    ) => {
 
         if (typeof pronounNumber === 'string' || <unknown>pronounNumber instanceof String) {
             pronounNumber = Number(`${pronounNumber}`);

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -45,42 +45,54 @@ const PronounVariable: ReplaceVariable = {
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.TEXT]
     },
-    evaluator: async (trigger, username: string, pronounNumber: number, fallback: string) => {
+    evaluator: async (trigger,
+        username: string,
+        pronounNumber: number | string = 0,
+        // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+        fallback : string = "they/them") => {
+
+        if (typeof pronounNumber === 'string' || <unknown>pronounNumber instanceof String) {
+            pronounNumber = Number(`${pronounNumber}`);
+        }
+
+        if (!Number.isFinite(<number>pronounNumber)) {
+            logger.warn(`Pronoun index not a number using ${fallback}`);
+            return fallback;
+        }
         try {
             const pronouns = (await callUrl('https://pronouns.alejo.io/api/pronouns')).data;
-            const userPronounData = (await callUrl(`https://pronouns.alejo.io/api/users/${username}`)).data[0];
+            let userPronounData = (await callUrl(`https://pronouns.alejo.io/api/users/${username}`)).data[0];
 
-            if (pronouns != null && userPronounData != null) {
-                try {
-                    const pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
-                    if (pronoun != null) {
-                        if (pronounNumber === 0) {
-                            return pronoun.display;
-                        }
+            let pronounArray = [];
+            if (userPronounData == null || userPronounData === undefined) {
+                userPronounData = { "pronoun_id": `${fallback.replace("/", "")}` };
+            }
 
-                        const pronounArray = pronoun.display.split('/');
+            let pronoun = pronouns.find(p => p.name === userPronounData.pronoun_id);
+            if (pronoun != null) {
+                pronounArray = pronoun.display.split('/');
+            } else {
+                pronoun = { "display": `${fallback}` };
+                pronounArray = fallback.split('/');
+            }
 
-                        if (pronounArray.length === 1) {
-                            return pronounArray[0];
-                        }
+            if (pronounNumber === 0) {
+                return pronoun.display;
+            }
 
-                        if (pronounArray.length >= pronounNumber) {
-                            return pronounArray[pronounNumber - 1];
-                        }
-                        return fallback || "them/they";
-                    }
+            if (pronounArray.length === 1) {
+                return pronounArray[0];
+            }
 
-                    return fallback;
-                } catch (err) {
-                    logger.warn("error when parsing pronoun api", err);
-                    return fallback || "they/them";
-                }
+            if (pronounArray.length >= pronounNumber) {
+                return pronounArray[pronounNumber - 1];
             }
 
         } catch (err) {
             logger.warn("error when parsing pronoun api", err);
-            return fallback || "they/them";
+            return fallback;
         }
+        return fallback;
     }
 };
 

--- a/src/backend/variables/builtin/user/pronouns.ts
+++ b/src/backend/variables/builtin/user/pronouns.ts
@@ -24,7 +24,7 @@ const callUrl = async (url: string) => {
     }
 };
 
-const PronounVariable: ReplaceVariable = {
+const model : ReplaceVariable = {
     definition: {
         handle: "pronouns",
         description: "Returns the pronouns of the given user. It uses https://pronouns.alejo.io/ to get the pronouns.",
@@ -97,5 +97,4 @@ const PronounVariable: ReplaceVariable = {
         return fallback;
     }
 };
-
-export default PronounVariable;
+export default model;


### PR DESCRIPTION
### Description of the Change
Pronoun variable would return blank on fallback and unknown user


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2373

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


tested with my account and my bot account that has no pronoun
everything as documented supplies the expected data

$pronouns[username, 0, they/them]
Returns 'she/her' if available, otherwise uses they/them.

$pronouns[username, 1, they]
Returns 'she' pronoun in she/her set if available, otherwise uses they.

$pronouns[username, 2, them]
Returns 'her' pronoun in she/her set if available, otherwise uses them.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
