### PR TITLE
fix:missing autodisconnect #2423

### DIFF
--- a/src/backend/chat/twitch-chat.ts
+++ b/src/backend/chat/twitch-chat.ts
@@ -135,7 +135,7 @@ class TwitchChat extends EventEmitter {
 
             this._streamerIncomingChatClient.irc.onDisconnect((manual, reason) => {
                 if (!manual) {
-                    logger.error("Incomeing Chat disconnected unexpectedly", reason);
+                    logger.error("Incoming Chat disconnected unexpectedly", reason);
                     frontendCommunicator.send("twitch:chat:autodisconnected", true);
                 }
             });

--- a/src/backend/chat/twitch-chat.ts
+++ b/src/backend/chat/twitch-chat.ts
@@ -117,6 +117,7 @@ class TwitchChat extends EventEmitter {
             });
             this._streamerOutgoingingChatClient.irc.onRegister(() => {
                 this._streamerOutgoingingChatClient.join(streamer.username);
+                frontendCommunicator.send("twitch:chat:autodisconnected", false);
             });
 
             this._streamerIncomingChatClient.irc.onPasswordError((event) => {
@@ -134,14 +135,14 @@ class TwitchChat extends EventEmitter {
 
             this._streamerIncomingChatClient.irc.onDisconnect((manual, reason) => {
                 if (!manual) {
-                    logger.error("Chat disconnected unexpectedly", reason);
+                    logger.error("Incomeing Chat disconnected unexpectedly", reason);
                     frontendCommunicator.send("twitch:chat:autodisconnected", true);
                 }
             });
 
             this._streamerOutgoingingChatClient.irc.onDisconnect((manual, reason) => {
                 if (!manual) {
-                    logger.error("Chat disconnected unexpectedly", reason);
+                    logger.error("Outgoing Chat disconnected unexpectedly", reason);
                     frontendCommunicator.send("twitch:chat:autodisconnected", true);
                 }
             });


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
allow for updating the ui when re-connected to outgoing chat 
updated the error messages to see what side of the connection is struggling 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2423


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
have ran this for 1 hour without the alert staying 
before that the only way to get the alert to remove itself was to restart 


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://github.com/crowbartools/Firebot/assets/8982158/701b99e7-b10d-48c9-bdcc-244d8152718c)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
