### PR TITLE
chore: username refactor

### DIFF
--- a/src/backend/chat/chat-helpers.ts
+++ b/src/backend/chat/chat-helpers.ts
@@ -193,8 +193,8 @@ class FirebotChatHelpers {
         return parts.flatMap((p) => {
             if (p.type === "text" && p.text != null) {
 
-                if (firebotChatMessage.username !== streamer.displayName &&
-                    (!bot.loggedIn || firebotChatMessage.username !== bot.displayName)) {
+                if (firebotChatMessage.username !== streamer.username &&
+                    (!bot.loggedIn || firebotChatMessage.username !== bot.username)) {
                     if (!firebotChatMessage.whisper &&
                     !firebotChatMessage.tagged &&
                     streamer.loggedIn &&
@@ -346,9 +346,8 @@ class FirebotChatHelpers {
     buildBasicFirebotChatMessage(msgText: string, username: string): FirebotChatMessage {
         return {
             id: null,
-            userIdName: null,
-            userId: null,
             username: username,
+            userId: null,
             rawText: msgText,
             whisper: false,
             action: false,
@@ -362,9 +361,9 @@ class FirebotChatHelpers {
     async buildFirebotChatMessage(msg: ChatMessage, msgText: string, whisper = false, action = false) {
         const firebotChatMessage: FirebotChatMessage = {
             id: msg.tags.get("id"),
-            username: msg.userInfo.displayName,
-            userIdName: msg.userInfo.userName,
+            username: msg.userInfo.userName,
             userId: msg.userInfo.userId,
+            userDisplayName: msg.userInfo.displayName,
             customRewardId: msg.tags.get("custom-reward-id") || undefined,
             isHighlighted: msg.tags.get("msg-id") === "highlighted-message",
             isAnnouncement: false,
@@ -442,12 +441,12 @@ class FirebotChatHelpers {
         firebotChatMessage.isSubscriber = msg.userInfo.isSubscriber;
         firebotChatMessage.isVip = msg.userInfo.isVip;
 
-        if (streamer.loggedIn && firebotChatMessage.username === streamer.displayName) {
+        if (streamer.loggedIn && firebotChatMessage.username === streamer.username) {
             firebotChatMessage.isBroadcaster = true;
             firebotChatMessage.roles.push("broadcaster");
         }
 
-        if (bot.loggedIn && firebotChatMessage.username === bot.displayName) {
+        if (bot.loggedIn && firebotChatMessage.username === bot.username) {
             firebotChatMessage.isBot = true;
             firebotChatMessage.roles.push("bot");
         }
@@ -478,8 +477,8 @@ class FirebotChatHelpers {
         const firebotChatMessage: FirebotChatMessage = {
             id: id,
             username: extensionName,
-            userIdName: extensionName,
             userId: extensionName,
+            userDisplayName: extensionName,
             rawText: text,
             profilePicUrl: extensionIconUrl,
             whisper: false,
@@ -513,9 +512,9 @@ class FirebotChatHelpers {
 
         const viewerFirebotChatMessage: FirebotChatMessage = {
             id: msg.messageId,
-            username: msg.senderDisplayName,
-            userIdName: msg.senderName,
+            username: msg.senderName,
             userId: msg.senderId,
+            userDisplayName: msg.senderDisplayName,
             rawText: msg.messageContent,
             profilePicUrl: profilePicUrl,
             whisper: false,

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -40,9 +40,9 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
         frontendCommunicator.send("twitch:chat:message", firebotChatMessage);
 
         twitchEventsHandler.announcement.triggerAnnouncement(
-            firebotChatMessage.userIdName,
-            firebotChatMessage.userId,
             firebotChatMessage.username,
+            firebotChatMessage.userId,
+            firebotChatMessage.userDisplayName,
             firebotChatMessage.roles,
             firebotChatMessage.rawText
         );
@@ -71,7 +71,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
                 messageText: firebotChatMessage.rawText,
                 user: {
                     id: firebotChatMessage.userId,
-                    username: firebotChatMessage.username
+                    username: firebotChatMessage.username,
+                    displayName: firebotChatMessage.userDisplayName
                 },
                 reward: {
                     id: HIGHLIGHT_MESSAGE_REWARD_ID,
@@ -89,9 +90,9 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
         await activeUserHandler.addActiveUser(msg.userInfo, true);
 
         twitchEventsHandler.viewerArrived.triggerViewerArrived(
-            msg.userInfo.displayName,
             msg.userInfo.userName,
             msg.userInfo.userId,
+            msg.userInfo.displayName,
             messageText,
             firebotChatMessage
         );
@@ -118,6 +119,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
 
         twitchEventsHandler.whisper.triggerWhisper(
             msg.userInfo.userName,
+            msg.userInfo.userId,
+            msg.userInfo.displayName,
             messageText,
             accountType
         );
@@ -149,9 +152,9 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
         }
 
         twitchEventsHandler.viewerArrived.triggerViewerArrived(
-            msg.userInfo.displayName,
             msg.userInfo.userName,
             msg.userInfo.userId,
+            msg.userInfo.displayName,
             messageText,
             firebotChatMessage
         );
@@ -218,8 +221,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
     streamerChatClient.onGiftPaidUpgrade((_channel, _user, subInfo, msg) => {
         twitchEventsHandler.giftSub.triggerSubGiftUpgrade(
             msg.userInfo.userName,
-            subInfo.displayName,
             subInfo.userId,
+            subInfo.displayName,
             subInfo.gifterDisplayName,
             subInfo.plan
         );
@@ -228,8 +231,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
     streamerChatClient.onPrimePaidUpgrade((_channel, _user, subInfo, msg) => {
         twitchEventsHandler.sub.triggerPrimeUpgrade(
             msg.userInfo.userName,
-            subInfo.displayName,
             subInfo.userId,
+            subInfo.displayName,
             subInfo.plan
         );
     });

--- a/src/backend/chat/commands/chat-command-handler.ts
+++ b/src/backend/chat/commands/chat-command-handler.ts
@@ -212,6 +212,7 @@ class CommandHandler {
                 metadata: {
                     username: commandSender,
                     userId: firebotChatMessage.userId,
+                    userDisplayName: firebotChatMessage.userDisplayName,
                     userTwitchRoles: firebotChatMessage.roles,
                     command: command,
                     userCommand: userCmd,

--- a/src/backend/chat/commands/command-runner.ts
+++ b/src/backend/chat/commands/command-runner.ts
@@ -117,7 +117,7 @@ class CommandRunner {
                 metadata: {
                     username: userCommand.commandSender,
                     userId: undefined,
-                    userIdName: undefined,
+                    userDisplayName: userCommand.commandSender,
                     command: command,
                     userCommand: userCommand,
                     chatMessage: firebotChatMessage
@@ -128,7 +128,7 @@ class CommandRunner {
 
         if (firebotChatMessage != null) {
             processEffectsRequest.trigger.metadata.userId = firebotChatMessage.userId;
-            processEffectsRequest.trigger.metadata.userIdName = firebotChatMessage.userIdName;
+            processEffectsRequest.trigger.metadata.userDisplayName = firebotChatMessage.userDisplayName;
         }
 
         return effectRunner.processEffects(processEffectsRequest).catch((reason) => {

--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -12,15 +12,16 @@ module.exports = {
             cached: true,
             cacheMetaKey: "username",
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 viewerCount: 5
             },
             activityFeed: {
                 icon: "fad fa-siren-on",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** raided with **${eventData.viewerCount}** viewer(s)`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** raided with **${eventData.viewerCount}** viewer(s)`;
                 }
             }
         },
@@ -31,14 +32,15 @@ module.exports = {
             cached: true,
             cacheMetaKey: "username",
             manualMetadata: {
-                username: "Firebot"
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: ""
             },
             activityFeed: {
                 icon: "fas fa-heart",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** followed`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** followed`;
                 }
             }
         },
@@ -48,7 +50,9 @@ module.exports = {
             description: "When someone subscribes (or resubscribes) to your channel.",
             cached: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 isPrime: false,
                 isResub: false,
                 subPlan: {
@@ -68,9 +72,8 @@ module.exports = {
             activityFeed: {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** ${eventData.isResub ? 'resubscribed' : 'subscribed'} for **${eventData.totalMonths} month(s)** ${eventData.subPlan === 'Prime' ?
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** ${eventData.isResub ? 'resubscribed' : 'subscribed'} for **${eventData.totalMonths} month(s)** ${eventData.subPlan === 'Prime' ?
                         "with **Twitch Prime**" : `at **Tier ${eventData.subPlan.replace("000", "")}**`}`;
                 }
             }
@@ -81,7 +84,9 @@ module.exports = {
             description: "When someone upgrades to a paid sub from a Prime sub.",
             cached: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 subPlan: {
                     type: "enum",
                     options: {
@@ -95,9 +100,8 @@ module.exports = {
             activityFeed: {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** upgraded their Prime sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** upgraded their Prime sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
                 }
             }
         },
@@ -171,7 +175,9 @@ module.exports = {
             description: "When someone upgrades to a paid sub from a gift sub.",
             cached: false,
             manualMetadata: {
-                username: "CaveMobster",
+                username: "cavemobster",
+                userDisplayName: "CaveMobster",
+                userId: "",
                 gifteeUsername: "CaveMobster",
                 gifterUsername: "Firebot",
                 subPlan: {
@@ -187,9 +193,8 @@ module.exports = {
             activityFeed: {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** upgraded their gift sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** upgraded their gift sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
                 }
             }
         },
@@ -199,7 +204,9 @@ module.exports = {
             description: "When someone cheers in your channel (uses bits).",
             cached: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 isAnonymous: false,
                 bits: 100,
                 totalBits: 1200,
@@ -208,9 +215,8 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-diamond",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** cheered **${eventData.bits}** bits. They have cheered a total of **${eventData.totalBits}** in the channel.`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** cheered **${eventData.bits}** bits. They have cheered a total of **${eventData.totalBits}** in the channel.`;
                 }
             }
         },
@@ -220,7 +226,9 @@ module.exports = {
             description: "When someone unlocks a new bits badge tier in your channel.",
             cached: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 message: "Test message",
                 badgeTier: {
                     type: "enum",
@@ -260,9 +268,8 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-diamond",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** unlocked the **${eventData.badgeTier}** bits badge in your channel!`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** unlocked the **${eventData.badgeTier}** bits badge in your channel!`;
                 }
             }
         },
@@ -273,14 +280,15 @@ module.exports = {
             cached: true,
             cacheMetaKey: "username",
             manualMetadata: {
-                username: "Firebot"
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: ""
             },
             activityFeed: {
                 icon: "fad fa-house-return",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** arrived`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** arrived`;
                 }
             }
         },
@@ -291,7 +299,9 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 messageText: "Test message"
             }
         },
@@ -302,15 +312,16 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 messageText: "Test message"
             },
             activityFeed: {
                 icon: "fad fa-sparkles",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** has chatted in your channel for the very first time`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** has chatted in your channel for the very first time`;
                 }
             }
         },
@@ -321,7 +332,9 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 messageText: "Test announcement"
             }
         },
@@ -332,20 +345,20 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "CaveMobster",
+                username: "cavemobster",
+                userDisplayName: "CaveMobster",
+                userId: "",
                 moderator: "Firebot",
                 modReason: "They were extra naughty"
             },
             activityFeed: {
                 icon: "fad fa-gavel",
                 getMessage: (eventData) => {
-                    let message;
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    let message = `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was banned by **${eventData.moderator}**.`;
+
                     if (eventData.modReason) {
-                        message = `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** was banned by **${eventData.moderator}**. Reason: **${eventData.modReason}**`;
-                    } else {
-                        message = `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** was banned by **${eventData.moderator}**.`;
+                        message = `${message} Reason: **${eventData.modReason}**`;
                     }
                     return message;
                 }
@@ -358,15 +371,16 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "CaveMobster",
+                username: "cavemobster",
+                userDisplayName: "CaveMobster",
+                userId: "",
                 moderator: "Firebot"
             },
             activityFeed: {
                 icon: "fad fa-gavel",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** was unbanned by **${eventData.moderator}**.`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was unbanned by **${eventData.moderator}**.`;
                 }
             }
         },
@@ -377,7 +391,9 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "ebiggz",
+                username: "alca",
+                userDisplayName: "Alca",
+                userId: "",
                 timeoutDuration: "1",
                 moderator: "Firebot",
                 modReason: "They were naughty"
@@ -385,13 +401,11 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-stopwatch",
                 getMessage: (eventData) => {
-                    let message;
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    let message = `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was timed out for **${eventData.timeoutDuration} sec(s)** by ${eventData.moderator}.`;
+
                     if (eventData.modReason) {
-                        message = `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** was timed out for **${eventData.timeoutDuration} sec(s)** by ${eventData.moderator}. Reason: **${eventData.modReason}**`;
-                    } else {
-                        message = `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** was timed out for **${eventData.timeoutDuration} sec(s)** by ${eventData.moderator}.`;
+                        message = `${message} Reason: **${eventData.modReason}**`;
                     }
                     return message;
                 }
@@ -406,7 +420,9 @@ module.exports = {
             cacheTtlInSecs: 1,
             queued: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 rewardName: "Test Reward",
                 rewardImage: "https://static-cdn.jtvnw.net/automatic-reward-images/highlight-1.png",
                 rewardCost: 200,
@@ -415,9 +431,8 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-circle",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** redeemed **${eventData.rewardName}**${eventData.messageText && !!eventData.messageText.length ? `: *${eventData.messageText}*` : ''}`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** redeemed **${eventData.rewardName}**${eventData.messageText && !!eventData.messageText.length ? `: *${eventData.messageText}*` : ''}`;
                 }
             }
         },
@@ -427,7 +442,9 @@ module.exports = {
             description: "When someone sends you or your bot account a whisper.",
             cached: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 message: "Test whisper",
                 sentTo: {
                     type: "enum",
@@ -441,9 +458,8 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-comment-alt",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** sent your **${eventData.sentTo}** account the following whisper: ${eventData.message}`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** sent your **${eventData.sentTo}** account the following whisper: ${eventData.message}`;
                 }
             }
         },
@@ -844,14 +860,15 @@ module.exports = {
             manualMetadata: {
                 moderator: "Firebot",
                 username: "zunderscore",
+                userDisplayName: "zunderscore",
+                userId: "",
                 viewerCount: 10
             },
             activityFeed: {
                 icon: "fad fa-bullhorn",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.moderator}** sent a shoutout to **${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}**`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.moderator}** sent a shoutout to **${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}**`;
                 }
             }
         },
@@ -862,15 +879,16 @@ module.exports = {
             cached: false,
             queued: false,
             manualMetadata: {
-                username: "Firebot",
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
                 viewerCount: 10
             },
             activityFeed: {
                 icon: "fad fa-bullhorn",
                 getMessage: (eventData) => {
-                    const showUserIdName = eventData.userIdName
-                        && eventData.username.toLowerCase() !== eventData.userIdName.toLowerCase();
-                    return `**${eventData.username}${showUserIdName ? ` (${eventData.userIdName})` : ""}** shouted out your channel to ${eventData.viewerCount} viewers`;
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** shouted out your channel to ${eventData.viewerCount} viewers`;
                 }
             }
         },

--- a/src/backend/events/filters/builtin/viewer-roles.js
+++ b/src/backend/events/filters/builtin/viewer-roles.js
@@ -64,13 +64,13 @@ module.exports = {
         const { comparisonType, value } = filterSettings;
         const { eventMeta } = eventData;
 
-        const { username, userIdName } = eventMeta;
-        if (!username && !userIdName) {
+        const { username } = eventMeta;
+        if (!username) {
             return false;
         }
 
         try {
-            const user = await twitchApi.users.getUserByName(userIdName ?? username.toLowerCase());
+            const user = await twitchApi.users.getUserByName(username);
             if (user == null) {
                 return false;
             }

--- a/src/backend/events/twitch-events/announcement.ts
+++ b/src/backend/events/twitch-events/announcement.ts
@@ -1,16 +1,16 @@
 import eventManager from "../EventManager";
 
 export function triggerAnnouncement(
-    userName: string,
+    username: string,
     userId: string,
     userDisplayName: string,
     twitchUserRoles: string[],
     messageText: string
 ): void {
     eventManager.triggerEvent("twitch", "announcement", {
-        userIdName: userName,
+        username,
         userId,
-        username: userDisplayName,
+        userDisplayName,
         twitchUserRoles,
         messageText
     });

--- a/src/backend/events/twitch-events/charity.ts
+++ b/src/backend/events/twitch-events/charity.ts
@@ -24,6 +24,8 @@ export function triggerCharityCampaignStart(
 
 export function triggerCharityDonation(
     username: string,
+    userId: string,
+    userDisplayName: string,
     charityName: string,
     charityDescription: string,
     charityLogo: string,
@@ -32,7 +34,10 @@ export function triggerCharityDonation(
     donationCurrency: string
 ) {
     eventManager.triggerEvent("twitch", "charity-donation", {
-        from: username,
+        username,
+        userId,
+        userDisplayName,
+        from: userDisplayName,
         charityName,
         charityDescription,
         charityLogo,

--- a/src/backend/events/twitch-events/chat-message.ts
+++ b/src/backend/events/twitch-events/chat-message.ts
@@ -3,9 +3,9 @@ import eventManager from "../../events/EventManager";
 
 export function triggerChatMessage(firebotChatMessage: FirebotChatMessage): void {
     eventManager.triggerEvent("twitch", "chat-message", {
-        userId: firebotChatMessage.userId,
-        userIdName: firebotChatMessage.userIdName,
         username: firebotChatMessage.username,
+        userId: firebotChatMessage.userId,
+        userDisplayName: firebotChatMessage.userDisplayName,
         twitchUserRoles: firebotChatMessage.roles,
         messageText: firebotChatMessage.rawText,
         chatMessage: firebotChatMessage
@@ -14,9 +14,9 @@ export function triggerChatMessage(firebotChatMessage: FirebotChatMessage): void
 
 export function triggerFirstTimeChat(firebotChatMessage: FirebotChatMessage): void {
     eventManager.triggerEvent("twitch", "first-time-chat", {
-        userId: firebotChatMessage.userId,
-        userIdName: firebotChatMessage.userIdName,
         username: firebotChatMessage.username,
+        userId: firebotChatMessage.userId,
+        userDisplayName: firebotChatMessage.userDisplayName,
         twitchUserRoles: firebotChatMessage.roles,
         messageText: firebotChatMessage.rawText,
         chatMessage: firebotChatMessage

--- a/src/backend/events/twitch-events/cheer.ts
+++ b/src/backend/events/twitch-events/cheer.ts
@@ -1,16 +1,18 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerCheer(
-    userName: string,
+    username: string,
     userId: string,
+    userDisplayName: string,
     isAnonymous: boolean,
     bits: number,
     totalBits: number,
     cheerMessage: string
 ): void {
     eventManager.triggerEvent("twitch", "cheer", {
-        username: userName,
+        username,
         userId,
+        userDisplayName,
         isAnonymous,
         bits,
         totalBits,
@@ -19,12 +21,16 @@ export function triggerCheer(
 }
 
 export function triggerBitsBadgeUnlock(
-    userName: string,
+    username: string,
+    userId: string,
+    userDisplayName: string,
     message: string,
     badgeTier: number
 ): void {
     eventManager.triggerEvent("twitch", "bits-badge-unlocked", {
-        username: userName,
+        username,
+        userId,
+        userDisplayName,
         message,
         badgeTier
     });

--- a/src/backend/events/twitch-events/follow.ts
+++ b/src/backend/events/twitch-events/follow.ts
@@ -1,13 +1,13 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerFollow(
+    username: string,
     userId: string,
-    userName: string,
     userDisplayName: string
 ): void {
     eventManager.triggerEvent("twitch", "follow", {
+        username,
         userId,
-        userIdName: userName,
-        username: userDisplayName
+        userDisplayName
     });
 }

--- a/src/backend/events/twitch-events/gift-sub.ts
+++ b/src/backend/events/twitch-events/gift-sub.ts
@@ -54,9 +54,9 @@ export function triggerSubGift(
                         communitySubCache.set<CommunityGiftSubCache>(cacheKey, {subCount: newCount, giftReceivers: giftReceivers});
                     } else {
                         eventManager.triggerEvent("twitch", "community-subs-gifted", {
-                            username: gifterDisplayName,
-                            userIdName: gifterUserName,
+                            username: gifterUserName,
                             userId: gifterUserId,
+                            userDisplayName: gifterDisplayName,
                             subCount: giftReceivers.length,
                             subPlan,
                             isAnonymous,
@@ -79,9 +79,9 @@ export function triggerSubGift(
     }
 
     eventManager.triggerEvent("twitch", "subs-gifted", {
-        username: gifterDisplayName,
-        userIdName: gifterUserName,
+        username: gifterUserName,
         userId: gifterUserId,
+        userDisplayName: gifterDisplayName,
         giftSubMonths,
         gifteeUsername: gifteeDisplayName,
         gifterUsername: gifterDisplayName,
@@ -93,16 +93,16 @@ export function triggerSubGift(
 }
 
 export function triggerSubGiftUpgrade(
-    gifteeUserName: string,
-    gifteeDisplayName: string,
+    gifteeUsername: string,
     gifteeUserId: string,
+    gifteeDisplayName: string,
     gifterDisplayName: string,
     subPlan: string
 ): void {
     eventManager.triggerEvent("twitch", "gift-sub-upgraded", {
-        username: gifteeDisplayName,
-        userIdName: gifteeUserName,
+        username: gifteeUsername,
         userId: gifteeUserId,
+        userDisplayName: gifteeDisplayName,
         gifterUsername: gifterDisplayName,
         gifteeUsername: gifteeDisplayName,
         subPlan

--- a/src/backend/events/twitch-events/raid.ts
+++ b/src/backend/events/twitch-events/raid.ts
@@ -7,9 +7,9 @@ export function triggerRaid(
     viewerCount = 0
 ): void {
     eventManager.triggerEvent("twitch", "raid", {
-        username: userDisplayName,
-        userIdName: username,
+        username,
         userId,
+        userDisplayName,
         viewerCount
     });
 }

--- a/src/backend/events/twitch-events/reward-redemption.ts
+++ b/src/backend/events/twitch-events/reward-redemption.ts
@@ -8,7 +8,7 @@ export function handleRewardRedemption(
     isQueued: boolean,
     messageText: string,
     userId: string,
-    userName: string,
+    username: string,
     userDisplayName: string,
     rewardId: string,
     rewardTitle: string,
@@ -23,7 +23,8 @@ export function handleRewardRedemption(
         messageText,
         user: {
             id: userId,
-            username: userName
+            username,
+            displayName: userDisplayName
         },
         reward: {
             id: rewardId,
@@ -35,9 +36,9 @@ export function handleRewardRedemption(
 
     setTimeout(() => {
         const redemptionMeta = {
-            username: userDisplayName,
-            userIdName: userName,
-            userId: userId,
+            username,
+            userId,
+            userDisplayName,
             messageText,
             redemptionId,
             rewardId,

--- a/src/backend/events/twitch-events/shoutout.ts
+++ b/src/backend/events/twitch-events/shoutout.ts
@@ -1,23 +1,36 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerShoutoutSent(
+    username: string,
+    userId: string,
     userDisplayName: string,
+    moderatorUsername: string,
+    moderatorId: string,
     moderatorDisplayName: string,
     viewerCount: number
 ) {
     eventManager.triggerEvent("twitch", "shoutout-sent", {
-        username: userDisplayName,
+        username,
+        userId,
+        userDisplayName,
+        moderatorUsername,
+        moderatorId,
+        moderatorDisplayName,
         moderator: moderatorDisplayName,
         viewerCount
     });
 }
 
 export function triggerShoutoutReceived(
+    username: string,
+    userId: string,
     userDisplayName: string,
     viewerCount: number
 ) {
     eventManager.triggerEvent("twitch", "shoutout-received", {
-        username: userDisplayName,
+        username,
+        userId,
+        userDisplayName,
         viewerCount
     });
 }

--- a/src/backend/events/twitch-events/stream.ts
+++ b/src/backend/events/twitch-events/stream.ts
@@ -1,25 +1,25 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerStreamOnline(
+    username: string,
     userId: string,
-    userLogin: string,
     userDisplayName: string
 ) {
     eventManager.triggerEvent("twitch", "stream-online", {
+        username,
         userId,
-        userLogin,
         userDisplayName
     });
 }
 
 export function triggerStreamOffline(
+    username: string,
     userId: string,
-    userLogin: string,
     userDisplayName: string
 ) {
     eventManager.triggerEvent("twitch", "stream-offline", {
+        username,
         userId,
-        userLogin,
         userDisplayName
     });
 }

--- a/src/backend/events/twitch-events/sub.ts
+++ b/src/backend/events/twitch-events/sub.ts
@@ -1,7 +1,7 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerSub(
-    userName: string,
+    username: string,
     userId: string,
     userDisplayName: string,
     subPlan: string,
@@ -12,9 +12,9 @@ export function triggerSub(
     isResub: boolean
 ): void {
     eventManager.triggerEvent("twitch", "sub", {
-        userIdName: userName,
-        username: userDisplayName,
+        username,
         userId,
+        userDisplayName,
         subPlan,
         totalMonths,
         subMessage,
@@ -26,14 +26,14 @@ export function triggerSub(
 
 export function triggerPrimeUpgrade(
     username: string,
-    userDisplayName: string,
     userId: string,
+    userDisplayName: string,
     subPlan: string
- ): void {
+): void {
     eventManager.triggerEvent("twitch", "prime-sub-upgraded", {
-        username: userDisplayName,
-        userIdName: username,
+        username,
         userId,
+        userDisplayName,
         subPlan
     });
 }

--- a/src/backend/events/twitch-events/viewer-arrived.ts
+++ b/src/backend/events/twitch-events/viewer-arrived.ts
@@ -2,16 +2,16 @@ import { FirebotChatMessage } from "../../../types/chat";
 import eventManager from "../../events/EventManager";
 
 export function triggerViewerArrived(
-    userDisplayName: string,
-    userName: string,
+    username: string,
     userId: string,
+    userDisplayName: string,
     messageText: string,
     chatMessage: FirebotChatMessage
 ) {
     eventManager.triggerEvent("twitch", "viewer-arrived", {
-        username: userDisplayName,
-        userIdName: userName,
+        username,
         userId,
+        userDisplayName,
         messageText,
         chatMessage
     });

--- a/src/backend/events/twitch-events/viewer-banned.ts
+++ b/src/backend/events/twitch-events/viewer-banned.ts
@@ -1,23 +1,41 @@
 import eventManager from "../EventManager";
 
 export function triggerBanned(
+    username: string,
+    userId: string,
     userDisplayName: string,
-    moderator: string,
+    moderatorUsername: string,
+    moderatorId: string,
+    moderatorDisplayName: string,
     modReason: string
 ): void {
     eventManager.triggerEvent("twitch", "banned", {
-        username: userDisplayName,
-        moderator,
+        username,
+        userId,
+        userDisplayName,
+        moderatorUsername,
+        moderatorId,
+        moderatorDisplayName,
+        moderator: moderatorDisplayName,
         modReason
     });
 }
 
 export function triggerUnbanned(
+    username: string,
+    userId: string,
     userDisplayName: string,
-    moderator: string
+    moderatorUsername: string,
+    moderatorId: string,
+    moderatorDisplayName: string
 ) {
     eventManager.triggerEvent("twitch", "unbanned", {
-        username: userDisplayName,
-        moderator
+        username,
+        userId,
+        userDisplayName,
+        moderatorUsername,
+        moderatorId,
+        moderatorDisplayName,
+        moderator: moderatorDisplayName
     });
 }

--- a/src/backend/events/twitch-events/viewer-timeout.ts
+++ b/src/backend/events/twitch-events/viewer-timeout.ts
@@ -1,15 +1,24 @@
 import eventManager from "../EventManager";
 
 export function triggerTimeout(
+    username: string,
+    userId: string,
     userDisplayName: string,
+    moderatorUsername: string,
+    moderatorId: string,
+    moderatorDisplayName: string,
     timeoutDuration: string | number,
-    moderator: string,
     modReason: string
 ): void {
     eventManager.triggerEvent("twitch", "timeout", {
-        username: userDisplayName,
+        username,
+        userId,
+        userDisplayName,
+        moderatorUsername,
+        moderatorId,
+        moderatorDisplayName,
+        moderator: moderatorDisplayName,
         timeoutDuration,
-        moderator,
         modReason
     });
 }

--- a/src/backend/events/twitch-events/whisper.ts
+++ b/src/backend/events/twitch-events/whisper.ts
@@ -1,12 +1,16 @@
 import eventManager from "../../events/EventManager";
 
 export function triggerWhisper(
+    username: string,
+    userId: string,
     userDisplayName: string,
     message: string,
     sentTo: "streamer" | "bot"
 ): void {
     eventManager.triggerEvent("twitch", "whisper", {
-        username: userDisplayName,
+        username,
+        userId,
+        userDisplayName,
         message,
         sentTo
     });

--- a/src/backend/timers/scheduled-task-manager.ts
+++ b/src/backend/timers/scheduled-task-manager.ts
@@ -60,6 +60,8 @@ class ScheduledTaskManager extends JsonDbManager<ScheduledTask> {
                         type: TriggerType.SCHEDULED_TASK,
                         metadata: {
                             username: accountAccess.getAccounts().streamer.username,
+                            userId: accountAccess.getAccounts().streamer.userId,
+                            userDisplayName: accountAccess.getAccounts().streamer.displayName,
                             task: task
                         }
                     },

--- a/src/backend/timers/timer-manager.ts
+++ b/src/backend/timers/timer-manager.ts
@@ -124,6 +124,8 @@ class TimerManager extends JsonDbManager<Timer> {
                     type: TriggerType.TIMER,
                     metadata: {
                         username: accountAccess.getAccounts().streamer.username,
+                        userId: accountAccess.getAccounts().streamer.userId,
+                        userDisplayName: accountAccess.getAccounts().streamer.displayName,
                         timer: timer
                     }
                 },

--- a/src/backend/twitch-api/eventsub/eventsub-client.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-client.ts
@@ -18,8 +18,8 @@ class TwitchEventSubClient {
         // Stream online
         const onlineSubscription = this._eventSubListener.onStreamOnline(streamer.userId, (event) => {
             twitchEventsHandler.stream.triggerStreamOnline(
-                event.broadcasterId,
                 event.broadcasterName,
+                event.broadcasterId,
                 event.broadcasterDisplayName
             );
         });
@@ -28,8 +28,8 @@ class TwitchEventSubClient {
         // Stream offline
         const offlineSubscription = this._eventSubListener.onStreamOffline(streamer.userId, (event) => {
             twitchEventsHandler.stream.triggerStreamOffline(
-                event.broadcasterId,
                 event.broadcasterName,
+                event.broadcasterId,
                 event.broadcasterDisplayName
             );
         });
@@ -38,8 +38,8 @@ class TwitchEventSubClient {
         // Follows
         const followSubscription = this._eventSubListener.onChannelFollow(streamer.userId, streamer.userId, (event) => {
             twitchEventsHandler.follow.triggerFollow(
-                event.userId,
                 event.userName,
+                event.userId,
                 event.userDisplayName
             );
         });
@@ -50,8 +50,9 @@ class TwitchEventSubClient {
             const totalBits = (await TwitchApi.bits.getChannelBitsLeaderboard(1, "all", new Date(), event.userId))[0]?.amount ?? 0;
 
             twitchEventsHandler.cheer.triggerCheer(
-                event.userDisplayName ?? "An Anonymous Cheerer",
+                event.userName ?? "ananonymouscheerer",
                 event.userId,
+                event.userDisplayName ?? "An Anonymous Cheerer",
                 event.isAnonymous,
                 event.bits,
                 totalBits,
@@ -107,7 +108,11 @@ class TwitchEventSubClient {
         // Shoutout sent to another channel
         const shoutoutSentSubscription = this._eventSubListener.onChannelShoutoutCreate(streamer.userId, streamer.userId, (event) => {
             twitchEventsHandler.shoutout.triggerShoutoutSent(
+                event.shoutedOutBroadcasterName,
+                event.shoutedOutBroadcasterId,
                 event.shoutedOutBroadcasterDisplayName,
+                event.moderatorName,
+                event.moderatorId,
                 event.moderatorDisplayName,
                 event.viewerCount
             );
@@ -117,6 +122,8 @@ class TwitchEventSubClient {
         // Shoutout received from another channel
         const shoutoutReceivedSubscription = this._eventSubListener.onChannelShoutoutReceive(streamer.userId, streamer.userId, (event) => {
             twitchEventsHandler.shoutout.triggerShoutoutReceived(
+                event.shoutingOutBroadcasterName,
+                event.shoutingOutBroadcasterId,
                 event.shoutingOutBroadcasterDisplayName,
                 event.viewerCount
             );
@@ -297,15 +304,23 @@ class TwitchEventSubClient {
             if (event.endDate) {
                 const timeoutDuration = (event.endDate.getTime() - event.startDate.getTime()) / 1000;
                 twitchEventsHandler.viewerTimeout.triggerTimeout(
+                    event.userName,
+                    event.userId,
                     event.userDisplayName,
-                    timeoutDuration,
                     event.moderatorName,
+                    event.moderatorId,
+                    event.moderatorDisplayName,
+                    timeoutDuration,
                     event.reason
                 );
             } else {
                 twitchEventsHandler.viewerBanned.triggerBanned(
+                    event.userName,
+                    event.userId,
                     event.userDisplayName,
                     event.moderatorName,
+                    event.moderatorId,
+                    event.moderatorDisplayName,
                     event.reason
                 );
             }
@@ -318,7 +333,11 @@ class TwitchEventSubClient {
         const unbanSubscription = this._eventSubListener.onChannelUnban(streamer.userId, (event) => {
             twitchEventsHandler.viewerBanned.triggerUnbanned(
                 event.userName,
-                event.moderatorName
+                event.userId,
+                event.userDisplayName,
+                event.moderatorName,
+                event.moderatorId,
+                event.moderatorDisplayName
             );
         });
         this._subscriptions.push(unbanSubscription);
@@ -341,6 +360,8 @@ class TwitchEventSubClient {
         // Charity Donation
         const charityDonationSubscription = this._eventSubListener.onChannelCharityDonation(streamer.userId, (event) => {
             twitchEventsHandler.charity.triggerCharityDonation(
+                event.donorName,
+                event.donorId,
                 event.donorDisplayName,
                 event.charityName,
                 event.charityDescription,
@@ -400,7 +421,10 @@ class TwitchEventSubClient {
 
         try {
             this._eventSubListener = new EventSubWsListener({
-                apiClient: TwitchApi.streamerClient
+                apiClient: TwitchApi.streamerClient,
+                logger: {
+                    minLevel: "debug"
+                }
             });
 
             this._eventSubListener.start();

--- a/src/backend/twitch-api/eventsub/eventsub-client.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-client.ts
@@ -421,10 +421,7 @@ class TwitchEventSubClient {
 
         try {
             this._eventSubListener = new EventSubWsListener({
-                apiClient: TwitchApi.streamerClient,
-                logger: {
-                    minLevel: "debug"
-                }
+                apiClient: TwitchApi.streamerClient
             });
 
             this._eventSubListener.start();

--- a/src/backend/twitch-api/pubsub/pubsub-client.js
+++ b/src/backend/twitch-api/pubsub/pubsub-client.js
@@ -69,6 +69,8 @@ async function createClient() {
 
         const bitsBadgeUnlockListener = pubSubClient.onBitsBadgeUnlock(streamer.userId, (message) => {
             twitchEventsHandler.cheer.triggerBitsBadgeUnlock(
+                message.userName ?? "ananonymouscheerer",
+                message.userId,
                 message.userName ?? "An Anonymous Cheerer",
                 message.message ?? "",
                 message.badgeTier
@@ -122,9 +124,6 @@ async function createClient() {
                         id: message.targetUserId,
                         username: message.targetUserName
                     });
-                    break;
-                case "vip_removed":
-                    chatRolesManager.removeVipFromVipList(message.targetUserId);
                     break;
                 default:
                     switch (message.action) {

--- a/src/backend/variables/builtin/currency/top-currency-raw.ts
+++ b/src/backend/variables/builtin/currency/top-currency-raw.ts
@@ -46,7 +46,9 @@ const model : ReplaceVariable = {
 
         const topHoldersDisplay = topCurrencyHolders.map((u, i) => ({
             place: i + 1,
-            username: u.displayName,
+            username: u.username,
+            userId: u._id,
+            userDisplayName: u.displayName,
             amount: u.currency[currency.id]
         }));
 

--- a/src/backend/variables/builtin/metadata/top-metadata-raw.ts
+++ b/src/backend/variables/builtin/metadata/top-metadata-raw.ts
@@ -37,7 +37,9 @@ const model : ReplaceVariable = {
             // map each entry to #position) name - amount
             .map((user, idx) => ({
                 place: idx + 1,
-                username: user.displayName,
+                username: user.username,
+                userId: user._id,
+                userDisplayName: user.displayName,
                 amount: user.metadata[metadataKey]
             }));
 

--- a/src/backend/variables/builtin/misc/top-view-time-raw.ts
+++ b/src/backend/variables/builtin/misc/top-view-time-raw.ts
@@ -24,6 +24,8 @@ const model : ReplaceVariable = {
         return topViewTimeUsers.map((u, i) => ({
             place: i + 1,
             username: u.username,
+            userId: u._id,
+            userDisplayName: u.displayName,
             minutes: u.minutesInChannel
         }));
     }

--- a/src/backend/variables/builtin/twitch/cheer/bits-leaderboard.ts
+++ b/src/backend/variables/builtin/twitch/cheer/bits-leaderboard.ts
@@ -1,9 +1,11 @@
+import { HelixBitsLeaderboardPeriod } from "@twurple/api";
+import moment from "moment";
+
 import { ReplaceVariable, Trigger } from "../../../../../types/variables";
 import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+import twitchApi from "../../../../twitch-api/api";
 
 const expressionish = require('expressionish');
-const moment = require("moment");
-const twitchApi = require("../../../../twitch-api/api");
 
 const model : ReplaceVariable = {
     definition: {
@@ -54,21 +56,21 @@ const model : ReplaceVariable = {
     },
     evaluator: async (
         trigger: Trigger,
-        count = 10,
-        // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-        period: string = "all",
+        count: number = 10, // eslint-disable-line @typescript-eslint/no-inferrable-types
+        period: string = "all", // eslint-disable-line @typescript-eslint/no-inferrable-types
         startDate = null
     ) => {
         count = count ?? 1;
         period = (period ?? "all").toLowerCase();
         startDate = startDate == null ? moment() : moment(startDate);
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const leaderboard = await twitchApi.bits.getChannelBitsLeaderboard(count, period, (<any>startDate).toDate());
+        const leaderboard = await twitchApi.bits.getChannelBitsLeaderboard(count, (period as HelixBitsLeaderboardPeriod), (<any>startDate).toDate());
 
-        return leaderboard.map(l => {
+        return leaderboard.map((l) => {
             return {
                 username: l.userName,
+                userId: l.userId,
+                userDisplayName: l.userDisplayName,
                 amount: l.amount
             };
         });

--- a/src/backend/variables/builtin/user/index.ts
+++ b/src/backend/variables/builtin/user/index.ts
@@ -5,6 +5,7 @@ import randomViewer from './random-viewer';
 import randomActiveViewer from './random-active-viewer';
 import userAvatarUrl from './user-avatar-url';
 import userBadgeUrl from './user-badge-urls';
+import userDisplayName from './user-display-name';
 import userExists from './user-exists';
 import userId from './user-id';
 import userIdName from './user-id-name';
@@ -25,6 +26,7 @@ export default [
     randomActiveViewer,
     userAvatarUrl,
     userBadgeUrl,
+    userDisplayName,
     userExists,
     userId,
     userIdName,

--- a/src/backend/variables/builtin/user/user-display-name.ts
+++ b/src/backend/variables/builtin/user/user-display-name.ts
@@ -7,17 +7,17 @@ import twitchApi from "../../../twitch-api/api";
 
 const model : ReplaceVariable = {
     definition: {
-        handle: "userId",
-        usage: "userId[username]",
-        description: "Gets the user ID for the given username. Searches local viewer DB first, then Twitch API.",
+        handle: "userDisplayName",
+        usage: "userDisplayName[username]",
+        description: "Gets the formatted display name for the given username. Searches local viewer DB first, then Twitch API.",
         categories: [VariableCategory.USER],
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: async (trigger, username: string) => {
         if (username == null) {
-            const userId = trigger.metadata.userid ?? trigger.metadata.userId;
-            if (userId != null) {
-                return userId;
+            const userDisplayName = trigger.metadata.userDisplayName ?? trigger.metadata.userDisplayName;
+            if (userDisplayName != null) {
+                return userDisplayName;
             }
             username = trigger.metadata.username;
             if (username == null) {
@@ -26,13 +26,13 @@ const model : ReplaceVariable = {
         }
         const viewer = await viewerDatabase.getViewerByUsername(username);
         if (viewer != null) {
-            return viewer._id;
+            return viewer.displayName;
         }
 
         try {
             const user = await twitchApi.users.getUserByName(username);
             if (user != null) {
-                return user.id;
+                return user.displayName;
             }
             return "[No user found]";
         } catch (error) {

--- a/src/backend/variables/builtin/user/user-id-name.ts
+++ b/src/backend/variables/builtin/user/user-id-name.ts
@@ -1,6 +1,8 @@
+// Deprecated
 import { ReplaceVariable } from "../../../../types/variables";
 import { OutputDataType } from "../../../../shared/variable-constants";
 import { EffectTrigger } from "../../../../shared/effect-constants";
+import user from "../metadata/user";
 
 const triggers = {};
 triggers[EffectTrigger.COMMAND] = true;
@@ -14,18 +16,11 @@ triggers[EffectTrigger.QUICK_ACTION] = true;
 const model : ReplaceVariable = {
     definition: {
         handle: "useridname",
-        description: "The associated underlying user identifying name for the given trigger.",
+        description: "(Deprecated: Use $user or $username) The associated underlying user identifying name for the given trigger.",
         triggers: triggers,
         possibleDataOutput: [OutputDataType.TEXT]
     },
-    evaluator: (trigger) => {
-        // We have a few places where this might be set, so we check them all
-        // Start with any event data, then we check the regular metadata
-        return trigger.metadata?.eventData?.userIdName ??
-            trigger.metadata?.eventData?.chatMessage?.userIdName ??
-            trigger.metadata?.userIdName ??
-            trigger.metadata?.chatMessage?.userIdName;
-    }
+    evaluator: user.evaluator
 };
 
 export default model;

--- a/src/backend/viewers/viewer-database.ts
+++ b/src/backend/viewers/viewer-database.ts
@@ -186,9 +186,9 @@ class ViewerDatabase extends EventEmitter {
         // Insert our record into db.
         try {
             eventManager.triggerEvent("firebot", "viewer-created", {
-                username: displayName,
-                userIdName: username,
-                userId
+                username,
+                userId,
+                userDisplayName: displayName
             });
 
             const newViewer = await this._db.insertAsync(viewer);

--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -119,13 +119,13 @@
                                     ng-click="$root.openLinkExternally('https://pronouns.alejo.io/')"
                                     ng-show="$ctrl.showPronoun && $ctrl.pronouns.pronounCache[$ctrl.message.username] != null"
                                 >{{$ctrl.pronouns.pronounCache[$ctrl.message.username]}}</span>
-                                <b ng-style="{'color': $ctrl.message.color}">{{$ctrl.message.username}}</b>
+                                <b ng-style="{'color': $ctrl.message.color}">{{$ctrl.message.userDisplayName != null ? $ctrl.message.userDisplayName : $ctrl.message.username}}</b>
                                 <span
-                                    ng-if="$ctrl.message.userIdName && $ctrl.message.username.toLowerCase() !== $ctrl.message.userIdName.toLowerCase()"
+                                    ng-if="$ctrl.message.username && $ctrl.message.userDisplayName && $ctrl.message.username.toLowerCase() !== $ctrl.message.userDisplayName.toLowerCase()"
                                     style="font-weight: 100"
                                     ng-style="{'color': $ctrl.message.color}"
                                     class="muted"
-                                >&nbsp;({{$ctrl.message.userIdName}})</span>
+                                >&nbsp;({{$ctrl.message.username}})</span>
                                 <span
                                     ng-if="$ctrl.compactDisplay && !$ctrl.message.action"
                                     style="color:white;font-weight:200;"
@@ -366,7 +366,7 @@
                         {
                             html: `<div class="name-wrapper">
                                     <img class="user-avatar" src="${message.profilePicUrl}">
-                                    <span style="margin-left: 10px" class="user-name">${message.username}</span>
+                                    <span style="margin-left: 10px" class="user-name">${message.userDisplayName}${message.username && message.username.toLowerCase() !== message.userDisplayName.toLowerCase() ? ` (${message.username})` : ""}</span>
                                 </div>`,
                             enabled: false
                         },
@@ -399,56 +399,56 @@
                         })];
                 };
 
-                $ctrl.messageActionSelected = (action, userName, userId, msgId, rawText) => {
+                $ctrl.messageActionSelected = (action, username, userId, msgId, rawText) => {
                     switch (action.toLowerCase()) {
                         case "delete message":
                             chatMessagesService.deleteMessage(msgId);
                             break;
                         case "timeout":
-                            updateChatField(`/timeout @${userName} 300`);
+                            updateChatField(`/timeout @${username} 300`);
                             break;
                         case "ban":
                             utilityService
                                 .showConfirmationModal({
                                     title: "Ban User",
-                                    question: `Are you sure you want to ban ${userName}?`,
+                                    question: `Are you sure you want to ban ${username}?`,
                                     confirmLabel: "Ban",
                                     confirmBtnType: "btn-danger"
                                 })
                                 .then((confirmed) => {
                                     if (confirmed) {
-                                        backendCommunicator.fireEvent("update-user-banned-status", { username: userName, shouldBeBanned: true });
+                                        backendCommunicator.fireEvent("update-user-banned-status", { username: username, shouldBeBanned: true });
                                     }
                                 });
                             break;
                         case "mod":
-                            chatMessagesService.changeModStatus(userName, true);
+                            chatMessagesService.changeModStatus(username, true);
                             break;
                         case "unmod":
                             utilityService
                                 .showConfirmationModal({
                                     title: "Mod User",
-                                    question: `Are you sure you want to unmod ${userName}?`,
+                                    question: `Are you sure you want to unmod ${username}?`,
                                     confirmLabel: "Unmod",
                                     confirmBtnType: "btn-danger"
                                 })
                                 .then((confirmed) => {
                                     if (confirmed) {
-                                        chatMessagesService.changeModStatus(userName, false);
+                                        chatMessagesService.changeModStatus(username, false);
                                     }
                                 });
                             break;
                         case "add as vip":
-                            backendCommunicator.fireEvent("update-user-vip-status", { username: userName, shouldBeVip: true });
+                            backendCommunicator.fireEvent("update-user-vip-status", { username: username, shouldBeVip: true });
                             break;
                         case "remove vip":
-                            backendCommunicator.fireEvent("update-user-vip-status", { username: userName, shouldBeVip: false });
+                            backendCommunicator.fireEvent("update-user-vip-status", { username: username, shouldBeVip: false });
                             break;
                         case "whisper":
-                            updateChatField(`/w @${userName} `);
+                            updateChatField(`/w @${username} `);
                             break;
                         case "mention":
-                            updateChatField(`@${userName} `);
+                            updateChatField(`@${username} `);
                             break;
                         case "reply to message":
                             $ctrl.onReplyClicked({
@@ -456,13 +456,13 @@
                             });
                             break;
                         case "quote message":
-                            updateChatField(`!quote add @${userName} ${rawText}`);
+                            updateChatField(`!quote add @${username} ${rawText}`);
                             break;
                         case "spotlight message":
-                            chatMessagesService.highlightMessage(userName, rawText);
+                            chatMessagesService.highlightMessage(username, rawText);
                             break;
                         case "shoutout":
-                            updateChatField(`!so @${userName}`);
+                            updateChatField(`!so @${username}`);
                             break;
                         case "details": {
                             $ctrl.showUserDetailsModal(userId);

--- a/src/gui/app/directives/chat/feed items/reward-redemption.js
+++ b/src/gui/app/directives/chat/feed items/reward-redemption.js
@@ -8,8 +8,8 @@
             },
             template: `
                 <div class="reward-redemption" ng-class="{ isHighlight: $ctrl.redemption.id === 'highlight-message' }">
-                    <img ng-src="{{$ctrl.rewardImageUrl}}" />    
-                    <b>{{$ctrl.redemption.user.username}}</b> <span>redeemed</span> <b>{{$ctrl.redemption.reward.name}}</b>            
+                    <img ng-src="{{$ctrl.rewardImageUrl}}" />
+                    <b>{{$ctrl.redemption.user.displayName}}{{($ctrl.redemption.user.displayName.toLowerCase() !== $ctrl.redemption.user.username.toLowerCase() ? " (" + $ctrl.redemption.user.username + ")" : "")}}</b> <span>redeemed</span> <b>{{$ctrl.redemption.reward.name}}</b>
                 </div>
             `,
             controller: function() {

--- a/src/types/chat.d.ts
+++ b/src/types/chat.d.ts
@@ -15,9 +15,9 @@ export type FirebotParsedMessagePart = {
 export type FirebotChatMessage = {
     id: string;
     username: string;
-    userIdName: string;
-    profilePicUrl?: string;
     userId: string;
+    userDisplayName?: string;
+    profilePicUrl?: string;
     isExtension?: boolean;
     roles: string[];
     badges: unknown[];


### PR DESCRIPTION
### Description of the Change
Refactors all uses of username to use the actual user login name instead of the display name, updates UI elements (mostly chat feed) to use the display name property for display purposes, deprecates `$useridname`, and adds `$userDisplayName`.


### Applicable Issues
#2421


### Testing
Verified basic bot functionality that depends on username, including chat messages, variables, events, channel rewards, roles
Verified chat feed display
Verified `$username` still functions properly in non-Unicode scenarios
Verified new `$userDisplayName` variable works as designed