### PR TITLE
Follow Restriction Improvements

### DIFF
--- a/src/backend/common/user-access.js
+++ b/src/backend/common/user-access.js
@@ -13,26 +13,42 @@ const teamRolesManager = require("../roles/team-roles-manager");
 
 const followCache = new NodeCache({ stdTTL: 10, checkperiod: 10 });
 
-async function userFollowsChannels(username, channelNames) {
+async function userFollowsChannels(username, channelNames, durationInSeconds = 0) {
     let userfollowsAllChannels = true;
 
     for (const channelName of channelNames) {
-        let userFollowsChannel = false;
+        /**
+         * @type {import('@twurple/api').HelixChannelFollower | boolean}
+         */
+        let userFollow;
 
         // check cache first
         const cachedFollow = followCache.get(`${username}:${channelName}`);
         if (cachedFollow !== undefined) {
-            userFollowsChannel = cachedFollow;
+            userFollow = cachedFollow;
         } else {
-            userFollowsChannel = await twitchApi.users.doesUserFollowChannel(username, channelName);
+            userFollow = await twitchApi.users.getUserChannelFollow(username, channelName);
 
             // set cache value
-            followCache.set(`${username}:${channelName}`, userFollowsChannel);
+            followCache.set(`${username}:${channelName}`, userFollow);
         }
 
-        if (!userFollowsChannel) {
+        if (!userFollow) {
             userfollowsAllChannels = false;
             break;
+        }
+
+        if (userFollow === true) { // streamer follow
+            continue;
+        }
+
+        if (durationInSeconds > 0) {
+            const followTime = Math.round(userFollow.followDate.getTime() / 1000);
+            const currentTime = Math.round(new Date().getTime() / 1000);
+            if ((currentTime - followTime) < durationInSeconds) {
+                userfollowsAllChannels = false;
+                break;
+            }
         }
     }
 

--- a/src/backend/restrictions/builtin/follow-check.js
+++ b/src/backend/restrictions/builtin/follow-check.js
@@ -23,6 +23,28 @@ const model = {
                     </div>
                 </div>
             </firebot-radio-container>
+
+            <div style="margin-bottom: 30px;">
+                <div class="form-group flex-row jspacebetween" style="margin-bottom: 0;">
+                    <div>
+                        <label class="control-label" style="margin:0;">Follow Age</label>
+                        <p class="help-block">Time the user must be followed to the channel.</p>
+                    </div>
+                    <div>
+                        <toggle-button toggle-model="restriction.useFollowAge" auto-update-value="true" font-size="32"></toggle-button>
+                    </div>
+                </div>
+                <div>
+                    <time-input
+                        ng-model="restriction.followAgeSeconds"
+                        name="cooldownSeconds"
+                        ui-validate="'!restriction.useFollowAge || ($value != null && $value > 0)'"
+                        ui-validate-watch="'restriction.useFollowAge"
+                        large="true"
+                        disabled="!restriction.useFollowAge"
+                    />
+                </div>
+            </div>
         </div>
     `,
 
@@ -60,7 +82,9 @@ const model = {
                 .filter(f => f != null)
                 .map(f => f.toLowerCase().trim());
 
-            const followCheck = await userAccess.userFollowsChannels(triggerUsername, followCheckList);
+            const seconds = restrictionData.useFollowAge ? restrictionData.followAgeSeconds : 0;
+
+            const followCheck = await userAccess.userFollowsChannels(triggerUsername, followCheckList, seconds);
 
             if (followCheck) {
                 return resolve();

--- a/src/backend/restrictions/builtin/follow-check.js
+++ b/src/backend/restrictions/builtin/follow-check.js
@@ -13,6 +13,10 @@ const model = {
                 User follows
             </div>
             <input type="text" class="form-control" placeholder="Enter value" ng-model="restriction.value">
+
+            <div style="margin-top: 15px;" class="alert alert-warning">
+                You must be the streamer or a moderator to check follows for a channel.
+            </div>
         </div>
     `,
     optionsValueDisplay: (restriction) => {

--- a/src/backend/twitch-api/resource/users.ts
+++ b/src/backend/twitch-api/resource/users.ts
@@ -75,7 +75,7 @@ export class TwitchUsersApi {
 
         const [user, channel] = await this.getUsersByNames([username, channelName]);
 
-        if (user.id == null || channel.id == null) {
+        if (user?.id == null || channel?.id == null) {
             return false;
         }
 

--- a/src/gui/app/directives/controls/time-input.js
+++ b/src/gui/app/directives/controls/time-input.js
@@ -9,7 +9,8 @@
                 ngModel: "<",
                 validationError: "<?",
                 large: "<?",
-                disabled: "<?"
+                disabled: "<?",
+                maxTimeUnit: "<?"
             },
             require: { ngModelCtrl: 'ngModel' },
             template: `
@@ -34,29 +35,51 @@
                     "Seconds",
                     "Minutes",
                     "Hours",
-                    "Days"
+                    "Days",
+                    "Weeks",
+                    "Months",
+                    "Years"
                 ];
 
                 // units of time in secs
                 const MINUTE = 60;
                 const HOUR = 3600;
                 const DAY = 86400;
+                const WEEK = 7 * DAY;
+                const MONTH = 31 * DAY;
+                const YEAR = 365 * DAY;
 
                 function getTimeScaleSeconds(unit) {
-                    let timeScale = 1;
-                    if (unit === "Minutes") {
-                        timeScale = MINUTE;
-                    } else if (unit === "Hours") {
-                        timeScale = HOUR;
-                    } else if (unit === "Days") {
-                        timeScale = DAY;
+                    switch (unit) {
+                        case "Minutes":
+                            return MINUTE;
+                        case "Hours":
+                            return HOUR;
+                        case "Days":
+                            return DAY;
+                        case "Weeks":
+                            return WEEK;
+                        case "Months":
+                            return MONTH;
+                        case "Years":
+                            return YEAR;
+                        default:
+                            return MINUTE;
                     }
-                    return timeScale;
                 }
 
                 $ctrl.selectedTimeUnit = $ctrl.timeUnits[0];
 
                 function determineTimeUnit(seconds) {
+                    if (seconds % YEAR === 0) {
+                        return "Years";
+                    }
+                    if (seconds % MONTH === 0) {
+                        return "Months";
+                    }
+                    if (seconds % WEEK === 0) {
+                        return "Weeks";
+                    }
                     if (seconds % DAY === 0) {
                         return "Days";
                     }
@@ -89,6 +112,10 @@
                 };
 
                 $ctrl.$onInit = () => {
+                    if ($ctrl.maxTimeUnit != null && $ctrl.timeUnits.includes($ctrl.maxTimeUnit)) {
+                        $ctrl.timeUnits.length = $ctrl.timeUnits.findIndex(unit => unit === $ctrl.maxTimeUnit) + 1;
+                    }
+
                     if ($ctrl.ngModel != null) {
                         $ctrl.selectedTimeUnit = determineTimeUnit($ctrl.ngModel);
 

--- a/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
+++ b/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
@@ -119,6 +119,7 @@
                             <div style="width: 50%;">
                                 <time-input
                                     ng-model="$ctrl.reward.twitchData.globalCooldownSetting.globalCooldownSeconds"
+                                    max-time-unit="'Days'"
                                     name="cooldownSeconds"
                                     ui-validate="'!$ctrl.reward.twitchData.globalCooldownSetting.isEnabled || ($value != null && $value > -1 && $value <= 604800)'"
                                     ui-validate-watch="'$ctrl.reward.twitchData.globalCooldownSetting.isEnabled'"


### PR DESCRIPTION
### Description of the Change
Adds the ability to check for the streamer's channel in the Follow restriction
Adds the ability to check for a certain follow age in the Follow restriction


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1193
#2453

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the following:
- Updated UI for restriction works in commands and channel rewards
- A warning is now shown when custom follow check is used regarding the streamer/mod restriction from Twitch.
- By default, Custom follow check is selected.
- Commands and Channel Rewards will successfully reject their triggers when either the follow isn't met, or a follow restriction isn't met
- Both will fail gracefully (reject) if the Custom option is chosen, and a channel is entered that the streamer is not a moderator for
- Both will fail gracefully when an invalid username is entered into the Custom field
- Channel rewards will automatically reject if "Automatically approve/reject redemptions based on restrictions outcome" is enabled 
- The Follow Age setting only takes effect when enabled, and properly checks and handles the restriction.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://github.com/crowbartools/Firebot/assets/70665154/0656e2b8-55af-4833-8c6a-3d571bc1084f)
![image](https://github.com/crowbartools/Firebot/assets/70665154/b041adf1-65af-4654-bbcc-2acea4aca6b9)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
