### PR TITLE
feat: implement item table advanced search options popover

### DIFF
--- a/src/gui/app/directives/controls/firebot-checkbox.js
+++ b/src/gui/app/directives/controls/firebot-checkbox.js
@@ -7,12 +7,13 @@
             bindings: {
                 label: "@",
                 tooltip: "@?",
+                tooltipPlacement: "@?",
                 model: "=",
                 style: "@?",
                 disabled: "<?"
             },
             template: `
-            <label class="control-fb control--checkbox" style="{{$ctrl.style}}"> {{$ctrl.label}} <tooltip ng-if="$ctrl.tooltip" text="$ctrl.tooltip"></tooltip>
+            <label class="control-fb control--checkbox" style="{{$ctrl.style}}"> {{$ctrl.label}} <tooltip ng-if="$ctrl.tooltip" text="$ctrl.tooltip" placement="{{$ctrl.tooltipPlacement || ''}}"></tooltip>
                 <input type="checkbox" ng-model="$ctrl.model" ng-disabled="$ctrl.disabled">
                 <div class="control__indicator"></div>
             </label>

--- a/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.html
+++ b/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.html
@@ -28,13 +28,35 @@
           query="searchQuery"
           class="fit-header-search"
         ></searchbar>
-        <firebot-checkbox
-          ng-if="$ctrl.customFilterName != null"
-          label="Full text search"
-          model="$ctrl.useFullTextSearch"
-          tooltip="Search all fields. Use ! to exclude a term."
-          style="white-space: nowrap; margin: 0 0 0 5px;"
-        />
+        <button
+            ng-if="$ctrl.showAdvancedOptionsButton"
+            uib-tooltip="Advanced Search Options"
+            tooltip-append-to-body="true"
+            tooltip-placement="top-right"
+            uib-popover-template="'advancedSearchOptionsPopover.html'"
+            popover-placement="bottom-right"
+            popover-append-to-body="true"
+            popover-trigger="'outsideClick'"
+            class="btn-reset fbit-advance-search-btn"
+        >
+          <i 
+            class="fas fa-toolbox"
+          ></i>
+          <div ng-if="$ctrl.hasAdvancedOptionsApplied()" class="options-applied-indicator"></div>
+        </button>
+        <script type="text/ng-template" id="advancedSearchOptionsPopover.html">
+            <div class="p-3">
+              <firebot-checkbox
+                ng-if="$ctrl.customFilterName != null"
+                label="Full text search"
+                model="$ctrl.useFullTextSearch"
+                tooltip="Search all fields. Prefix with ! to preform an exclusive search."
+                tooltip-placement="top-right"
+                style="margin: 0;"
+              />
+            </div>
+        </script>
+        
       </div>
     </div>
     <div class="p-6">

--- a/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.js
+++ b/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.js
@@ -53,6 +53,12 @@
                     return $ctrl.useFullTextSearch ? null : $ctrl.customFilterName;
                 };
 
+                $ctrl.showAdvancedOptionsButton = false;
+
+                $ctrl.hasAdvancedOptionsApplied = () => {
+                    return $ctrl.useFullTextSearch;
+                };
+
                 $ctrl.$onInit = () => {
                     if ($ctrl.items == null) {
                         $ctrl.items = [];
@@ -63,6 +69,8 @@
 
                     $ctrl.showStatusIndicator = $ctrl.statusField != null;
                     $ctrl.headerClass = `${$ctrl.sortTagContext.split(' ').join('-')}-header`;
+
+                    $ctrl.showAdvancedOptionsButton = $ctrl.customFilterName != null;
                 };
 
                 $ctrl.triggerItemsUpdate = () => {

--- a/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.js
+++ b/src/gui/app/directives/misc/firebot-item-table/firebot-item-table.js
@@ -40,15 +40,6 @@
                     reverse: false
                 };
 
-                $ctrl.getSearchQuery = () => {
-                    if ($ctrl.searchField) {
-                        return {
-                            [$ctrl.searchField]: $scope.searchQuery
-                        };
-                    }
-                    return $scope.searchQuery;
-                };
-
                 $ctrl.getFilterName = () => {
                     return $ctrl.useFullTextSearch ? null : $ctrl.customFilterName;
                 };

--- a/src/gui/app/directives/misc/tooltip.js
+++ b/src/gui/app/directives/misc/tooltip.js
@@ -5,10 +5,11 @@
         bindings: {
             text: "<",
             type: "@",
+            placement: "@?",
             styles: "@"
         },
         template: `
-                <i class="fal" style="{{$ctrl.styles}}" ng-class="{'fa-question-circle': $ctrl.type === 'question', 'fa-info-circle': $ctrl.type === 'info' }" uib-tooltip="{{$ctrl.text}}" tooltip-append-to-body="true"></i>
+                <i class="fal" style="{{$ctrl.styles}}" ng-class="{'fa-question-circle': $ctrl.type === 'question', 'fa-info-circle': $ctrl.type === 'info' }" uib-tooltip="{{$ctrl.text}}" tooltip-placement="{{$ctrl.placement || ''}}" tooltip-append-to-body="true"></i>
             `,
         controller: function() {
             const ctrl = this;

--- a/src/gui/app/templates/chat/_commands.html
+++ b/src/gui/app/templates/chat/_commands.html
@@ -40,7 +40,6 @@
         no-data-message="No custom commands saved. You should make one! :)"
         none-found-message="No custom commands found."
         search-placeholder="Search commands"
-        search-field="trigger"
         test-button="true"
         on-test-button-clicked="manuallyTriggerCommand(itemId)"
         status-field="active"

--- a/src/gui/scss/core/_firebot-item-table.scss
+++ b/src/gui/scss/core/_firebot-item-table.scss
@@ -74,3 +74,25 @@
         }
     }
 }
+
+.fbit-advance-search-btn {
+    position: relative;
+    margin-left: 10px;
+    margin-right: 5px;
+    padding: 2px;
+    &:hover {
+        cursor: pointer;
+        i {
+            opacity: 0.75;
+        }
+    }
+    .options-applied-indicator {
+        position: absolute;
+        top: -5px;
+        right: -5px;
+        background-color: #1c9dc1;
+        border-radius: 50%;
+        width: 10px;
+        height: 10px;
+    }
+}

--- a/src/gui/scss/core/_helpers.scss
+++ b/src/gui/scss/core/_helpers.scss
@@ -204,3 +204,20 @@ font-weight: 900;
 .text-center {
     text-align: center;
 }
+
+.relative {
+    position: relative;
+}
+
+.absolute {
+    position: absolute;
+}
+
+.btn-reset {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+}


### PR DESCRIPTION
- Moves the new "Search full text" option into a popover 
- Removes "search field" option of the item table as it has now been superseded (and likely was bugged)

<img width="276" alt="Screenshot 2024-03-24 at 5 12 52 PM" src="https://github.com/crowbartools/Firebot/assets/3515161/47be741f-fe2f-4768-bc14-625eb585a996">
<br>
<img width="292" alt="Screenshot 2024-03-24 at 5 13 31 PM" src="https://github.com/crowbartools/Firebot/assets/3515161/55293edf-e86c-40fd-821e-12881c186169">
<br>
<img width="303" alt="Screenshot 2024-03-24 at 5 13 13 PM" src="https://github.com/crowbartools/Firebot/assets/3515161/4976e6c6-61da-416c-8986-bf2b3da116d5">

