### PR TITLE
feat: Split auth and token endpoints if auth exist

### DIFF
--- a/src/backend/auth/auth-manager.ts
+++ b/src/backend/auth/auth-manager.ts
@@ -40,7 +40,7 @@ class AuthManager extends EventEmitter {
                 break;
 
             case "device":
-                authorizationUri = `${provider.auth.tokenHost}${provider.auth.authorizePath}`;
+                authorizationUri = `${provider.auth.authorizeHost ?? provider.auth.tokenHost}${provider.auth.authorizePath}`;
                 break;
         }
 
@@ -62,7 +62,7 @@ class AuthManager extends EventEmitter {
     }
 
     getAuthProvider(providerId: string): AuthProvider {
-        return this._authProviders.find((p) => p.id === providerId);
+        return this._authProviders.find(p => p.id === providerId);
     }
 
     buildOAuthClientForProvider(provider: AuthProviderDefinition, redirectUri: string): ClientOAuth2 {
@@ -75,7 +75,7 @@ class AuthManager extends EventEmitter {
             scopes = [];
         }
 
-        const authUri = `${provider.auth.tokenHost}${provider.auth.authorizePath}`;
+        const authUri = `${provider.auth.authorizeHost ?? provider.auth.tokenHost}${provider.auth.authorizePath}`;
         const tokenUri = `${provider.auth.tokenHost}${provider.auth.tokenPath ?? ""}`;
 
         return new ClientOAuth2({

--- a/src/backend/auth/auth.d.ts
+++ b/src/backend/auth/auth.d.ts
@@ -9,6 +9,7 @@ export interface AuthProviderDefinition {
     };
     auth: {
         type: "code" | "token" | "device";
+        authorizeHost?: string;
         tokenHost: string;
         authorizePath: string;
         tokenPath?: string;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
there was a need by me to have the auth and token endpoints to be different in some use cases 
this simply adds the auth as an optional end point and if it exists then it use that instead of the token endpoint.
while i was editing the file there was a small linting issue that i resolved. 


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2504 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->

i have ran this for a full week reauthed with streamlabs and tippy stream and twitch(both main account and bot account) to see if any issues would arise. 


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
