### PR TITLE
fix: Import not handling number names

### DIFF
--- a/src/backend/import/third-party/streamlabs-chatbot.js
+++ b/src/backend/import/third-party/streamlabs-chatbot.js
@@ -96,7 +96,7 @@ const importViewers = async (data) => {
 
     for (const viewer of viewersToUpdate) {
         const viewerToUpdate = viewer;
-        const importedViewer = viewers.find(v => v.name.toLowerCase() === viewer.username.toLowerCase());
+        const importedViewer = viewers.find(v => String(v.name).toLowerCase() === viewer.username.toLowerCase());
 
         if (settings.includeViewHours) {
             viewerToUpdate.minutesInChannel += importedViewer.viewHours * 60;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
ensure that V.name is a string, Twitch allows accounts to be just numbers and the import expects a string name. 
sometimes a the exported file will contain name as number Instead of string. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2518 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
using sample data I have ensured that the names are treated proper. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
