### PR TITLE
fix: ensure number ignoring string empty

### DIFF
--- a/src/backend/variables/builtin/number/ensure-number.ts
+++ b/src/backend/variables/builtin/number/ensure-number.ts
@@ -14,7 +14,7 @@ const model : ReplaceVariable = {
         input: unknown,
         defaultNumber: unknown
     ) : number => {
-        if (input != null && Number.isFinite(Number(input))) {
+        if (input !== '' && input != null && Number.isFinite(Number(input))) {
             return Number(input);
         }
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
added check for if not string empty because Number('') = 0 and is finite 
would return 0 ignoring the default out  

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2522

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
ran tests for 

current behavior 
$ensureNumber[$arg[1],1] = 0
$ensureNumber[test,1] = 1
$ensureNumber[$null,1] = 0
$ensureNumber[20,1] = 20
expected

$ensureNumber[$arg[1],1] = 1
$ensureNumber[test,1] = 1
$ensureNumber[$null,1] = 1
$ensureNumber[20,1] = 20

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
