### PR TITLE
fix: reward filters not having display names

### DIFF
--- a/src/backend/events/filters/builtin/reward.js
+++ b/src/backend/events/filters/builtin/reward.js
@@ -9,26 +9,26 @@ module.exports = {
     ],
     comparisonTypes: ["is", "is not"],
     valueType: "preset",
-    presetValues: backendCommunicator => {
+    presetValues: (backendCommunicator) => {
         return backendCommunicator
             .fireEventAsync("get-channel-rewards").then(rewards =>
-                rewards.map(r => ({value: r.id, display: r.title})));
+                rewards.map(r => ({value: r.id, display: r.twitchData.title})));
     },
     valueIsStillValid: (filterSettings, backendCommunicator) => {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             backendCommunicator
-                .fireEventAsync("get-channel-rewards").then(rewards => {
+                .fireEventAsync("get-channel-rewards").then((rewards) => {
                     resolve(rewards.some(r => r.id === filterSettings.value));
                 });
         });
     },
     getSelectedValueDisplay: (filterSettings, backendCommunicator) => {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             backendCommunicator
-                .fireEventAsync("get-channel-rewards").then(rewards => {
+                .fireEventAsync("get-channel-rewards").then((rewards) => {
                     const reward = rewards.find(r => r.id === filterSettings.value);
 
-                    resolve(reward ? reward.title : "Unknown Reward");
+                    resolve(reward ? reward.twitchData.title : "Unknown Reward");
                 });
         });
     },


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
title got moved at some point to reward.twitchData.title 
updated to reflect this 
also fixed linting 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2491

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

![image](https://github.com/crowbartools/Firebot/assets/8982158/c572820d-3dd9-4554-89ac-4f369a9fea78)

![image](https://github.com/crowbartools/Firebot/assets/8982158/290573c7-24c5-47ac-bdc9-9ef40f96065a)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
