### PR TITLE
fix: runCommand Effect arg returning undefined

### DIFF
--- a/src/backend/effects/builtin/run-command.js
+++ b/src/backend/effects/builtin/run-command.js
@@ -99,6 +99,8 @@ const model = {
                 clonedTrigger.metadata.username = effect.username;
             }
 
+            // ensure effect.args is not undefined/null if it is change it to string empty
+            effect.args = effect.args ?? "";
             if (effect.commandType === "system") {
                 commandRunner.runSystemCommandFromEffect(effect.systemCommandId, clonedTrigger, effect.args);
             } else {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
ensure effect.args is not undefined/null if it is change it to string empty

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2503

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
ran command effect and undefined was not returned

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
