### PR TITLE
fix: show image duration

### DIFF
--- a/src/gui/app/directives/effect-option-settings/eosEnterExitAnimations.js
+++ b/src/gui/app/directives/effect-option-settings/eosEnterExitAnimations.js
@@ -225,7 +225,7 @@
                     if (durationValue == null || durationValue < 1) {
                         durationValue = 1;
                     }
-                    ctrl.effect.enterDuration = `${ctrl.selected.enterDurationValue}${ctrl.selected.enterDurationType}`;
+                    ctrl.effect.enterDuration = `${durationValue}${ctrl.selected.enterDurationType}`;
                 };
 
                 ctrl.exitDurationUpdated = function() {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
the enter duration would allow for 0.25 where the rest of the durations would enforce a min of 1 second 
this enforces a min of 1 second 
if less then 1 second is needed there is a millisecond setting 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2509

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
i have tested this by creating a show image effect and setting the enter, in-between and exit animation times to less than 1 second
the durations are then all changed to 1 second  

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
