### PR TITLE
Fix: Log requestor ip for api calls

### DIFF
--- a/src/server/api/v1/v1Router.js
+++ b/src/server/api/v1/v1Router.js
@@ -6,8 +6,13 @@ const logger = require("../../../backend/logwrapper");
 
 router.use(function log(req, res, next) {
     // here we could do stuff for every request if we wanted
+    const clientIp = req.socket.remoteAddress;
+    // check for proper ipv4 address (possible for ipv4 address in ipv6 format)
+    const matches = clientIp.match(/(\d+\.\d+\.\d+\.\d+)/);
+    // if we find a match it is ipv4 if not fall back to given client ip which is most likely ipv6
+    const ip = matches ? matches[0] : clientIp;
     logger.info(
-        `API Request from: ${req.headers.host}, for path: ${req.originalUrl}`
+        `API Request from: ${ip}, for path: ${req.originalUrl}`
     );
     next();
 });

--- a/src/server/api/v1/v1Router.js
+++ b/src/server/api/v1/v1Router.js
@@ -6,13 +6,8 @@ const logger = require("../../../backend/logwrapper");
 
 router.use(function log(req, res, next) {
     // here we could do stuff for every request if we wanted
-    const clientIp = req.socket.remoteAddress;
-    // check for proper ipv4 address (possible for ipv4 address in ipv6 format)
-    const matches = clientIp.match(/(\d+\.\d+\.\d+\.\d+)/);
-    // if we find a match it is ipv4 if not fall back to given client ip which is most likely ipv6
-    const ip = matches ? matches[0] : clientIp;
     logger.info(
-        `API Request from: ${ip}, for path: ${req.originalUrl}`
+        `API Request from: ${req.socket.remoteAddress}, for path: ${req.originalUrl}`
     );
     next();
 });


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Changed from using req.headers.host to using req.socket.remoteAddress


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2519 


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
- Start firebot on this branch
- open the developer tools (you can also see this log in the terminal you started firebot from)
- make a request from another device to ${your_devices_local_ip}:7472/api/v1/status
- verify the logging is using the ip of the second device and not the device firebot is running on
- log should look like:  info: API Request from: 192.168.1.65, for path: /api/v1/status


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
<!--
**No longer applicable as the regex for ipv4 has been removed**
[Testing the regex with regexr.com](https://i.imgur.com/jRsVECF.png)
-->
<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
