### PR TITLE
Feat: Add $chatMessageTextOnly variable

### DIFF
--- a/src/backend/variables/builtin/twitch/chat/message/chat-message-text-only.ts
+++ b/src/backend/variables/builtin/twitch/chat/message/chat-message-text-only.ts
@@ -1,0 +1,36 @@
+import { ReplaceVariable } from "../../../../../../types/variables";
+import { EffectTrigger } from "../../../../../../shared/effect-constants";
+import { OutputDataType, VariableCategory } from "../../../../../../shared/variable-constants";
+
+const triggers = {};
+triggers[EffectTrigger.MANUAL] = true;
+triggers[EffectTrigger.COMMAND] = true;
+triggers[EffectTrigger.EVENT] = [
+    "twitch:chat-message",
+    "twitch:first-time-chat",
+    "firebot:highlight-message",
+    "twitch:viewer-arrived"
+];
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: "chatMessageTextOnly",
+        description: "Outputs the chat message from the associated command or event, with any emotes or URLs trimmed out",
+        triggers: triggers,
+        categories: [VariableCategory.COMMON, VariableCategory.TRIGGER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (trigger) => {
+        let messageParts = [];
+        if (trigger.type === EffectTrigger.COMMAND) {
+            messageParts = trigger.metadata.chatMessage.parts;
+        } else if (trigger.type === EffectTrigger.EVENT) {
+            messageParts = trigger.metadata.eventData.chatMessage.parts;
+        }
+
+        const textParts = messageParts.filter(p => p.type === "text").map(p => p.text);
+        return textParts.join(" ").trim();
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/chat/message/index.ts
+++ b/src/backend/variables/builtin/twitch/chat/message/index.ts
@@ -1,6 +1,7 @@
 import chatMessageAnimatedEmoteUrls from './chat-message-animated-emote-urls';
 import chatMessageEmoteNames from './chat-message-emote-names';
 import chatMessageEmoteUrls from './chat-message-emote-urls';
+import chatMessageTextOnly from './chat-message-text-only';
 import chatMessage from './chat-message';
 import chatColor from './chat-user-color';
 
@@ -13,6 +14,7 @@ export default [
     chatMessageAnimatedEmoteUrls,
     chatMessageEmoteNames,
     chatMessageEmoteUrls,
+    chatMessageTextOnly,
     chatMessage,
 
     chatColor,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adds a `$chatMessageTextOnly` variable to get solely the text component of Twitch chat messages. This will trim `link` (URLs), `third-party-emote`, `emote`, and `cheer` message subparts from `$chatMessage`, returning only the plain-text of the message concatenated with spaces. This is suitable for use as a variable for Text-To-Speech input, amongst others, trimming out noisy portions of messages.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1640 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Despite seemingly being unable to get fontawesome configured appropriately, and having a massively broken user interface in my development environment, verified that numerous messages containing various subsets of words, emotes, third-party emotes, URLs, and the like all were filtered out appropriately through Twitch chat.

<!-- ### Screenshots -->
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
