### PR TITLE
Fix: windows resize with display scaling

### DIFF
--- a/src/backend/app-management/electron/window-management.js
+++ b/src/backend/app-management/electron/window-management.js
@@ -67,6 +67,10 @@ function createStreamPreviewWindow() {
         webPreferences: {},
         icon: path.join(__dirname, "../../../gui/images/logo_transparent_2.png")
     });
+    streamPreview.setBounds({
+        height: streamPreviewWindowState.height || 480,
+        width: streamPreviewWindowState.width || 815
+    }, false);
     streamPreview.setMenu(null);
 
     const view = new BrowserView();
@@ -164,6 +168,10 @@ async function createMainWindow() {
             preload: path.join(__dirname, './preload.js')
         }
     });
+    mainWindow.setBounds({
+        height: mainWindowState.height || 720,
+        width: mainWindowState.width || 1280
+    }, false);
 
     mainWindow.webContents.setWindowOpenHandler(({ frameName, url }) => {
         if (frameName === 'modal') {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Resets BrowserWindow bounds immediately after creation to accommodate display scaling scenarios.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
Fixes #2569
See also https://github.com/mawie81/electron-window-state/issues/80 (hat-tip [SslTomH](https://github.com/SslTomH))

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested in Win32 on multiple monitors, including negative of the primary monitor in both X and Y directions, in both maximized and windowed states. Tested over multiple scaling values, including non-scaled.
Solution would still ideally need to be confirmed non-breaking for OS-X and Linux, but it's hard to imagine it would be.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Short two-minute video of existing behavior, then application of these changes, followed by a glimpse of the Windows display settings while it recompiles, followed by the new behavior: https://www.youtube.com/watch?v=L3uRZ8vMTj4

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
