### PR TITLE
Fix: Setup import dialog styling issues

### DIFF
--- a/src/gui/app/directives/modals/setups/import-setup-modal.js
+++ b/src/gui/app/directives/modals/setups/import-setup-modal.js
@@ -24,7 +24,7 @@
                         </file-chooser>
                     </div>
                     <div ng-if="$ctrl.setupSelected">
-                        <div style="padding: 15px;background: #242529;border-radius: 5px;">
+                        <div class="effect-list" style="padding: 15px;border-radius: 5px;">
                             <div class="script-name" style="font-size: 30px;font-weight: 100;">{{$ctrl.setup.name || "Unnamed Setup"}} <span class="script-version muted">v{{$ctrl.setup.version}}</span></div>
                             <div style="font-size: 13px;">by <span class="script-author">{{$ctrl.setup.author}}</span></div>
                             <div class="script-description" ng-bind-html="$ctrl.setup.description"></div>
@@ -36,7 +36,7 @@
                             <div ng-repeat="(key, name) in $ctrl.componentTypes">
                                 <div ng-repeat="component in $ctrl.setup.components[key]">
                                     <div style="display: flex;align-items: center;">
-                                        <span style="padding: 2px 7px;font-size: 13px;background: #242529;border-radius: 3px;">{{name}}</span>
+                                        <span class="list-group-item" style="padding: 2px 7px;font-size: 13px;border-radius: 3px;">{{name}}</span>
                                         <span style="margin-left: 5px;font-size: 20px;font-weight: 500;">{{component.trigger || component.name}}</span>
                                         <span ng-show="$ctrl.currentIds[component.id]" style="color:red;margin-left: 4px;"><i class="far fa-exclamation-triangle" uib-tooltip="This {{name}} already exists for you. If you import this Setup, the {{name}} will be replaced by the version in this setup."></i></span>
                                     </div>
@@ -46,9 +46,9 @@
 
                         <div ng-show="$ctrl.setup.requireCurrency" style="margin-top: 25px;">
                             <h4 class="muted">Currency To Use:</h4>
-                            <p class="muted">This setup requires that you select one of your currencies so it can be used in the included effects, variables, and restrictions.</p>
+                            <h5>This setup requires that you select one of your currencies so it can be used in the included effects, variables, and restrictions.</h5>
                             <select
-                                class="fb-select"
+                                class="form-control fb-select"
                                 ng-model="$ctrl.selectedCurrency"
                                 ng-options="currency as currency.name for currency in $ctrl.currencies">
                                 <option value="" disabled selected>Select currency...</option>
@@ -140,7 +140,6 @@
                     `);
 
                     modal.document.title = `Firebot Setup - ${$ctrl.setup.name}`;
-                    modal.document.body.style.color = "white";
                     modal.document.body.style.fontFamily = "sans-serif";
                 };
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adjusts the styling of the firebotsetup import dialogs. The use of the `effect-list` class is *not* ideal here, but seems a better solution than a hard-coded color, or the addition of new .scss definitions, which is at the edge of my comfort zone.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
None found

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ran through with a few meaningless examples, and validated all application themes and Windows coloring schemes. Ideally, this still needs to be tested on BSD/OS-X/*nix to validate the L143 change, but I can't imagine that I made it any worse.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

**Before**:
*note* that the text in the Popout Description dialog is in-fact there and selectable, but it is rendered with white text on a white background in Windows.
![Before](https://github.com/crowbartools/Firebot/assets/14035789/a73a83a5-eded-421c-b274-6731ae90c883)

**After**:  
![After](https://github.com/crowbartools/Firebot/assets/14035789/afcaa1a9-5835-4fa8-84e9-d63b70e1c4fb)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
