### PR TITLE
Fix: Several OBS Source Effects Lacked Padding

### DIFF
--- a/src/backend/integrations/builtin/obs/effects/set-obs-browser-source-url.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-browser-source-url.ts
@@ -32,7 +32,7 @@ export const SetOBSBrowserSourceUrlEffectType: EffectType<{
             No sources found. {{ isObsConfigured ? "Is OBS running?" : "Have you configured the OBS integration?" }}
         </div>
     </eos-container>
-    <eos-container ng-if="browserSources != null && effect.browserSourceName != null" header="URL" style="margin-top: 10px;">
+    <eos-container ng-if="browserSources != null && effect.browserSourceName != null" header="URL" style="margin-top: 10px;" pad-top="true">
         <firebot-input model="effect.url"></firebot-input>
     </eos-container>
   `,

--- a/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
@@ -34,7 +34,7 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
         </div>
     </eos-container>
 
-    <eos-container ng-if="colorSources != null && effect.colorSourceName != null" header="Color" style="margin-top: 10px;">
+    <eos-container ng-if="colorSources != null && effect.colorSourceName != null" header="Color" style="margin-top: 10px;" pad-top="true">
         <firebot-input model="effect.color" placeholder-text="Format: #0066FF or #FF336699"></firebot-input>
     </eos-container>
   `,

--- a/src/backend/integrations/builtin/obs/effects/set-obs-image-source-file.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-image-source-file.ts
@@ -33,7 +33,7 @@ export const SetOBSImageSourceFileEffectType: EffectType<{
         </div>
     </eos-container>
 
-    <eos-container ng-if="imageSources != null && effect.imageSourceName != null" header="File" style="margin-top: 10px;">
+    <eos-container ng-if="imageSources != null && effect.imageSourceName != null" header="File" style="margin-top: 10px;" pad-top="true">
         <file-chooser model="effect.file" options="{ filters: [ {name: 'OBS-Supported Image Files', extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'tga', 'jxr', 'psd', 'webp']}, {name: 'All Files', extensions: ['*']} ]}"></file-chooser>
     </eos-container>
   `,

--- a/src/backend/integrations/builtin/obs/effects/set-obs-media-source-file.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-media-source-file.ts
@@ -31,7 +31,7 @@ export const SetOBSMediaSourceFileEffectType: EffectType<{
         </div>
     </eos-container>
 
-    <eos-container ng-if="mediaSources != null && effect.mediaSourceName != null" header="File" style="margin-top: 10px;">
+    <eos-container ng-if="mediaSources != null && effect.mediaSourceName != null" header="File" style="margin-top: 10px;" pad-top="true">
         <file-chooser model="effect.file" options="{ filters: [ {name: 'OBS-Supported Video Files', extensions: ['mp4', 'm4v', 'ts', 'mov', 'mxf', 'flv', 'mkv', 'avi', 'gif', 'webm']}, {name: 'OBS-Supported Audio Files', extensions: ['mp3', 'aac', 'ogg', 'wav']}, {name: 'All Files', extensions: ['*']} ]}"></file-chooser>
     </eos-container>
   `,

--- a/src/backend/integrations/builtin/obs/effects/set-obs-source-text.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-source-text.ts
@@ -32,7 +32,7 @@ export const SetOBSSourceTextEffectType: EffectType<{
             No sources found. {{ isObsConfigured ? "Is OBS running?" : "Have you configured the OBS integration?" }}
         </div>
     </eos-container>
-    <eos-container ng-if="textSources != null && effect.textSourceName != null" header="Text" style="margin-top: 10px;">
+    <eos-container ng-if="textSources != null && effect.textSourceName != null" header="Text" style="margin-top: 10px;" pad-top="true">
         <label class="control-fb control--checkbox">Use file as text source
             <input type="checkbox" ng-click="toggleSource()" ng-checked="effect.textSource === 'file'"  aria-label="..." >
             <div class="control__indicator"></div>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adds padding to five obs-set-* effects (`[ "obs-set-media-source-file", "obs-set-source-text", "obs-set-image-source-file", "obs-set-color-source-color", "obs-set-browser-source-url" ]`) that were lacking it.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
Corrects #2580

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
"Yes."

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Before (*top*) and afters (*bottom*):  
![2580 before and after](https://github.com/crowbartools/Firebot/assets/14035789/234553a3-e36f-495b-b1ef-b9375107f148)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
