### PR TITLE
Fix: Confusing readFile Example Description

### DIFF
--- a/src/backend/variables/builtin/utility/file-read.ts
+++ b/src/backend/variables/builtin/utility/file-read.ts
@@ -17,7 +17,7 @@ const model : ReplaceVariable = {
             },
             {
                 usage: "readFile[path\\to\\file.txt, first]",
-                description: "Read the last line from the file."
+                description: "Read the first line from the file."
             },
             {
                 usage: "readFile[path\\to\\file.txt, first, true]",
@@ -70,7 +70,7 @@ const model : ReplaceVariable = {
         if (ignoreWhitespace === true || `${ignoreWhitespace}`.toLowerCase() === 'true') {
             lines = contents
 
-                // remove leading and trailing whtiespace(EOLs, spaces, tabs, etc)
+                // remove leading and trailing whitespace (EOLs, spaces, tabs, etc)
                 .trim()
 
                 // Split based on new lines, consuming all whitespace around the new line character.


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
`$readFile[file.txt, first]` reads the *first* line of the file, **not** the *last* line.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2574

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Nope.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
See linked issue for a before screenshot, here's the after (with post-production highlighting in red):  
![2574_after](https://github.com/crowbartools/Firebot/assets/14035789/e8095641-06f7-48e9-9461-bed87db1dc4e)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
