### PR TITLE
fix: Effect Modal Test Effect Aria accessibility

### DIFF
--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -738,10 +738,9 @@
                     <div>
                         <a href role="button"
                             aria-label="Open effect menu"
-                            class="effects-actions-btn clickable"
+                            class="effects-actions-btn"
                             uib-tooltip="Open effect menu"
-                            uib-dropdown
-                            uib-dropdown-toggle
+                            uib-dropdown-menu
                             context-menu="getOverflowMenu()"
                             context-menu-on="click"
                             context-menu-class="effect-overflow-menu"

--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -725,17 +725,31 @@
                 <h4 class="modal-title" style="display:inline;">{{isAddMode ? "Add New Effect" : "Edit Effect"}}</h4>
 
                 <div class="flex-row acenter jspacebetween">
-                    <div class="test-effects-btn clickable" uib-tooltip="Test Effect" ng-hide="effect == null || effect.type === 'Nothing'" aria-label="Test Effect">
-                        <i class="far fa-play-circle" style="cursor: pointer;" ng-click="runEffect()"></i>
-                    </div>
-                    <div
-                      uib-dropdown
-                      uib-dropdown-toggle
-                      context-menu="getOverflowMenu()"
-                      context-menu-on="click"
-                      context-menu-class="effect-overflow-menu" aria-label="Open Effect Menu"
+                  <div
+                        class="test-effects-btn clickable"
+                        uib-tooltip="Test Effect" 
+                        ng-hide="effect == null || effect.type === 'Nothing'" 
+                        ng-click="runEffect()" 
+                        aria-label="Test Effect" 
+                        role="button"
                     >
-                        <span class="noselect pointer effects-actions-btn" style="font-size: 31px"><i class="fal fa-ellipsis-v"></i></span>
+                        <i class="far fa-play-circle"></i>
+                    </div> 
+                    <div>
+                        <a href role="button"
+                            aria-label="Open effect menu"
+                            class="effects-actions-btn clickable"
+                            uib-tooltip="Open effect menu"
+                            uib-dropdown
+                            uib-dropdown-toggle
+                            context-menu="getOverflowMenu()"
+                            context-menu-on="click"
+                            context-menu-class="effect-overflow-menu"
+                            tooltip-append-to-body="true"
+                            style="font-size: 31px"
+                        >
+                          <i class="fal fa-ellipsis-v"></i>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
made the test effect button on the effect modal accessible with tab
made the effect menu button on the effect modal accessible  with tab 
fixing not screen readers not being able to see the buttons.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2600

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
used NVDA screen reader to tell me what element i was tabbing into

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
