### PR TITLE
fix: `api/v1/viewers` to return proper username and displayName

### DIFF
--- a/src/backend/viewers/viewer-database.ts
+++ b/src/backend/viewers/viewer-database.ts
@@ -264,20 +264,21 @@ class ViewerDatabase extends EventEmitter {
         }
     }
 
-    async getAllUsernamesWithIds(): Promise<{ id: string; username: string; }[]> {
+    async getAllUsernamesWithIds(): Promise<{ id: string; username: string; displayName: string; }[]> {
         if (this.isViewerDBOn() !== true) {
             return [];
         }
 
         const projectionObj = {
-            displayName: 1
+            displayName: 1,
+            username: 1
         };
 
         try {
             const viewers = await this._db.findAsync({ twitch: true })
                 .projection(projectionObj);
 
-            return viewers?.map(u => ({ id: u._id, username: u.displayName })) ?? [];
+            return viewers?.map(u => ({ id: u._id, username: u.username, displayName: u.displayName })) ?? [];
         } catch (error) {
             logger.error("Error getting all viewers: ", error);
             return [];


### PR DESCRIPTION
### Description of the Change
With the refactor  of username earlier in the year this endpoint was missed. This was returning the displayName as the username / login name on the API.  This change may break integrations / projects that use the `api/v1/viewers` endpoint where it now will show the login name instead. So this now return the id, username and displayName to still allow integrations / projects  to adapt and show ether the displayName or username / login name.


### Applicable Issues
Related: #2432



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
