### PR TITLE
Feat: `OBS Connected` and `OBS Disconnected` Events

### DIFF
--- a/src/backend/integrations/builtin/obs/constants.ts
+++ b/src/backend/integrations/builtin/obs/constants.ts
@@ -26,3 +26,5 @@ export const OBS_INPUT_AUDIO_BALANCE_CHANGED_EVENT_ID = "input-audio-balance-cha
 export const OBS_INPUT_AUDIO_SYNC_OFFSET_CHANGED_EVENT_ID = "input-audio-sync-offset-changed";
 export const OBS_INPUT_AUDIO_TRACKS_CHANGED_EVENT_ID = "input-audio-tracks-changed";
 export const OBS_INPUT_AUDIO_MONITOR_TYPE_CHANGED_EVENT_ID = "input-audio-monitor-type-changed";
+export const OBS_CONNECTED_EVENT_ID = "connected";
+export const OBS_DISCONNECTED_EVENT_ID = "disconnected";

--- a/src/backend/integrations/builtin/obs/events/obs-event-source.ts
+++ b/src/backend/integrations/builtin/obs/events/obs-event-source.ts
@@ -6,6 +6,8 @@ import {
     OBS_CURRENT_SCENE_TRANSITION_CHANGED_EVENT_ID,
     OBS_CURRENT_SCENE_TRANSITION_DURATION_CHANGED_EVENT_ID,
     OBS_EVENT_SOURCE_ID,
+    OBS_CONNECTED_EVENT_ID,
+    OBS_DISCONNECTED_EVENT_ID,
     OBS_RECORDING_STARTED_EVENT_ID,
     OBS_RECORDING_STOPPED_EVENT_ID,
     OBS_REPLAY_BUFFER_SAVED_EVENT_ID,
@@ -34,6 +36,18 @@ export const OBSEventSource: EventSource = {
     id: OBS_EVENT_SOURCE_ID,
     name: "OBS",
     events: [
+        {
+            id: OBS_CONNECTED_EVENT_ID,
+            name: "OBS Connected",
+            description: "When OBS websocket is connected",
+            manualMetadata: {}
+        },
+        {
+            id: OBS_DISCONNECTED_EVENT_ID,
+            name: "OBS Disconnected",
+            description: "When OBS websocket is disconnected",
+            manualMetadata: {}
+        },
         {
             id: OBS_SCENE_CHANGED_EVENT_ID,
             name: "OBS Scene Changed",

--- a/src/backend/integrations/builtin/obs/obs-remote.ts
+++ b/src/backend/integrations/builtin/obs/obs-remote.ts
@@ -28,7 +28,9 @@ import {
     OBS_INPUT_AUDIO_BALANCE_CHANGED_EVENT_ID,
     OBS_INPUT_AUDIO_SYNC_OFFSET_CHANGED_EVENT_ID,
     OBS_INPUT_AUDIO_MONITOR_TYPE_CHANGED_EVENT_ID,
-    OBS_INPUT_AUDIO_TRACKS_CHANGED_EVENT_ID
+    OBS_INPUT_AUDIO_TRACKS_CHANGED_EVENT_ID,
+    OBS_CONNECTED_EVENT_ID,
+    OBS_DISCONNECTED_EVENT_ID
 } from "./constants";
 import logger from "../../../logwrapper";
 
@@ -372,13 +374,18 @@ async function maintainConnection(
 
             connected = true;
 
+            eventManager?.triggerEvent(OBS_EVENT_SOURCE_ID, OBS_CONNECTED_EVENT_ID, {});
+
             setupRemoteListeners();
 
             obs.on("ConnectionClosed", () => {
                 if (!connected) {
                     return;
                 }
+
                 connected = false;
+                eventManager?.triggerEvent(OBS_EVENT_SOURCE_ID, OBS_DISCONNECTED_EVENT_ID, {});
+
                 if (isForceClosing) {
                     return;
                 }

--- a/src/backend/integrations/builtin/obs/obs-remote.ts
+++ b/src/backend/integrations/builtin/obs/obs-remote.ts
@@ -373,7 +373,6 @@ async function maintainConnection(
             logger.info("Successfully connected to OBS.");
 
             connected = true;
-
             eventManager?.triggerEvent(OBS_EVENT_SOURCE_ID, OBS_CONNECTED_EVENT_ID, {});
 
             setupRemoteListeners();


### PR DESCRIPTION
### Description of the Change
Little followup to the `obsIsConnected` Replace Variable, would like to be able to do Housekeeping on some sources/text when I first start up OBS and Disconnected is just good for keeping tabs on things


### Applicable Issues
n/a


### Testing
Deployed locally and both events fired as expected


### Screenshots
https://github.com/user-attachments/assets/0e22a576-29c1-4bd8-8671-da21a3bbf87f


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
