### PR TITLE
Feature/avatar url alias

### DIFF
--- a/src/backend/variables/builtin/user/user-avatar-url.ts
+++ b/src/backend/variables/builtin/user/user-avatar-url.ts
@@ -6,6 +6,7 @@ const twitchApi = require("../../../twitch-api/api");
 const model : ReplaceVariable = {
     definition: {
         handle: "userAvatarUrl",
+        aliases: ["userProfileImageUrl"],
         usage: "userAvatarUrl",
         description: "Gets the url for the avatar of the associated user (Ie who triggered command, pressed button, etc).",
         examples: [


### PR DESCRIPTION
### Description of the Change
Implemented `userProfileImageUrl` alias for `userAvatarUrl`


### Applicable Issues
n/a

### Testing
Deployed locally and confirmed listed in Aliases list in UI and working in place of `$userAvatarUrl`


### Screenshots
n/a


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
