### PR TITLE
Feat: `Convert to Preset Effects List` in Effect list dropdown

### DIFF
--- a/src/backend/variables/builtin/user/user-avatar-url.ts
+++ b/src/backend/variables/builtin/user/user-avatar-url.ts
@@ -6,6 +6,7 @@ const twitchApi = require("../../../twitch-api/api");
 const model : ReplaceVariable = {
     definition: {
         handle: "userAvatarUrl",
+        aliases: ["userProfileImageUrl"],
         usage: "userAvatarUrl",
         description: "Gets the url for the avatar of the associated user (Ie who triggered command, pressed button, etc).",
         examples: [

--- a/src/gui/app/directives/controls/effectList.js
+++ b/src/gui/app/directives/controls/effectList.js
@@ -364,9 +364,14 @@
                             return;
                         }
 
-                        //const runEffectList = effectManager.getEffectByName("firebot:run-effect-list");
-
-                        console.log(savedPresetEffectsList);
+                        ctrl.effectsData.list = [{
+                            id: uuidv1(),
+                            type: "firebot:run-effect-list",
+                            active: true,
+                            listType: "preset",
+                            presetListId: savedPresetEffectsList.id,
+                            presetListArgs: {}
+                        }];
                     });
                 };
 

--- a/src/gui/app/directives/controls/effectList.js
+++ b/src/gui/app/directives/controls/effectList.js
@@ -354,7 +354,6 @@
                 };
 
                 ctrl.convertToPresetEffectList = async () => {
-                    console.log(ctrl.effectsData.list);
                     $q.when(presetEffectListsService.showAddEditPresetEffectListModal({
                         effects: {
                             list: ctrl.effectsData.list

--- a/src/gui/app/directives/controls/effectList.js
+++ b/src/gui/app/directives/controls/effectList.js
@@ -180,7 +180,7 @@
 
             </div>
             `,
-            controller: function(utilityService, effectHelperService, objectCopyHelper, effectQueuesService, presetEffectListsService,
+            controller: function($q, utilityService, effectHelperService, objectCopyHelper, effectQueuesService, presetEffectListsService,
                 backendCommunicator, ngToast, $http) {
                 const ctrl = this;
 
@@ -354,10 +354,19 @@
                 };
 
                 ctrl.convertToPresetEffectList = async () => {
-                    presetEffectListsService.showAddEditPresetEffectListModal({
+                    console.log(ctrl.effectsData.list);
+                    $q.when(presetEffectListsService.showAddEditPresetEffectListModal({
                         effects: {
                             list: ctrl.effectsData.list
                         }
+                    })).then((savedPresetEffectsList) => {
+                        if (!savedPresetEffectsList) {
+                            return;
+                        }
+
+                        //const runEffectList = effectManager.getEffectByName("firebot:run-effect-list");
+
+                        console.log(savedPresetEffectsList);
                     });
                 };
 

--- a/src/gui/app/directives/controls/effectList.js
+++ b/src/gui/app/directives/controls/effectList.js
@@ -180,7 +180,7 @@
 
             </div>
             `,
-            controller: function(utilityService, effectHelperService, objectCopyHelper, effectQueuesService,
+            controller: function(utilityService, effectHelperService, objectCopyHelper, effectQueuesService, presetEffectListsService,
                 backendCommunicator, ngToast, $http) {
                 const ctrl = this;
 
@@ -212,6 +212,13 @@
 
                 ctrl.createAllEffectsMenuOptions = () => {
                     const allEffectsMenuOptions = [
+                        {
+                            html: `<a href role="menuitem"><i class="fal fa-magic mr-4"></i> Convert to Preset Effect List</a>`,
+                            click: function () {
+                                ctrl.convertToPresetEffectList();
+                            },
+                            enabled: ctrl.effectsData.list.length > 0
+                        },
                         {
                             html: `<a href role="menuitem"><span class="iconify mr-4" data-icon="mdi:content-copy"></span> Copy all effects</a>`,
                             click: () => {
@@ -344,6 +351,14 @@
                     ];
 
                     return effectMenuOptions;
+                };
+
+                ctrl.convertToPresetEffectList = async () => {
+                    presetEffectListsService.showAddEditPresetEffectListModal({
+                        effects: {
+                            list: ctrl.effectsData.list
+                        }
+                    });
                 };
 
                 ctrl.shareEffects = async () => {


### PR DESCRIPTION
### Description of the Change
This adds a new option to the dropdown that has `Copy All Effects`, `Delete All Effects`, etc., that allows you to easily add a group of Effects to a new Preset Effect List, and instantly add it in a Run Effect List effect


### Applicable Issues
#2624
#2530 (kinda, solves the underlying issue but does not implement the requested Effect)


### Testing
Tested the new option both with Submitting the created Preset Effect List and cancelling, both with expected behavior


### Screenshots
https://github.com/user-attachments/assets/bda5dcf8-7260-43ae-9f72-59c2c9ef5151


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
