### PR TITLE
feat: multiline textarea in preset list args (#2399)

### DIFF
--- a/src/backend/effects/builtin/effect-group.js
+++ b/src/backend/effects/builtin/effect-group.js
@@ -42,7 +42,7 @@ const effectGroup = {
                 <div style="display: flex; align-items: center; justify-content: space-between;">
                     <span><b>{{arg.name}}: </b></span>
                     <div style="width: 100%; padding: 0 10px;">
-                        <input type="text" class="form-control" placeholder="Enter data" ng-model="effect.presetListArgs[arg.name]" replace-variables />
+                    <textarea type="text" class="form-control" placeholder="Enter data" ng-model="effect.presetListArgs[arg.name]" replace-variables rows="1"></textarea>
                     </div>
                 </div>
             </div>
@@ -88,7 +88,7 @@ const effectGroup = {
                 return;
             }
             presetEffectListsService.showAddEditPresetEffectListModal($scope.selectedPresetList)
-                .then(presetList => {
+                .then((presetList) => {
                     if (presetList) {
                         $scope.selectedPresetList = presetList;
                     }
@@ -123,15 +123,15 @@ const effectGroup = {
         }
 
     },
-    optionsValidator: effect => {
+    optionsValidator: (effect) => {
         const errors = [];
         if (effect.listType === 'preset' && effect.presetListId == null) {
             errors.push("Please select a preset list");
         }
         return errors;
     },
-    onTriggerEvent: event => {
-        return new Promise(resolve => {
+    onTriggerEvent: (event) => {
+        return new Promise((resolve) => {
 
             const { effect, trigger, outputs } = event;
 
@@ -175,7 +175,7 @@ const effectGroup = {
             if (effect.dontWait) {
                 resolve(true);
             } else {
-                effectExecutionPromise.then(result => {
+                effectExecutionPromise.then((result) => {
                     if (result != null && result.success === true) {
 
                         if (result.stopEffectExecution) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Updates the preset list argument inputs to textarea to allow multi-line input

These fields default to 1 line high, and can be changed by the user

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2399 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured saved preset list args load into fields properly
Ensured args are saved properly into the effect
Ensured textareas start at 1 line when opening the effect

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://github.com/user-attachments/assets/2aea9931-97fb-4db2-9315-4f3986e55b7f)
![image](https://github.com/user-attachments/assets/d55926c2-bd88-4acf-b8d4-22322f4c4706)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
