### PR TITLE
fix: Export Setup Components Filter Negation

### DIFF
--- a/src/gui/app/directives/modals/setups/firebot-component-list-modal.js
+++ b/src/gui/app/directives/modals/setups/firebot-component-list-modal.js
@@ -16,7 +16,10 @@
                         <searchbar search-id="componentSearch" placeholder-text="Search {{$ctrl.label}}..." query="$ctrl.componentSearch" style="width: 100%;"></searchbar>
                     </div>
                     <div class="viewer-group-list" style="height: inherit; min-height: 100px;max-height: 300px;">
-                        <label ng-repeat="component in $ctrl.allComponents | filter:$ctrl.componentSearch track by component.id" class="control-fb control--checkbox">{{component.name}}
+                        <label class="control-fb control--checkbox"
+                            ng-repeat="component in $ctrl.allComponents | filter: ($ctrl.componentSearch.startsWith('!') ? $ctrl.componentSearch.slice(1) : $ctrl.componentSearch) track by component.id"
+                        >
+                            {{component.name}}
                             <input type="checkbox" ng-click="$ctrl.toggleComponentSelected(component.id)" ng-checked="$ctrl.componentIsSelected(component.id)"  aria-label="..." >
                             <div class="control__indicator"></div>
                         </label>
@@ -39,7 +42,7 @@
                 $ctrl.allComponents = [];
                 $ctrl.selectedIds = [];
 
-                $ctrl.componentIsSelected = (id) => $ctrl.selectedIds.includes(id);
+                $ctrl.componentIsSelected = id => $ctrl.selectedIds.includes(id);
                 $ctrl.toggleComponentSelected = (id) => {
                     const index = $ctrl.selectedIds.findIndex(i => i === id);
                     if (index < 0) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Fix the Export Setup Component dialog filtering. 
  - Angular will negate filters that start with an exclamation mark, which is cool. However, many commands start with an exclamation mark, so that negation behavior is undesired here.
  - This completely removes any leading exclamation marks from the filtering.
- Cleaned up a trivial arrow-parens lint warning.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
None applicable

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tried a number of things to break it, but I think even this one will get past CK.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Screenshot showing searching for (in clockwise order):
- Nothing
- Previously-negated text
- Group/Sorting tags
- Identifiers

![command searching round 2](https://github.com/user-attachments/assets/5eb1bcc8-f3b0-4ee6-9a40-a06811fc79c1)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
