### PR TITLE
Implementation of `unixTimestamp` Replace Variable

### DIFF
--- a/src/backend/variables/builtin/misc/index.ts
+++ b/src/backend/variables/builtin/misc/index.ts
@@ -12,6 +12,7 @@ import rollDice from './roll-dice';
 import time from './time';
 import topViewTime from './top-view-time';
 import topViewTimeRaw from './top-view-time-raw';
+import unixTimestamp from './unix-timestamp';
 import uptime from './uptime';
 import viewTime from './view-time';
 
@@ -30,6 +31,7 @@ export default [
     time,
     topViewTime,
     topViewTimeRaw,
+    unixTimestamp,
     uptime,
     viewTime
 ];

--- a/src/backend/variables/builtin/misc/unix-timestamp.ts
+++ b/src/backend/variables/builtin/misc/unix-timestamp.ts
@@ -24,7 +24,7 @@ const model : ReplaceVariable = {
                 description: "Unix timestamp for date variable set to 2 weeks ago formatted as MMM Do YYYY"
             }
         ],
-        description: "The current date formatted as miliseconds since January 1, 1970 00:00:00 UTC",
+        description: "The current date formatted as seconds since January 1, 1970 00:00:00 UTC",
         categories: [VariableCategory.COMMON],
         possibleDataOutput: [OutputDataType.TEXT]
     },

--- a/src/backend/variables/builtin/misc/unix-timestamp.ts
+++ b/src/backend/variables/builtin/misc/unix-timestamp.ts
@@ -8,8 +8,20 @@ const model : ReplaceVariable = {
         handle: "unixTimestamp",
         examples: [
             {
-                usage: "unixTimestamp[date]",
-                description: "Provided date formatted as miliseconds since January 1, 1970 00:00:00 UTC."
+                usage: "unixTimestamp[2011-03-18 18:49 UTC]",
+                description: "Unix timestamp for provided date"
+            },
+            {
+                usage: "unixTimestamp[07/28/2024, MM/DD/YYYY]",
+                description: "Unix timestamp for provided date with specified format"
+            },
+            {
+                usage: "unixTimestamp[$accountCreationDate]",
+                description: "Unix timestamp for provided account creation date"
+            },
+            {
+                usage: "unixTimestamp[$date[MMM Do YYYY, -14, days], MMM Do YYYY]",
+                description: "Unix timestamp for date variable set to 2 weeks ago formatted as MMM Do YYYY"
             }
         ],
         description: "The current date formatted as miliseconds since January 1, 1970 00:00:00 UTC",
@@ -17,8 +29,8 @@ const model : ReplaceVariable = {
         possibleDataOutput: [OutputDataType.TEXT]
     },
     // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-    evaluator: (_, date?: string) => {
-        const time = date ? moment(new Date(date)) : moment();
+    evaluator: (_, date?: string, format?: string) => {
+        const time = date ? moment(date, format) : moment();
 
         return time.unix();
     }

--- a/src/backend/variables/builtin/misc/unix-timestamp.ts
+++ b/src/backend/variables/builtin/misc/unix-timestamp.ts
@@ -1,0 +1,27 @@
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+
+const moment = require("moment");
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "unixTimestamp",
+        examples: [
+            {
+                usage: "unixTimestamp[date]",
+                description: "Provided date formatted as miliseconds since January 1, 1970 00:00:00 UTC."
+            }
+        ],
+        description: "The current date formatted as miliseconds since January 1, 1970 00:00:00 UTC",
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+    evaluator: (_, date?: string) => {
+        const time = date ? moment(new Date(date)) : moment();
+
+        return time.unix();
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/misc/unix-timestamp.ts
+++ b/src/backend/variables/builtin/misc/unix-timestamp.ts
@@ -30,7 +30,7 @@ const model : ReplaceVariable = {
     },
     // eslint-disable-next-line @typescript-eslint/no-inferrable-types
     evaluator: (_, date?: string, format?: string) => {
-        const time = date ? moment(date, format) : moment();
+        const time = moment(date, format);
 
         return time.unix();
     }


### PR DESCRIPTION
### Description of the Change
Implements a `$unixTimestamp` Replace Variable for efficient comparison of multiple dates


### Applicable Issues
n/a


### Testing
All examples tested working, tested various other date formats being parsed with and without passing a date format parameter


### Screenshots
n/a


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
