### PR TITLE
Fixed `possibleDataOutput` for `unixTimestamp` Replacement Variable

### DIFF
--- a/src/backend/variables/builtin/misc/unix-timestamp.ts
+++ b/src/backend/variables/builtin/misc/unix-timestamp.ts
@@ -26,7 +26,7 @@ const model : ReplaceVariable = {
         ],
         description: "The current date formatted as seconds since January 1, 1970 00:00:00 UTC",
         categories: [VariableCategory.COMMON],
-        possibleDataOutput: [OutputDataType.TEXT]
+        possibleDataOutput: [OutputDataType.NUMBER]
     },
     // eslint-disable-next-line @typescript-eslint/no-inferrable-types
     evaluator: (_, date?: string, format?: string) => {


### PR DESCRIPTION
### Description of the Change
Turns out Numbers are in fact Numbers, oops 😰


### Applicable Issues
n/a


### Testing
No functionality changes, but did confirm it still works just in case


### Screenshots
n/a


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
