### PR TITLE
Fix: manual metadata null values for strings

### DIFF
--- a/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
+++ b/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
@@ -95,11 +95,13 @@
                     const eventSource = await backendCommunicator.fireEventAsync("getEventSource", event);
                     if (eventSource.manualMetadata) {
                         $ctrl.metadata = Object.keys(eventSource.manualMetadata).map(mmd => {
+                            const meta = eventSource.manualMetadata[mmd];
+                            const dataType = meta == null ? "string" : meta.type || typeof meta;
                             const data = {
                                 key: mmd,
                                 title: getTitle(mmd),
-                                type: eventSource.manualMetadata[mmd].type || typeof eventSource.manualMetadata[mmd],
-                                options: eventSource.manualMetadata[mmd].options || {}
+                                type: dataType,
+                                options: meta?.options || {}
                             };
 
                             return data;


### PR DESCRIPTION
Co-authored-by: DennisRijsdijk <dennisrijsdijk@users.noreply.github.com>

### Description of the Change
<!-- Please describe your change here -->
some scripts would try to use null as a manualMetadata 
resulting in error 
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'type')
    at simulateGroupEventsModal.js:101:71
    at Array.map (<anonymous>)
    at $ctrl.eventChanged (simulateGroupEventsModal.js:97:82)
```
![image](https://github.com/user-attachments/assets/b4e4dfd5-94aa-4b0a-a33c-4626247373d3)

this change trys to help alleviate that but will fail with nulled type objects 

![image](https://github.com/user-attachments/assets/5feee5c1-9872-4348-b862-f7c768094268)

as illustrated in this screenshot campaign info is empty
and to be clear i do not have tiltify configured so that may change 


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2647

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
 this was loaded with the tiltafy script and tested as its the only offended script that could be found 
 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
