### PR TITLE
feat: $array indexing improvements

### DIFF
--- a/src/backend/variables/builtin/array/array-element.ts
+++ b/src/backend/variables/builtin/array/array-element.ts
@@ -6,6 +6,32 @@ const model : ReplaceVariable = {
         handle: "arrayElement",
         usage: "arrayElement[array, index]",
         description: "Returns the element at the given index of the input array.",
+        examples: [
+            {
+                usage: 'arrayElement["[1,2,3]", 0]',
+                description: "Returns the element at the 0 index (1)"
+            },
+            {
+                usage: 'arrayElement["[1,2,3]", first]',
+                description: "Returns the element at the first index (1)"
+            },
+            {
+                usage: 'arrayElement["[1,2,3]", last]',
+                description: 'Returns the element at the last index (3)'
+            },
+            {
+                usage: 'arrayElement[rawArray, 0]',
+                description: "Returns the element at the 0 index"
+            },
+            {
+                usage: 'arrayElement[rawArray, first]',
+                description: 'Returns the element at the first index'
+            },
+            {
+                usage: 'arrayElement[rawArray, last]',
+                description: 'Returns the element at the last index'
+            }
+        ],
         categories: [VariableCategory.ADVANCED],
         possibleDataOutput: [OutputDataType.TEXT, OutputDataType.NUMBER]
     },
@@ -18,15 +44,19 @@ const model : ReplaceVariable = {
         if (typeof subject === 'string' || subject instanceof String) {
             try {
                 subject = JSON.parse(`${subject}`);
-
-            //eslint-disable-next-line no-empty
-            } catch (ignore) {
+            } catch {
                 return null;
             }
         }
 
-        if (subject == null || subject[index] == null) {
+        if (!Array.isArray(subject) || subject.length === 0) {
             return null;
+        }
+        if (`${index}`.toLowerCase() === 'first') {
+            return subject[0];
+        }
+        if (`${index}`.toLowerCase() === 'last') {
+            return subject[subject.length - 1];
         }
 
         return subject[index];

--- a/src/backend/variables/builtin/array/array-remove.ts
+++ b/src/backend/variables/builtin/array/array-remove.ts
@@ -12,12 +12,20 @@ const model : ReplaceVariable = {
                 description: "Removes the element at the 0 index (2,3)"
             },
             {
+                usage: 'arrayRemove["[1,2,3]", first]',
+                description: "Removes the element at the first index (2,3)"
+            },
+            {
                 usage: 'arrayRemove["[1,2,3]", last]',
                 description: 'Removes the element at the last index (1,2)'
             },
             {
                 usage: 'arrayRemove[rawArray, 0]',
                 description: "Removes the element at the 0 index"
+            },
+            {
+                usage: 'arrayRemove[rawArray, first]',
+                description: 'Removes the element at the first index'
             },
             {
                 usage: 'arrayRemove[rawArray, last]',
@@ -39,11 +47,14 @@ const model : ReplaceVariable = {
                 return [];
             }
         }
-        if (!Array.isArray(subject)) {
+        if (!Array.isArray(subject) || subject.length < 2) {
             return [];
         }
         if (`${index}`.toLowerCase() === 'last') {
             return subject.slice(0, subject.length - 1);
+        }
+        if (`${index}`.toLowerCase() === 'first') {
+            return subject.slice(1);
         }
         index = Number(index);
         if (Number.isNaN(index)) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- `$arrayRemove`
  - Add "first" option as an index argument, with examples.
  - Shortcut single-item arrays into returning [].
- `$arrayElement`
  - Add numerous invocation examples.
  - Add "first" and "last" as index arguments.
  - POSSIBLY BREAKING: use Array.isArray to validate that it's an array.
    - This likely *BREAKS* ArrayBuffer, Uin8Array, DataView, Blob, etc. types.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested a command using the following in a **Log Message**, which all output appropriate text, g-i being null:
```
a) $arrayElement["[1,2,3]", 0]
b) $arrayElement["[1,2,3]", first]
c) $arrayElement["[1,2,3]", last]
d) $arrayRemove["[1,2,3]", 0]
e) $arrayRemove["[1,2,3]", first]
f) $arrayRemove["[1,2,3]", last]

g) $arrayElement["[1,2,3]", 4]
h) $arrayElement["[1,2,3]", four]
i) $arrayElement["[1,2,3]", -1]

j) $arrayRemove["[1,2,3]", 4]
k) $arrayRemove["[1,2,3]", four]
l) $arrayRemove["[1,2,3]", -1]
m) $arrayRemove["[1,2,3]", -2]
```

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![array-variable-examples](https://github.com/user-attachments/assets/e7ac4c6b-0d00-4dae-a1d2-d11a783a16a3)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
