### PR TITLE
fix: startup error in reportClientsToFrontend

### DIFF
--- a/src/server/websocket-server-manager.ts
+++ b/src/server/websocket-server-manager.ts
@@ -180,7 +180,7 @@ class WebSocketServerManager extends EventEmitter {
     }
 
     reportClientsToFrontend(isDefaultServerStarted: boolean) {
-        let hasClients = this.server !== null;
+        let hasClients = this.server != null;
         if (hasClients) {
             hasClients = [...this.server.clients].filter(client => client.type === "overlay").length > 0;
         }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes a startup error related to the websocket server manager's reportClientsToFrontend

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the error no longer shows up on startup.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
