### PR TITLE
fix: user metadata not saving when username mismatch

### DIFF
--- a/src/gui/app/directives/modals/viewers/viewerDetailsModal.js
+++ b/src/gui/app/directives/modals/viewers/viewerDetailsModal.js
@@ -230,7 +230,7 @@
                             } catch (error) { /* silently fail */ }
 
                             backendCommunicator.fireEvent("update-viewer-metadata", {
-                                username: $ctrl.viewerDetails.twitchData.username,
+                                username: $ctrl.viewerDetails.firebotData.username,
                                 key,
                                 value
                             });
@@ -250,7 +250,7 @@
                     }).then((confirmed) => {
                         if (confirmed) {
                             backendCommunicator.fireEvent("delete-viewer-metadata", {
-                                username: $ctrl.viewerDetails.twitchData.username,
+                                username: $ctrl.viewerDetails.firebotData.username,
                                 key
                             });
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes an issue in the viewer card where a mismatch between the userDB username and Twitch username caused metadata to not save.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2658

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that user metadata properly saves and deletes for users with matching usernames
Ensured that user metadata properly saves and deletes for users with mismatched usernames

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
