### PR TITLE
fix: don't open new macro modal when pressing enter on input

### DIFF
--- a/src/gui/app/directives/modals/variables/add-or-edit-variable-macro-modal.js
+++ b/src/gui/app/directives/modals/variables/add-or-edit-variable-macro-modal.js
@@ -36,6 +36,8 @@
                                     ng-model="$ctrl.macro.name"
                                     ng-disabled="$ctrl.nameFieldLocked"
                                     ng-style="{'padding-right': $ctrl.nameFieldLocked ? '77px' : ''}"
+                                    ng-keyup="$event.keyCode == 13 && $ctrl.save()"
+                                    ng-keydown="$event.keyCode != 13 ? $event:$event.preventDefault()"
                                 />
                                 <div
                                     style="width: 67px;size: 16px;position: absolute;top: 50%;transform: translateY(-50%);right: 10px;"
@@ -66,6 +68,8 @@
                                 style="font-size: 16px; padding: 10px 16px;"
                                 ng-model="$ctrl.macro.description"
                                 placeholder="Optional"
+                                ng-keyup="$event.keyCode == 13 && $ctrl.save()"
+                                ng-keydown="$event.keyCode != 13 ? $event:$event.preventDefault()"
                             />
                         </div>
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Changes Enter key behavior on name and description fields to save instead of opening a new modal instance

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the modal now saves and closes rather than opening a new modal instance