### PR TITLE
feat (effect): add activity feed effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
                 "@types/fs-extra": "^11.0.4",
                 "@types/luxon": "^3.1.0",
                 "@types/node": "^18.18.2",
+                "@types/uuid": "^10.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.62.0",
                 "@typescript-eslint/parser": "^5.62.0",
                 "electron": "^28.2.3",
@@ -2544,6 +2545,12 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.8.tgz",
             "integrity": "sha512-7axfYN8SW9pWg78NgenHasSproWQee5rzyPVLC9HpaQSDgNArsnKJD88EaMfi4Pl48AyciO3agYCFqpHS1gLpg=="
+        },
+        "node_modules/@types/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+            "dev": true
         },
         "node_modules/@types/ws": {
             "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/luxon": "^3.1.0",
         "@types/node": "^18.18.2",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "electron": "^28.2.3",

--- a/src/backend/effects/builtin-effect-loader.js
+++ b/src/backend/effects/builtin-effect-loader.js
@@ -5,6 +5,7 @@ const effectManager = require("./effectManager");
 exports.loadEffects = () => {
     [
         'active-user-lists',
+        'activity-feed-alert',
         'add-quote',
         'api',
         'block-unblock',

--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -1,9 +1,6 @@
 import { EffectType } from "../../../types/effects";
 import { EffectCategory } from "../../../shared/effect-constants";
-import moment from "moment";
-import { v4 as uuid } from "uuid";
-import frontendCommunicator from "./../../common/frontend-communicator";
-
+import { handleTriggeredEvent } from "../../events/activity-feed-manager";
 
 const effect: EffectType<{
     message: string;
@@ -39,22 +36,24 @@ const effect: EffectType<{
         return errors;
     },
     onTriggerEvent: async ({ effect }) => {
-
-        frontendCommunicator.send('event-activity', {
-            message: effect.message,
-            icon: effect.icon || "fad fa-comment-exclamation",
-            acknowledged: false,
-            event: {
-                id: "activity-feed-alert",
-                name: "Activity Feed Alert"
-            },
-            id: uuid(),
-            source: {
+        handleTriggeredEvent(
+            {
                 id: "firebot",
                 name: "Firebot"
             },
-            timestamp: moment().format("H:mm")
-        });
+            {
+                id: "activity-feed-alert",
+                name: "Activity Feed Alert",
+                activityFeed: {
+                    icon: effect.icon || "fad fa-comment-exclamation",
+                    getMessage: () => {
+                        return effect.message;
+                    }
+                }
+            },
+            {
+                username: "firebot"
+            });
 
         return true;
     }

--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -42,7 +42,7 @@ const effect: EffectType<{
 
         frontendCommunicator.send('event-activity', {
             message: effect.message,
-            icon: effect.icon ?? "fad fa-tv-alt",
+            icon: effect.icon || "fad fa-comment-exclamation",
             acknowledged: false,
             event: {
                 id: "activity-feed-alert",

--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -16,15 +16,25 @@ const effect: EffectType<{
     },
     optionsTemplate: `
     <eos-container>
-        <p>Use this effect to send yourself alerts in Firebot's activity feed. This alert is only visible to you if the activity feed is visible.</p>
+        <p>Use this effect to send yourself alerts in Firebot's activity feed.</p>
     </eos-container>
-    <eos-container header="Alert Icon" pad-top="true">
-        <h3>Icon</h3>
-        <p class="muted">A custom icon which allows you to identify your Activity alert.</p>
-        <input maxlength="2" type="text" class="form-control" ng-model="effect.icon" icon-picker required>
-    </eos-container>
-    <eos-container header="Alert Message" pad-top="true">
-        <textarea ng-model="effect.message" class="form-control" name="text" placeholder="Enter message" rows="4" cols="40" replace-variables></textarea>
+    <eos-container header="Message" pad-top="true">
+        <firebot-input 
+            model="effect.message" 
+            placeholder-text="Enter message"
+            use-text-area="true"
+            rows="4"
+            cols="40"
+        />
+    </eos-container> 
+    <eos-container header="Icon" pad-top="true">
+        <input 
+			maxlength="2" 
+			type="text" 
+			class="form-control" 
+			ng-model="effect.icon" 
+			icon-picker required
+		/>
     </eos-container> 
     `,
     optionsController: () => { },
@@ -53,6 +63,10 @@ const effect: EffectType<{
             },
             {
                 username: "firebot"
+            },
+            {
+                forceAllow: true,
+                canRetrigger: false
             });
 
         return true;

--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -1,6 +1,5 @@
 import { EffectType } from "../../../types/effects";
-import { EffectCategory, EffectDependency } from "../../../shared/effect-constants";
-import logger from "../../logwrapper"; 
+import { EffectCategory } from "../../../shared/effect-constants";
 import moment from "moment";
 import { v4 as uuid } from "uuid";
 import frontendCommunicator from "./../../common/frontend-communicator";
@@ -20,7 +19,7 @@ const effect: EffectType<{
     },
     optionsTemplate: `
     <eos-container>
-        <p>Use this effect to send yourself alerts in Firebot's activity feed. This alert is are only visible to you if the activity feed is visible.</p>
+        <p>Use this effect to send yourself alerts in Firebot's activity feed. This alert is only visible to you if the activity feed is visible.</p>
     </eos-container>
     <eos-container header="Alert Icon" pad-top="true">
         <h3>Icon</h3>
@@ -32,7 +31,7 @@ const effect: EffectType<{
     </eos-container> 
     `,
     optionsController: () => { },
-    optionsValidator: effect => {
+    optionsValidator: (effect) => {
         const errors = [];
         if (effect.message == null || effect.message === "") {
             errors.push("Alert message can't be blank.");
@@ -42,19 +41,19 @@ const effect: EffectType<{
     onTriggerEvent: async ({ effect }) => {
 
         frontendCommunicator.send('event-activity', {
-           message: effect.message,
+            message: effect.message,
             icon: effect.icon ?? "fad fa-tv-alt",
-           acknowledged: false,
-           event: {
-               id: "activity-feed-alert",
-               name: "Activity Feed Alert",
-           },
-           id: uuid(),
-           source:{
-               id: "firebot",
-               name: "Firebot",
-           },
-           timestamp: moment().format("H:mm"),
+            acknowledged: false,
+            event: {
+                id: "activity-feed-alert",
+                name: "Activity Feed Alert"
+            },
+            id: uuid(),
+            source: {
+                id: "firebot",
+                name: "Firebot"
+            },
+            timestamp: moment().format("H:mm")
         });
 
         return true;

--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -1,0 +1,64 @@
+import { EffectType } from "../../../types/effects";
+import { EffectCategory, EffectDependency } from "../../../shared/effect-constants";
+import logger from "../../logwrapper"; 
+import moment from "moment";
+import { v4 as uuid } from "uuid";
+import frontendCommunicator from "./../../common/frontend-communicator";
+
+
+const effect: EffectType<{
+    message: string;
+    icon: string;
+}> = {
+    definition: {
+        id: "firebot:activity-feed-alert",
+        name: "Activity Feed Alert",
+        description: "Display an alert in Firebot's activity feed",
+        icon: "fad fa-comment-exclamation",
+        categories: [EffectCategory.FUN],
+        dependencies: []
+    },
+    optionsTemplate: `
+    <eos-container>
+        <p>Use this effect to send yourself alerts in Firebot's activity feed. This alert is are only visible to you if the activity feed is visible.</p>
+    </eos-container>
+    <eos-container header="Alert Icon" pad-top="true">
+        <h3>Icon</h3>
+        <p class="muted">A custom icon which allows you to identify your Activity alert.</p>
+        <input maxlength="2" type="text" class="form-control" ng-model="effect.icon" icon-picker required>
+    </eos-container>
+    <eos-container header="Alert Message" pad-top="true">
+        <textarea ng-model="effect.message" class="form-control" name="text" placeholder="Enter message" rows="4" cols="40" replace-variables></textarea>
+    </eos-container> 
+    `,
+    optionsController: () => { },
+    optionsValidator: effect => {
+        const errors = [];
+        if (effect.message == null || effect.message === "") {
+            errors.push("Alert message can't be blank.");
+        }
+        return errors;
+    },
+    onTriggerEvent: async ({ effect }) => {
+
+        frontendCommunicator.send('event-activity', {
+           message: effect.message,
+            icon: effect.icon ?? "fad fa-tv-alt",
+           acknowledged: false,
+           event: {
+               id: "activity-feed-alert",
+               name: "Activity Feed Alert",
+           },
+           id: uuid(),
+           source:{
+               id: "firebot",
+               name: "Firebot",
+           },
+           timestamp: moment().format("H:mm"),
+        });
+
+        return true;
+    }
+};
+
+module.exports = effect;

--- a/src/backend/events/activity-feed-manager.js
+++ b/src/backend/events/activity-feed-manager.js
@@ -12,7 +12,7 @@ const timeFormat = isUSLocale ? "h:mm" : "H:mm";
 
 const previousActivity = [];
 
-export function handleTriggeredEvent(source, event, metadata) {
+export function handleTriggeredEvent(source, event, metadata, eventSettings = { forceAllow: false, canRetrigger: true }) {
     if (source == null || event == null || metadata == null) {
         return;
     }
@@ -44,7 +44,8 @@ export function handleTriggeredEvent(source, event, metadata) {
         },
         event: {
             id: event.id,
-            name: event.name
+            name: event.name,
+            ...eventSettings
         },
         message: event.activityFeed.getMessage(metadata),
         icon: event.activityFeed.icon,

--- a/src/backend/events/activity-feed-manager.js
+++ b/src/backend/events/activity-feed-manager.js
@@ -12,7 +12,7 @@ const timeFormat = isUSLocale ? "h:mm" : "H:mm";
 
 const previousActivity = [];
 
-function handleTriggeredEvent(source, event, metadata) {
+export function handleTriggeredEvent(source, event, metadata) {
     if (source == null || event == null || metadata == null) {
         return;
     }

--- a/src/gui/app/services/activity-feed.service.js
+++ b/src/gui/app/services/activity-feed.service.js
@@ -24,7 +24,7 @@
                 }
 
                 const allowedEvents = settingsService.getAllowedActivityEvents();
-                if (!allowedEvents.includes(`${activity.source.id}:${activity.event.id}`)) {
+                if (!allowedEvents.includes(`${activity.source.id}:${activity.event.id}`) && `${activity.source.id}:${activity.event.id}` !== "firebot:activity-feed-alert") {
                     return;
                 }
 

--- a/src/gui/app/services/activity-feed.service.js
+++ b/src/gui/app/services/activity-feed.service.js
@@ -24,7 +24,7 @@
                 }
 
                 const allowedEvents = settingsService.getAllowedActivityEvents();
-                if (!allowedEvents.includes(`${activity.source.id}:${activity.event.id}`) && `${activity.source.id}:${activity.event.id}` !== "firebot:activity-feed-alert") {
+                if (!activity.event.forceAllow && !allowedEvents.includes(`${activity.source.id}:${activity.event.id}`)) {
                     return;
                 }
 
@@ -42,13 +42,13 @@
             };
 
             service.markAllAcknowledged = () => {
-                service.allActivities.forEach(a => {
+                service.allActivities.forEach((a) => {
                     a.acknowledged = true;
                 });
             };
 
             service.markAllNotAcknowledged = () => {
-                service.allActivities.forEach(a => {
+                service.allActivities.forEach((a) => {
                     a.acknowledged = false;
                 });
             };

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -270,6 +270,7 @@
           style="font-size: 15px; display: flex; align-items: center"
         >
           <i
+            ng-if="activity.source.id + ':' + activity.event.id !== 'firebot:activity-feed-alert'"
             class="clickable far fa-redo mr-4"
             ng-click="afs.retriggerEvent(activity.id)"
             uib-tooltip="Retrigger event"

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -270,7 +270,7 @@
           style="font-size: 15px; display: flex; align-items: center"
         >
           <i
-            ng-if="activity.source.id + ':' + activity.event.id !== 'firebot:activity-feed-alert'"
+            ng-if="activity.event.canRetrigger !== false"
             class="clickable far fa-redo mr-4"
             ng-click="afs.retriggerEvent(activity.id)"
             uib-tooltip="Retrigger event"


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
this effect adds the ability to create entries in the activity feed.  

this change Required UUID Types so that was added in the package it is working but not sure if version 10.0.0 is too new? 
im unsure if the package lock is needed. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2634

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
added effect to preset list and changed the icon added text then clicked play 
added effect to preset list left icon empty and added text then clicked play as noted in the screenshots 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

![image](https://github.com/user-attachments/assets/d1da4247-2057-492d-97ab-8a96d6ba7608)
![image](https://github.com/user-attachments/assets/111561f2-045f-4497-b596-2cb0c78d864d)
![image](https://github.com/user-attachments/assets/0003ccde-9c73-4d82-99c7-5c6877b326b9)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
