### PR TITLE
fix: (effect) Cooldown Search Negation

### DIFF
--- a/src/backend/effects/builtin/cooldown-command.js
+++ b/src/backend/effects/builtin/cooldown-command.js
@@ -27,7 +27,7 @@ const model = {
 
             <ui-select ng-if="effect.selectionType && effect.selectionType === 'command'" ng-model="effect.commandId" theme="bootstrap" on-select="commandSelected($item, $model)">
                 <ui-select-match placeholder="Select or search for a command... ">{{$select.selected.trigger}}</ui-select-match>
-                <ui-select-choices repeat="command.id as command in commands | filter: { trigger: $select.search }" style="position:relative;">
+                <ui-select-choices repeat="command.id as command in commands | filter: { trigger: ($select.search.startsWith('!') ? $select.search.slice(1) : $select.search) }" style="position:relative;">
                     <div ng-bind-html="command.trigger | highlight: $select.search"></div>
                 </ui-select-choices>
             </ui-select>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Cooldown effect search bar isn't ideal when the search text starts with an exclamation mark.
- Thanks angular.
- [I'm not the only one](https://github.com/crowbartools/Firebot/pull/2643/commits/f9ef09bf97b9fd88db5bb74a50bff26ed7d06952)!


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
**Before**:
![Cooldown negation - Before](https://github.com/user-attachments/assets/76fa14bb-3177-4814-836c-64344f32fa8c)
**After**:
![Cooldown negation - After](https://github.com/user-attachments/assets/46f88eeb-96a7-4915-ac17-819a876784ee)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
