### PR TITLE
fix: export setup file extension on linux (#2677)

### DIFF
--- a/src/gui/app/directives/modals/setups/create-setup-modal.js
+++ b/src/gui/app/directives/modals/setups/create-setup-modal.js
@@ -233,7 +233,7 @@
                     /**@type {Electron.SaveDialogOptions} */
                     const saveDialogOptions = {
                         buttonLabel: "Save Setup",
-                        defaultPath: sanitizeFileName($ctrl.setup.name),
+                        defaultPath: `${sanitizeFileName($ctrl.setup.name)}.firebotsetup`,
                         title: "Save Setup File",
                         filters: [
                             {name: "Firebot Setup Files", extensions: ['firebotsetup']}


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adds the .firebotsetup file extension to a setup created on Linux

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2677 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured setups on linux now save with file extension
Ensured setups save properly with one instance of the file extension on Windows and Mac

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
