### PR TITLE
fix: channel rewards creating invalid default color codes

### DIFF
--- a/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
+++ b/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
@@ -299,7 +299,7 @@
             controller: function($scope, ngToast, channelRewardsService) {
                 const $ctrl = this;
 
-                const generateRandomColor = () => `#${Math.floor(Math.random() * 8 ** 8).toString(16)}`;
+                const generateRandomColor = () => `#${Math.floor(Math.random() * 8 ** 8).toString(16).padStart(6, '0')}`;
 
                 $ctrl.formFieldHasError = (fieldName) => {
                     return ($scope.rewardSettings.$submitted || $scope.rewardSettings[fieldName].$touched)


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixed an issue where channel rewards can generate invalid color codes, causing reward save/creation to fail silently

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2680

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured short color codes are now padded with 0s until the color code is valid

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
