### PR TITLE
feat: Add add/edit tags to sort-tags-row components

### DIFF
--- a/src/gui/app/directives/controls/sort-tags-row.js
+++ b/src/gui/app/directives/controls/sort-tags-row.js
@@ -12,6 +12,7 @@
                 <div
                     style="display: flex; position: relative;"
                     uib-popover-template="'sortTagsPopover.html'"
+                    popover-is-open="$ctrl.isPopupVisible"
                     popover-placement="auto bottom-left"
                     popover-append-to-body="true"
                     popover-trigger="'outsideClick'"
@@ -25,7 +26,7 @@
                             class="sort-tag-add mb-px"
                             aria-label="Add tag"
                         >
-                                <i class="far fa-plus"></i>
+                            <i class="far fa-plus"></i>
                         </button>
                     </div>
                     <div style="position: absolute;" ng-show="hasOverflow()" uib-tooltip-html="getSortTagNames()">
@@ -47,13 +48,26 @@
                                 <input type="checkbox" ng-click="$ctrl.toggleSortTag(tag)" ng-checked="$ctrl.item.sortTags.includes(tag.id)">
                                 <div class="control__indicator"></div>
                             </label>
-                            <div ng-if="sts.getSortTags($ctrl.context).length === 0">No tags created yet</div>
+                            <div class="button mb-2" ng-click="editSortTags()" ng-if="sts.getSortTags($ctrl.context).length === 0">
+                                Add tags
+                            </div>
+                            <hr class="divider mt-1 mb-1" ng-if="sts.getSortTags($ctrl.context).length > 0" />
+                            <div class="button mt-4 mb-2" ng-click="editSortTags()" ng-if="sts.getSortTags($ctrl.context).length > 0">
+                                Add/edit tags
+                            </div>
                         </div>
                     </script>
-                <div>
+                </div>
             `,
             controller: function($scope, $element, sortTagsService) {
                 const $ctrl = this;
+
+                $ctrl.isPopupVisible = false;
+
+                $scope.editSortTags = () => {
+                    $ctrl.isPopupVisible = false;
+                    sortTagsService.showEditSortTagsModal($ctrl.context);
+                };
 
                 $scope.getSortTags = () => sortTagsService.getSortTagsForItem($ctrl.context, $ctrl.item.sortTags);
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->

- Edits the tags popover menus to include add or add/edit tags menu options.
- The padding and margin values look appropriate for me, but are open to be adjusted as desired.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2188 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Yes.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Screenshot of an empty component lacking tags, atop a separate screenshot of a component with several tags available (manually blurred out for screenshot purposes):
![issue_2188](https://github.com/user-attachments/assets/ea5bf6cf-628f-44e4-a391-04305dfe8e7c)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
