### PR TITLE
feat: chat message deleted event

### DIFF
--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -165,7 +165,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
         );
     });
 
-    streamerChatClient.onMessageRemove((_channel, messageId) => {
+    streamerChatClient.onMessageRemove((_channel, messageId, message) => {
+        twitchEventsHandler.chatMessage.triggerChatMessageDeleted(message);
         frontendCommunicator.send("twitch:chat:message:deleted", messageId);
     });
 

--- a/src/backend/chat/chat-listeners/twitch-chat-listeners.js
+++ b/src/backend/chat/chat-listeners/twitch-chat-listeners.js
@@ -44,7 +44,8 @@ exports.setupChatListeners = (streamerChatClient, botChatClient) => {
             firebotChatMessage.userId,
             firebotChatMessage.userDisplayName,
             firebotChatMessage.roles,
-            firebotChatMessage.rawText
+            firebotChatMessage.rawText,
+            firebotChatMessage.id
         );
     });
 

--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -317,6 +317,17 @@ module.exports = {
             }
         },
         {
+            id: "chat-message-deleted",
+            name: "Chat Message Deleted",
+            description: "When a chat message is deleted in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                messageText: "Test message"
+            }
+        },
+        {
             id: "first-time-chat",
             name: "First Time Chat",
             description: "When someone chats in your channel for the very first time",

--- a/src/backend/events/twitch-events/announcement.ts
+++ b/src/backend/events/twitch-events/announcement.ts
@@ -5,13 +5,15 @@ export function triggerAnnouncement(
     userId: string,
     userDisplayName: string,
     twitchUserRoles: string[],
-    messageText: string
+    messageText: string,
+    messageId: string
 ): void {
     eventManager.triggerEvent("twitch", "announcement", {
         username,
         userId,
         userDisplayName,
         twitchUserRoles,
-        messageText
+        messageText,
+        messageId
     });
 }

--- a/src/backend/events/twitch-events/chat-message.ts
+++ b/src/backend/events/twitch-events/chat-message.ts
@@ -1,3 +1,4 @@
+import { ClearMsg } from "@twurple/chat";
 import { FirebotChatMessage } from "../../../types/chat";
 import eventManager from "../../events/EventManager";
 
@@ -9,6 +10,15 @@ export function triggerChatMessage(firebotChatMessage: FirebotChatMessage): void
         twitchUserRoles: firebotChatMessage.roles,
         messageText: firebotChatMessage.rawText,
         chatMessage: firebotChatMessage
+    });
+}
+
+export function triggerChatMessageDeleted(deletedChatMessage: ClearMsg): void {
+    eventManager.triggerEvent("twitch", "chat-message-deleted", {
+        username: deletedChatMessage.userName,
+        messageText: deletedChatMessage.text,
+        messageId: deletedChatMessage.targetMessageId,
+        deletedChatMessage
     });
 }
 

--- a/src/backend/events/twitch-events/chat-message.ts
+++ b/src/backend/events/twitch-events/chat-message.ts
@@ -9,6 +9,7 @@ export function triggerChatMessage(firebotChatMessage: FirebotChatMessage): void
         userDisplayName: firebotChatMessage.userDisplayName,
         twitchUserRoles: firebotChatMessage.roles,
         messageText: firebotChatMessage.rawText,
+        messageId: firebotChatMessage.id,
         chatMessage: firebotChatMessage
     });
 }
@@ -29,6 +30,7 @@ export function triggerFirstTimeChat(firebotChatMessage: FirebotChatMessage): vo
         userDisplayName: firebotChatMessage.userDisplayName,
         twitchUserRoles: firebotChatMessage.roles,
         messageText: firebotChatMessage.rawText,
+        messageId: firebotChatMessage.id,
         chatMessage: firebotChatMessage
     });
 }

--- a/src/backend/events/twitch-events/viewer-arrived.ts
+++ b/src/backend/events/twitch-events/viewer-arrived.ts
@@ -13,6 +13,7 @@ export function triggerViewerArrived(
         userId,
         userDisplayName,
         messageText,
+        messageId: chatMessage.id,
         chatMessage
     });
 }

--- a/src/backend/variables/builtin/twitch/chat/message/chat-message-id.ts
+++ b/src/backend/variables/builtin/twitch/chat/message/chat-message-id.ts
@@ -1,0 +1,38 @@
+import { ReplaceVariable } from "../../../../../../types/variables";
+import { EffectTrigger } from "../../../../../../shared/effect-constants";
+import { OutputDataType, VariableCategory } from "../../../../../../shared/variable-constants";
+
+const triggers = {};
+triggers[EffectTrigger.MANUAL] = true;
+triggers[EffectTrigger.COMMAND] = true;
+triggers[EffectTrigger.EVENT] = [
+    "twitch:chat-message",
+    "twitch:chat-message-deleted",
+    "twitch:first-time-chat",
+    "twitch:announcement",
+    "twitch:viewer-arrived"
+];
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "chatMessageId",
+        description: "Outputs the chat message ID from the associated command or event.",
+        triggers: triggers,
+        categories: [VariableCategory.COMMON, VariableCategory.TRIGGER],
+        possibleDataOutput: [OutputDataType.NUMBER, OutputDataType.TEXT]
+    },
+    evaluator: (trigger) => {
+
+        let chatMessageId = "";
+        if (trigger.metadata.chatMessage) {
+            chatMessageId = trigger.metadata.chatMessage.id;
+
+        } else if (trigger.type === EffectTrigger.EVENT || trigger.type === EffectTrigger.MANUAL) {
+            chatMessageId = trigger.metadata.eventData.messageId;
+        }
+
+        return chatMessageId.trim();
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/chat/message/chat-message.ts
+++ b/src/backend/variables/builtin/twitch/chat/message/chat-message.ts
@@ -7,6 +7,7 @@ triggers[EffectTrigger.MANUAL] = true;
 triggers[EffectTrigger.COMMAND] = true;
 triggers[EffectTrigger.EVENT] = [
     "twitch:chat-message",
+    "twitch:chat-message-deleted",
     "twitch:first-time-chat",
     "firebot:highlight-message",
     "twitch:announcement",

--- a/src/backend/variables/builtin/twitch/chat/message/index.ts
+++ b/src/backend/variables/builtin/twitch/chat/message/index.ts
@@ -1,6 +1,7 @@
 import chatMessageAnimatedEmoteUrls from './chat-message-animated-emote-urls';
 import chatMessageEmoteNames from './chat-message-emote-names';
 import chatMessageEmoteUrls from './chat-message-emote-urls';
+import chatMessageId from './chat-message-id';
 import chatMessageTextOnly from './chat-message-text-only';
 import chatMessage from './chat-message';
 import chatColor from './chat-user-color';
@@ -14,6 +15,7 @@ export default [
     chatMessageAnimatedEmoteUrls,
     chatMessageEmoteNames,
     chatMessageEmoteUrls,
+    chatMessageId,
     chatMessageTextOnly,
     chatMessage,
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adds Chat Message Deleted event and $chatMessageId to commands and chat message related events

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2687 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured commands, chat event and new chat message deleted event properly supply $chatMessageId
Ensured chat message deleted event properly supplies $chatMessage, $user, $userDisplayName and $userId variables

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
