### PR TITLE
feat: OBS Color Picker, Raw/Variable Color Entry

### DIFF
--- a/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
@@ -39,13 +39,18 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
     <eos-container ng-if="colorSources != null && effect.colorSourceName != null" header="Color" style="margin-top: 10px;" pad-top="true">
         <firebot-checkbox
             label="Use Custom Color"
-            tooltip="Allow entering custom hex colors or variables. Will fail if variables don't resolve to hex color"
+            tooltip="Allow entering custom hex colors or replace variables. Will fail if the result is not a valid hex color."
             model="effect.customColor"
-            ng-click="toggleCustomColor()"
+            on-change="toggleCustomColor(newValue)"
             class="mb4"
         />
-        <firebot-input ng-if="effect.customColor" model="effect.color" placeholder-text="Format: #0066FF or #FF336699"></firebot-input>
-        <color-picker-input ng-if="!effect.customColor" model="effect.color" alpha="true" lg-input="true"></color-picker-input>
+        <firebot-input
+            input-title="#ARGB"
+            ng-if="effect.customColor"
+            model="effect.color"
+            placeholder-text="Format: #0066FF or #FF336699"
+        />
+        <color-picker-input label="#RGBA" ng-if="!effect.customColor" model="effect.color" alpha="true" lg-input="true"></color-picker-input>
     </eos-container>
   `,
     optionsController: ($scope: any, backendCommunicator: any, $q: any) => {
@@ -78,27 +83,19 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
             $scope.effect.colorSourceName = colorSourceName;
         };
 
-        $scope.toggleCustomColor = () => {
-            if ($scope.debounce) {
-                return;
-            }
-
-            $scope.debounce = true;
-
-            setTimeout(() => $scope.debounce = false, 5);
-
-            const value = !$scope.effect.customColor;
-            if (
-                (!value &&
+        $scope.toggleCustomColor = (newValue: boolean) => {
+            // Ignore the conversion when variables are included or when only RGB is provided
+            if ((
                 !rgbRegexp.test($scope.effect.color) &&
-                !argbRegexp.test($scope.effect.color)) ||
-                $scope.effect.color.length !== 9
-            ) {
-                //$scope.effect.color = "#FF0000FF";
+                !argbRegexp.test($scope.effect.color)
+            ) || (
+                rgbRegexp.test($scope.effect.color) &&
+                !argbRegexp.test($scope.effect.color)
+            )) {
                 return;
             }
 
-            $scope.effect.color = `#${value ? rgbaToArgb($scope.effect.color) : argbToRgba($scope.effect.color)}`;
+            $scope.effect.color = `#${newValue ? rgbaToArgb($scope.effect.color) : argbToRgba($scope.effect.color)}`;
         };
 
         $scope.getColorSources = () => {

--- a/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
@@ -80,7 +80,7 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
         if (hexColor.length === 8) {
             obsFormattedHexColor = `${hexColor.substring(0, 2)}${hexColor.substring(6, 8)}${hexColor.substring(4, 6)}${hexColor.substring(2, 4)}`;
         } else {
-            obsFormattedHexColor = `${hexColor.substring(4, 6)}${hexColor.substring(2, 4)}${hexColor.substring(0, 2)}`;
+            obsFormattedHexColor = `FF${hexColor.substring(4, 6)}${hexColor.substring(2, 4)}${hexColor.substring(0, 2)}`;
         }
 
         const intColorValue = parseInt(obsFormattedHexColor, 16);

--- a/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
+++ b/src/backend/integrations/builtin/obs/effects/set-obs-color-source-color.ts
@@ -61,6 +61,10 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
             $scope.effect.customColor = true;
         }
 
+        if ($scope.effect.customColor == null) {
+            $scope.effect.customColor = false;
+        }
+
         function argbToRgba(hexColor: string) {
             hexColor = hexColor.replace("#", "");
             return `${hexColor.substring(2, 4)}${hexColor.substring(4, 6)}${hexColor.substring(6, 8)}${hexColor.substring(0, 2)}`;
@@ -143,7 +147,7 @@ export const SetOBSColorSourceColorEffectType: EffectType<{
         let obsFormattedHexColor = "";
 
         // OBS likes the color values in the OTHER direction
-        if (!effect.customColor) {
+        if (effect.customColor === false) {
             obsFormattedHexColor = rgbaToAbgr(hexColor);
         } else if (hexColor.length === 8) {
             obsFormattedHexColor = argbToAbgr(hexColor);

--- a/src/gui/app/directives/controls/color-picker-input.js
+++ b/src/gui/app/directives/controls/color-picker-input.js
@@ -8,6 +8,7 @@
             bindings: {
                 model: "=",
                 label: "@?",
+                alpha: "<",
                 style: "@",
                 lgInput: "<",
                 showClear: "<"
@@ -39,10 +40,10 @@
                         required: true,
                         inputClass: `form-control ${$ctrl.lgInput ? 'input-lg' : ''}`,
                         allowEmpty: false,
-                        format: "hexString",
+                        format: $ctrl.alpha ? "hex8String" : "hexString",
                         placeholder: "#ffffff",
                         case: "lower",
-                        alpha: false,
+                        alpha: $ctrl.alpha,
                         clear: {
                             show: $ctrl.showClear !== false,
                             label: 'Clear',


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
fixed an issue where RGB-only color codes in the OBS Color Source Effect didn't get padded for transparency, thus getting transparency: 0 from OBS
Added a color picker for OBS Color Source Effect that allows users to pick a color with alpha
Added a custom color mode that allows for replace variables that result in ARGB hex codes

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
partially resolves #2250
- Variables are now allowed in the custom mode, however `$obsColorValue` will invert the color as it was meant for raw requests. #2076 may provide a solution here.

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured pre-existing effects (saved as ARGB) show their appropriate color, both with and without saving from effect settings UI

Ensured pre-existing effects switch to Custom Color mode when entering effect settings UI

Ensured new effects start in color picker mode with a default color

Ensured ARGB -> RGBA conversion only happens when alpha portion is present and input is a valid hex code

Ensured only valid color codes can be saved when custom mode is turned off

### Context

Due to technical limitations in the angularjs-color-picker component, the custom entry (ARGB) and color picker (RGBA) differ in color formats. I have added labels to indicate this as clearly as possible in order to forego some of the confusion.

When switching modes, Firebot will convert the color code as long as it's a valid ARGB or RGBA color code (depending on mode switch)

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

![image](https://github.com/user-attachments/assets/d7284a93-faa0-4499-9c36-ed962b6c190f)
![image](https://github.com/user-attachments/assets/58084930-aad9-4eed-a928-5a8e73f89520)
![image](https://github.com/user-attachments/assets/4ca8bacc-8020-41cc-9033-29b552298214)
![image](https://github.com/user-attachments/assets/307a6d6a-8c25-48ce-9f48-1d4a1c665c22)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
