### PR TITLE
feat: enable propertyPath and defaultData for effectOutput

### DIFF
--- a/src/backend/variables/builtin/metadata/effect-output.ts
+++ b/src/backend/variables/builtin/metadata/effect-output.ts
@@ -5,15 +5,59 @@ const model : ReplaceVariable = {
     definition: {
         handle: "effectOutput",
         usage: "effectOutput[name]",
+        examples: [
+            {
+                usage: "effectOutput[name, 1]",
+                description: "Get an array item by providing an array index as a second argument."
+            },
+            {
+                usage: "effectOutput[name, property]",
+                description: "Get a property by providing a property path (using dot notation) as a second argument."
+            },
+            {
+                usage: "effectOutput[name, null, exampleString]",
+                description: "Set a default value in case the effect output doesn't exist yet."
+            },
+            {
+                usage: "effectOutput[name, property, exampleString]",
+                description: "Set a default value in case the effect output doesn't have data at the specified property path."
+            }
+        ],
         description: "Get data that was outputted by a prior effect.",
         categories: [VariableCategory.ADVANCED],
         possibleDataOutput: [OutputDataType.NUMBER, OutputDataType.TEXT]
     },
 
     // eslint-disable-next-line @typescript-eslint/no-inferrable-types
-    evaluator: ({ effectOutputs }, name: string = "") => {
-        const output = (effectOutputs ?? {})[name];
-        return output || null;
+    evaluator: (
+        { effectOutputs },
+        name: string,
+        propertyPath: string,
+        defaultData: unknown = null
+    ) => {
+        let data = (effectOutputs ?? {})[name];
+
+        if (!data) {
+            return defaultData;
+        }
+
+        if (propertyPath == null || propertyPath === "null" || propertyPath === '') {
+            return data;
+        }
+
+        const nodes = propertyPath.split(".");
+
+        try {
+            for (const node of nodes) {
+                if (data == null) {
+                    return null;
+                }
+                data = data[node];
+            }
+            return data ?? defaultData;
+        } catch (error) {
+            return defaultData;
+        }
     }
 };
 

--- a/src/backend/variables/builtin/metadata/effect-output.ts
+++ b/src/backend/variables/builtin/metadata/effect-output.ts
@@ -47,6 +47,12 @@ const model : ReplaceVariable = {
 
         const nodes = propertyPath.split(".");
 
+        if (typeof data === "string") {
+            try {
+                data = JSON.parse(data as string);
+            } catch (_) { }
+        }
+
         try {
             for (const node of nodes) {
                 if (data == null) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Add property path and default data to effectOutput, similar to customVariable

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2091

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured providing no property path still returns the full value
Ensured providing a property path to an object or array output results in the proper path or defaultData being returned
Ensured providing a null property path to use defaultData returns defaultData when there is no data
Ensured using a JSON stringified effect output (eg. Obs Raw Request) returns the proper data at the property path

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
