### PR TITLE
fix: JsonDbManager created-item event

### DIFF
--- a/src/gui/app/directives/modals/chat/add-or-edit-custom-quick-action-modal.js
+++ b/src/gui/app/directives/modals/chat/add-or-edit-custom-quick-action-modal.js
@@ -1,8 +1,6 @@
 "use strict";
 
 (function() {
-    const uuidv1 = require("uuid/v1");
-
     angular.module("firebotApp")
         .component("addOrEditCustomQuickActionModal", {
             template: `
@@ -122,10 +120,6 @@
                         rootEffects: $ctrl.quickAction.effectList
                     };
 
-                    if ($ctrl.isNewQuickAction && $ctrl.quickAction.id == null) {
-                        $ctrl.quickAction.id = uuidv1();
-                    }
-
                     $ctrl.listType = $ctrl.quickAction.presetListId != null ? "preset" : "custom";
 
                     if ($ctrl.listType === "preset") {
@@ -160,7 +154,7 @@
                         $ctrl.quickAction.icon = "far fa-magic";
                     }
 
-                    quickActionsService.saveCustomQuickAction($ctrl.quickAction).then(successful => {
+                    quickActionsService.saveCustomQuickAction($ctrl.quickAction).then((successful) => {
                         if (successful) {
                             $ctrl.close();
                         } else {

--- a/src/gui/app/directives/modals/counters/add-edit-counter-modal.js
+++ b/src/gui/app/directives/modals/counters/add-edit-counter-modal.js
@@ -1,7 +1,6 @@
 "use strict";
 
 (function() {
-    const uuidv1 = require("uuid/v4");
     angular.module("firebotApp").component("addOrEditCounterModal", {
         template: `
             <context-menu-modal-header
@@ -132,7 +131,7 @@
                     return;
                 }
 
-                countersService.saveCounter($ctrl.counter).then(successful => {
+                countersService.saveCounter($ctrl.counter).then((successful) => {
                     if (successful) {
                         $ctrl.close({
                             $value: {
@@ -260,10 +259,6 @@
                     }
 
                     $ctrl.isNewCounter = false;
-                }
-
-                if ($ctrl.isNewCounter && $ctrl.counter.id == null) {
-                    $ctrl.counter.id = uuidv1();
                 }
 
                 $ctrl.txtFilePath = countersService.getTxtFilePath($ctrl.counter.name);

--- a/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
+++ b/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
@@ -1,7 +1,5 @@
 "use strict";
 (function() {
-    const uuidv1 = require("uuid/v1");
-
     angular.module("firebotApp").component("addOrEditEffectQueueModal", {
         template: `
             <scroll-sentinel element-class="edit-effect-queue-header"></scroll-sentinel>
@@ -89,10 +87,6 @@
 
                     $ctrl.isNewQueue = false;
                 }
-
-                if ($ctrl.isNewQueue && $ctrl.effectQueue.id == null) {
-                    $ctrl.effectQueue.id = uuidv1();
-                }
             };
 
             $ctrl.queueModes = effectQueuesService.queueModes;
@@ -108,7 +102,7 @@
                     return;
                 }
 
-                effectQueuesService.saveEffectQueue($ctrl.effectQueue).then(successful => {
+                effectQueuesService.saveEffectQueue($ctrl.effectQueue).then((successful) => {
                     if (successful) {
                         $ctrl.close({
                             $value: {

--- a/src/gui/app/directives/modals/effects/add-edit-preset-effect-list-modal.js
+++ b/src/gui/app/directives/modals/effects/add-edit-preset-effect-list-modal.js
@@ -2,8 +2,6 @@
 
 (function() {
 
-    const uuidv1 = require("uuid/v1");
-
     angular.module("firebotApp").component("addOrEditPresetEffectListModal", {
         template: `
             <scroll-sentinel element-class="edit-preset-effect-list-header"></scroll-sentinel>
@@ -92,7 +90,7 @@
                         inputPlaceholder: "Enter name",
                         saveText: "Save",
                         validationFn: (value) => {
-                            return new Promise(resolve => {
+                            return new Promise((resolve) => {
                                 if (value == null || value.trim().length < 1) {
                                     resolve(false);
                                 } else if ($ctrl.presetList.args.some(a => a.name === value.trim())) {
@@ -126,10 +124,6 @@
                     }
 
                     $ctrl.isNewPresetList = false;
-                }
-
-                if ($ctrl.isNewPresetList && $ctrl.presetList.id == null) {
-                    $ctrl.presetList.id = uuidv1();
                 }
             };
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Removes id generation in the frontend for quick actions, counters, queues and preset lists so JsonDbManager sends out the proper event.

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured quick actions, counters, queues and preset lists save properly
Ensured creating a quick action, counter, queue or preset list emits the `created-item` event rather than `updated-item`

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
