### PR TITLE
fix: overlay instance name for overlay connected event

### DIFF
--- a/src/server/websocket-server-manager.ts
+++ b/src/server/websocket-server-manager.ts
@@ -79,7 +79,7 @@ class WebSocketServerManager extends EventEmitter {
 
                                     sendResponse(ws, message.id);
 
-                                    const instanceName = (message.data as OverlayConnectedData).instanceName;
+                                    const instanceName = (message.data as Array<OverlayConnectedData>)[0].instanceName;
                                     eventManager.triggerEvent("firebot", "overlay-connected", {
                                         instanceName
                                     });


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes passing the instanceName into the overlay-connected event

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2742

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured $overlayInstance now reflects the instance that caused the event

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
