### PR TITLE
fix: OBS Scene Transition/Change Fixups

### DIFF
--- a/src/backend/integrations/builtin/obs/obs-remote.ts
+++ b/src/backend/integrations/builtin/obs/obs-remote.ts
@@ -194,16 +194,6 @@ async function setupRemoteListeners() {
         );
     });
 
-    obs.on("CurrentProgramSceneChanged", ({ sceneName }) => {
-        eventManager?.triggerEvent(
-            OBS_EVENT_SOURCE_ID,
-            OBS_CURRENT_PROGRAM_SCENE_CHANGED_EVENT_ID,
-            {
-                sceneName
-            }
-        );
-    });
-
     obs.on("CurrentSceneTransitionChanged", ({ transitionName }) => {
         eventManager?.triggerEvent(
             OBS_EVENT_SOURCE_ID,

--- a/src/backend/integrations/builtin/obs/obs-remote.ts
+++ b/src/backend/integrations/builtin/obs/obs-remote.ts
@@ -174,7 +174,8 @@ async function setupRemoteListeners() {
         );
     });
 
-    obs.on("SceneTransitionStarted", ({ transitionName }) => {
+    obs.on("SceneTransitionStarted", async ({ transitionName }) => {
+        programSceneName = (await obs.call("GetCurrentProgramScene"))?.sceneName || "";
         eventManager?.triggerEvent(
             OBS_EVENT_SOURCE_ID,
             OBS_SCENE_TRANSITION_STARTED_EVENT_ID,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Fix a bug where the OBS Program Scene Changed event was firing twice.
- Fix a bug where OBS Transition Started event could not access the new $obsSceneName until after a Scene Changed event propagates once the scene transition fully completes.
  - This is likely a bug or oversight in OBS Websockets.
  - But it can be worked around by immediately querying for the new scene name once a Transition Started event is received.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2749 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
