### PR TITLE
fix: remove rotation height

### DIFF
--- a/src/gui/app/directives/effect-option-settings/eosOverlayRotation.js
+++ b/src/gui/app/directives/effect-option-settings/eosOverlayRotation.js
@@ -10,7 +10,7 @@
             },
             template: `
             <eos-container header="Rotation" pad-top="$ctrl.padTop">
-                <div style="display: flex; flex-direction: row; width: 100%; height: 36px; align-items: center;">
+                <div style="display: flex; flex-direction: row; width: 100%; align-items: center;">
                     <firebot-input
                         style="flex-grow:1"
                         input-title="Rotation"


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
fix rotation field text box height 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2761

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
made sure the element was not a fixed height when seizing the textbox 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
