### PR TITLE
Feature Request #2767 Raid Sent Off Event

### DIFF
--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -7,7 +7,7 @@ module.exports = {
     events: [
         {
             id: "raid",
-            name: "Incoming Raid",
+            name: "Raid Incoming",
             description: "When someone raids your channel.",
             cached: true,
             cacheMetaKey: "username",
@@ -18,7 +18,7 @@ module.exports = {
                 viewerCount: 5
             },
             activityFeed: {
-                icon: "fad fa-siren-on",
+                icon: "fad fa-portal-enter",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
                     return `**${eventData.userDisplayName}${
@@ -29,8 +29,8 @@ module.exports = {
         },
         {
             id: "raid-sent-off",
-            name: "Raid Sent Off",
-            description: "When your raid finishes sending off",
+            name: "Raid Outgoing Completed",
+            description: "When your outgoing raid finishes.",
             cached: false,
             cacheMetaKey: "fromUsername",
             manualMetadata: {
@@ -43,7 +43,7 @@ module.exports = {
                 viewerCount: 5
             },
             activityFeed: {
-                icon: "fad fa-siren-on",
+                icon: "fad fa-portal-exit",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
                     return `**${eventData.userDisplayName}${

--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -7,7 +7,7 @@ module.exports = {
     events: [
         {
             id: "raid",
-            name: "Raid",
+            name: "Incoming Raid",
             description: "When someone raids your channel.",
             cached: true,
             cacheMetaKey: "username",
@@ -21,7 +21,36 @@ module.exports = {
                 icon: "fad fa-siren-on",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** raided with **${eventData.viewerCount}** viewer(s)`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** raided with **${eventData.viewerCount}** viewer(s)`;
+                }
+            }
+        },
+        {
+            id: "raid-sent-off",
+            name: "Raid Sent Off",
+            description: "When your raid finishes sending off",
+            cached: false,
+            cacheMetaKey: "fromUsername",
+            manualMetadata: {
+                username: "firebot",
+                userId: "",
+                userDisplayName: "Firebot",
+                raidTargetUsername: "user",
+                raidTargetUserId: "",
+                raidTargetUserDisplayName: "User",
+                viewerCount: 5
+            },
+            activityFeed: {
+                icon: "fad fa-siren-on",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** raiding user **${eventData.raidTargetUserDisplayName}** with **${
+                        eventData.viewerCount
+                    }** viewer(s)`;
                 }
             }
         },
@@ -40,7 +69,9 @@ module.exports = {
                 icon: "fas fa-heart",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** followed`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** followed`;
                 }
             }
         },
@@ -73,8 +104,13 @@ module.exports = {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** ${eventData.isResub ? 'resubscribed' : 'subscribed'} for **${eventData.totalMonths} month(s)** ${eventData.subPlan === 'Prime' ?
-                        "with **Twitch Prime**" : `at **Tier ${eventData.subPlan.replace("000", "")}**`}`;
+                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** ${
+                        eventData.isResub ? "resubscribed" : "subscribed"
+                    } for **${eventData.totalMonths} month(s)** ${
+                        eventData.subPlan === "Prime"
+                            ? "with **Twitch Prime**"
+                            : `at **Tier ${eventData.subPlan.replace("000", "")}**`
+                    }`;
                 }
             }
         },
@@ -101,7 +137,9 @@ module.exports = {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** upgraded their Prime sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** upgraded their Prime sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
                 }
             }
         },
@@ -129,7 +167,11 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-gift",
                 getMessage: (eventData) => {
-                    return `**${eventData.isAnonymous ? "An Anonymous Gifter" : eventData.gifterUsername}** gifted a ${eventData.giftDuration > 1 ? ` **${eventData.giftDuration} month** ` : ''} **Tier ${eventData.subPlan.replace("000", "")}** sub to **${eventData.gifteeUsername}** (Subbed for ${eventData.giftSubMonths} month${eventData.giftSubMonths > 1 ? 's' : ''} total)`;
+                    return `**${eventData.isAnonymous ? "An Anonymous Gifter" : eventData.gifterUsername}** gifted a ${
+                        eventData.giftDuration > 1 ? ` **${eventData.giftDuration} month** ` : ""
+                    } **Tier ${eventData.subPlan.replace("000", "")}** sub to **${
+                        eventData.gifteeUsername
+                    }** (Subbed for ${eventData.giftSubMonths} month${eventData.giftSubMonths > 1 ? "s" : ""} total)`;
                 }
             }
         },
@@ -165,7 +207,11 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-gifts",
                 getMessage: (eventData) => {
-                    return `**${eventData.isAnonymous ? "An Anonymous Gifter" : eventData.gifterUsername}** gifted **${eventData.subCount} Tier ${eventData.subPlan.replace("000", "")}** sub${eventData.subCount > 1 ? 's' : ''} to the community`;
+                    return `**${eventData.isAnonymous ? "An Anonymous Gifter" : eventData.gifterUsername}** gifted **${
+                        eventData.subCount
+                    } Tier ${eventData.subPlan.replace("000", "")}** sub${
+                        eventData.subCount > 1 ? "s" : ""
+                    } to the community`;
                 }
             }
         },
@@ -194,7 +240,9 @@ module.exports = {
                 icon: "fas fa-star",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** upgraded their gift sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** upgraded their gift sub at **Tier ${eventData.subPlan.replace("000", "")}!**`;
                 }
             }
         },
@@ -216,7 +264,11 @@ module.exports = {
                 icon: "fad fa-diamond",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** cheered **${eventData.bits}** bits. They have cheered a total of **${eventData.totalBits}** in the channel.`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** cheered **${eventData.bits}** bits. They have cheered a total of **${
+                        eventData.totalBits
+                    }** in the channel.`;
                 }
             }
         },
@@ -269,7 +321,9 @@ module.exports = {
                 icon: "fad fa-diamond",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** unlocked the **${eventData.badgeTier}** bits badge in your channel!`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** unlocked the **${eventData.badgeTier}** bits badge in your channel!`;
                 }
             }
         },
@@ -288,7 +342,9 @@ module.exports = {
                 icon: "fad fa-house-return",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** arrived`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** arrived`;
                 }
             }
         },
@@ -343,7 +399,9 @@ module.exports = {
                 icon: "fad fa-sparkles",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** has chatted in your channel for the very first time`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** has chatted in your channel for the very first time`;
                 }
             }
         },
@@ -377,7 +435,9 @@ module.exports = {
                 icon: "fad fa-gavel",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    let message = `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was banned by **${eventData.moderator}**.`;
+                    let message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** was banned by **${eventData.moderator}**.`;
 
                     if (eventData.modReason) {
                         message = `${message} Reason: **${eventData.modReason}**`;
@@ -402,7 +462,9 @@ module.exports = {
                 icon: "fad fa-gavel",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was unbanned by **${eventData.moderator}**.`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** was unbanned by **${eventData.moderator}**.`;
                 }
             }
         },
@@ -424,7 +486,9 @@ module.exports = {
                 icon: "fad fa-stopwatch",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    let message = `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** was timed out for **${eventData.timeoutDuration} sec(s)** by ${eventData.moderator}.`;
+                    let message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** was timed out for **${eventData.timeoutDuration} sec(s)** by ${eventData.moderator}.`;
 
                     if (eventData.modReason) {
                         message = `${message} Reason: **${eventData.modReason}**`;
@@ -454,7 +518,11 @@ module.exports = {
                 icon: "fad fa-circle",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** redeemed **${eventData.rewardName}**${eventData.messageText && !!eventData.messageText.length ? `: *${eventData.messageText}*` : ''}`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **${eventData.rewardName}**${
+                        eventData.messageText && !!eventData.messageText.length ? `: *${eventData.messageText}*` : ""
+                    }`;
                 }
             }
         },
@@ -479,7 +547,11 @@ module.exports = {
                 icon: "fad fa-circle",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}**'s redemption of **${eventData.rewardName}** was approved. ${eventData.messageText && !!eventData.messageText.length ? `*${eventData.messageText}*` : ''}`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }**'s redemption of **${eventData.rewardName}** was approved. ${
+                        eventData.messageText && !!eventData.messageText.length ? `*${eventData.messageText}*` : ""
+                    }`;
                 }
             }
         },
@@ -504,7 +576,11 @@ module.exports = {
                 icon: "fad fa-circle",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}**'s redemption of **${eventData.rewardName}** was rejected. ${eventData.messageText && !!eventData.messageText.length ? `*${eventData.messageText}*` : ''}`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }**'s redemption of **${eventData.rewardName}** was rejected. ${
+                        eventData.messageText && !!eventData.messageText.length ? `*${eventData.messageText}*` : ""
+                    }`;
                 }
             }
         },
@@ -531,7 +607,9 @@ module.exports = {
                 icon: "fad fa-comment-alt",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** sent your **${eventData.sentTo}** account the following whisper: ${eventData.message}`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** sent your **${eventData.sentTo}** account the following whisper: ${eventData.message}`;
                 }
             }
         },
@@ -545,19 +623,19 @@ module.exports = {
                 chatMode: {
                     type: "enum",
                     options: {
-                        "emoteonly": "Emote Only",
-                        "subscribers": "Subscribers Only",
-                        "followers": "Followers",
-                        "slow": "Slow",
-                        "r9kbeta": "Unique Chat"
+                        emoteonly: "Emote Only",
+                        subscribers: "Subscribers Only",
+                        followers: "Followers",
+                        slow: "Slow",
+                        r9kbeta: "Unique Chat"
                     },
                     value: "emoteonly"
                 },
                 chatModeState: {
                     type: "enum",
                     options: {
-                        "enabled": "Enabled",
-                        "disabled": "Disabled"
+                        enabled: "Enabled",
+                        disabled: "Disabled"
                     },
                     value: "enabled"
                 },
@@ -681,9 +759,13 @@ module.exports = {
                 getMessage: (eventData) => {
                     let message;
                     if (eventData.description) {
-                        message = `Channel ${eventData.type} goal **${eventData.description}** has ended. Goal **${eventData.isAchieved ? "was" : "was not"}** achieved. (**${eventData.currentAmount}**/**${eventData.targetAmount}**).`;
+                        message = `Channel ${eventData.type} goal **${eventData.description}** has ended. Goal **${
+                            eventData.isAchieved ? "was" : "was not"
+                        }** achieved. (**${eventData.currentAmount}**/**${eventData.targetAmount}**).`;
                     } else {
-                        message = `Channel ${eventData.type} goal has ended. Goal **${eventData.isAchieved ? "was" : "was not"}** achieved. (**${eventData.currentAmount}**/**${eventData.targetAmount}**).`;
+                        message = `Channel ${eventData.type} goal has ended. Goal **${
+                            eventData.isAchieved ? "was" : "was not"
+                        }** achieved. (**${eventData.currentAmount}**/**${eventData.targetAmount}**).`;
                     }
                     return message;
                 }
@@ -787,7 +869,9 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-train",
                 getMessage: (eventData) => {
-                    return `Level **${eventData.level}** hype train currently at **${Math.floor((eventData.progress / eventData.goal) * 100)}%**.`;
+                    return `Level **${eventData.level}** hype train currently at **${Math.floor(
+                        (eventData.progress / eventData.goal) * 100
+                    )}%**.`;
                 }
             }
         },
@@ -814,7 +898,7 @@ module.exports = {
             description: "When your stream starts.",
             cached: false,
             queued: false,
-            manualMetadata: { },
+            manualMetadata: {},
             activityFeed: {
                 icon: "fad fa-play-circle",
                 getMessage: () => {
@@ -828,7 +912,7 @@ module.exports = {
             description: "When your stream ends.",
             cached: false,
             queued: false,
-            manualMetadata: { },
+            manualMetadata: {},
             activityFeed: {
                 icon: "fad fa-stop-circle",
                 getMessage: () => {
@@ -923,7 +1007,9 @@ module.exports = {
             activityFeed: {
                 icon: "fad fa-ribbon",
                 getMessage: (eventData) => {
-                    return `Charity campaign has ended. Goal reached: **${eventData.goalReached ? "Yes" : "No"}**. Total raised: **${eventData.currentTotalAmount} ${eventData.currentTotalCurrency}**.`;
+                    return `Charity campaign has ended. Goal reached: **${
+                        eventData.goalReached ? "Yes" : "No"
+                    }**. Total raised: **${eventData.currentTotalAmount} ${eventData.currentTotalCurrency}**.`;
                 }
             }
         },
@@ -944,7 +1030,9 @@ module.exports = {
                 icon: "fad fa-bullhorn",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.moderator}** sent a shoutout to **${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}**`;
+                    return `**${eventData.moderator}** sent a shoutout to **${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }**`;
                 }
             }
         },
@@ -964,7 +1052,9 @@ module.exports = {
                 icon: "fad fa-bullhorn",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
-                    return `**${eventData.userDisplayName}${showUserIdName ? ` (${eventData.username})` : ""}** shouted out your channel to ${eventData.viewerCount} viewers`;
+                    return `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** shouted out your channel to ${eventData.viewerCount} viewers`;
                 }
             }
         },
@@ -1013,13 +1103,16 @@ module.exports = {
                     const mins = Math.floor(eventData.adBreakDuration / 60);
                     const remainingSecs = eventData.adBreakDuration % 60;
 
-                    const friendlyDuration = mins > 0
-                        ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
-                        : `${eventData.adBreakDuration}s`;
+                    const friendlyDuration =
+                        mins > 0
+                            ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
+                            : `${eventData.adBreakDuration}s`;
 
                     const minutesUntilNextAdBreak = Math.round(eventData.secondsUntilNextAdBreak / 60);
 
-                    return `**${friendlyDuration}** scheduled ad break starting in about **${minutesUntilNextAdBreak}** minute${minutesUntilNextAdBreak !== 1 ? "s" : ""}`;
+                    return `**${friendlyDuration}** scheduled ad break starting in about **${minutesUntilNextAdBreak}** minute${
+                        minutesUntilNextAdBreak !== 1 ? "s" : ""
+                    }`;
                 }
             }
         },
@@ -1038,11 +1131,14 @@ module.exports = {
                     const mins = Math.floor(eventData.adBreakDuration / 60);
                     const remainingSecs = eventData.adBreakDuration % 60;
 
-                    const friendlyDuration = mins > 0
-                        ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
-                        : `${eventData.adBreakDuration}s`;
+                    const friendlyDuration =
+                        mins > 0
+                            ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
+                            : `${eventData.adBreakDuration}s`;
 
-                    return `**${friendlyDuration}** **${eventData.isAdBreakScheduled ? "scheduled" : "manual"}** ad break started`;
+                    return `**${friendlyDuration}** **${
+                        eventData.isAdBreakScheduled ? "scheduled" : "manual"
+                    }** ad break started`;
                 }
             }
         },
@@ -1061,11 +1157,14 @@ module.exports = {
                     const mins = Math.floor(eventData.adBreakDuration / 60);
                     const remainingSecs = eventData.adBreakDuration % 60;
 
-                    const friendlyDuration = mins > 0
-                        ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
-                        : `${eventData.adBreakDuration}s`;
+                    const friendlyDuration =
+                        mins > 0
+                            ? `${mins}m${remainingSecs > 0 ? ` ${remainingSecs}s` : ""}`
+                            : `${eventData.adBreakDuration}s`;
 
-                    return `**${friendlyDuration}** **${eventData.isAdBreakScheduled ? "scheduled" : "manual"}** ad break ended`;
+                    return `**${friendlyDuration}** **${
+                        eventData.isAdBreakScheduled ? "scheduled" : "manual"
+                    }** ad break ended`;
                 }
             }
         }

--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -7,7 +7,7 @@ module.exports = {
     events: [
         {
             id: "raid",
-            name: "Raid Incoming",
+            name: "Incoming Raid",
             description: "When someone raids your channel.",
             cached: true,
             cacheMetaKey: "username",
@@ -18,7 +18,7 @@ module.exports = {
                 viewerCount: 5
             },
             activityFeed: {
-                icon: "fad fa-portal-enter",
+                icon: "fad fa-inbox-in",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
                     return `**${eventData.userDisplayName}${
@@ -29,8 +29,8 @@ module.exports = {
         },
         {
             id: "raid-sent-off",
-            name: "Raid Outgoing Completed",
-            description: "When your outgoing raid finishes.",
+            name: "Outgoing Raid",
+            description: "When your outgoing raid is completed.",
             cached: false,
             cacheMetaKey: "fromUsername",
             manualMetadata: {
@@ -43,7 +43,7 @@ module.exports = {
                 viewerCount: 5
             },
             activityFeed: {
-                icon: "fad fa-portal-exit",
+                icon: "fad fa-inbox-out",
                 getMessage: (eventData) => {
                     const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
                     return `**${eventData.userDisplayName}${

--- a/src/backend/events/filters/builtin/raid-viewer-count.js
+++ b/src/backend/events/filters/builtin/raid-viewer-count.js
@@ -7,7 +7,8 @@ module.exports = {
     name: "Raid Viewer Count",
     description: "Filter by how many viewers have been brought over by the raid.",
     events: [
-        { eventSourceId: "twitch", eventId: "raid" }
+        { eventSourceId: "twitch", eventId: "raid" },
+        { eventSourceId: "twitch", eventId: "raid-sent-off" }
     ],
     comparisonTypes: [
         ComparisonType.IS,
@@ -19,7 +20,6 @@ module.exports = {
     ],
     valueType: "number",
     predicate: (filterSettings, eventData) => {
-
         const { comparisonType, value } = filterSettings;
         const { eventMeta } = eventData;
 

--- a/src/backend/events/filters/builtin/raid-viewer-count.js
+++ b/src/backend/events/filters/builtin/raid-viewer-count.js
@@ -5,7 +5,7 @@ const { ComparisonType } = require("../../../../shared/filter-constants");
 module.exports = {
     id: "firebot:raid-viewer-count",
     name: "Raid Viewer Count",
-    description: "Filter by how many viewers have been brought over by the raid.",
+    description: "Filter by how many viewers have been brought or are being sent over by the raid.",
     events: [
         { eventSourceId: "twitch", eventId: "raid" },
         { eventSourceId: "twitch", eventId: "raid-sent-off" }

--- a/src/backend/events/twitch-events/raid.ts
+++ b/src/backend/events/twitch-events/raid.ts
@@ -1,6 +1,6 @@
 import eventManager from "../../events/EventManager";
 
-export function triggerRaid(
+export function triggerIncomingRaid(
     username: string,
     userId: string,
     userDisplayName: string,
@@ -10,6 +10,25 @@ export function triggerRaid(
         username,
         userId,
         userDisplayName,
+        viewerCount
+    });
+}
+export function triggerRaidSentOff(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    raidTargetUsername: string,
+    raidTargetUserId: string,
+    raidTargetUserDisplayName: string,
+    viewerCount = 0
+): void {
+    eventManager.triggerEvent("twitch", "raid-sent-off", {
+        username,
+        userId,
+        userDisplayName,
+        raidTargetUsername,
+        raidTargetUserId,
+        raidTargetUserDisplayName,
         viewerCount
     });
 }

--- a/src/backend/twitch-api/eventsub/eventsub-client.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-client.ts
@@ -133,16 +133,33 @@ class TwitchEventSubClient {
         });
         this._subscriptions.push(customRewardRedemptionUpdateSubscription);
 
-        // Raid
-        const raidSubscription = this._eventSubListener.onChannelRaidTo(streamer.userId, (event) => {
-            twitchEventsHandler.raid.triggerRaid(
+        // Incoming Raid
+        const incomingRaidSubscription = this._eventSubListener.onChannelRaidTo(streamer.userId, (event) => {
+            twitchEventsHandler.raid.triggerIncomingRaid(
                 event.raidingBroadcasterName,
                 event.raidingBroadcasterId,
                 event.raidingBroadcasterDisplayName,
                 event.viewers
             );
         });
-        this._subscriptions.push(raidSubscription);
+        this._subscriptions.push(incomingRaidSubscription);
+
+        // Outbound Raid Sent Off
+        const outboundRaidSubscription = this._eventSubListener.onChannelRaidFrom(streamer.userId, (event) => {
+            // sent off
+            if (event.raidingBroadcasterId === streamer.userId && event.raidedBroadcasterId !== streamer.userId) {
+                twitchEventsHandler.raid.triggerRaidSentOff(
+                    event.raidingBroadcasterName,
+                    event.raidingBroadcasterId,
+                    event.raidingBroadcasterDisplayName,
+                    event.raidedBroadcasterName,
+                    event.raidedBroadcasterId,
+                    event.raidedBroadcasterDisplayName,
+                    event.viewers
+                );
+            }
+        });
+        this._subscriptions.push(outboundRaidSubscription);
 
         // Shoutout sent to another channel
         const shoutoutSentSubscription = this._eventSubListener.onChannelShoutoutCreate(streamer.userId, streamer.userId, (event) => {

--- a/src/backend/variables/builtin/twitch/index.ts
+++ b/src/backend/variables/builtin/twitch/index.ts
@@ -5,6 +5,7 @@ import charityVariables from './charity';
 import cheerVariables from './cheer';
 import cheermoteVariables from './cheermote';
 import hypetrainVariables from './hype-train';
+import raidVariables from './raid';
 import rewardVariables from './reward';
 import streamVariables from './stream';
 import subVariables from './subs';
@@ -14,7 +15,6 @@ import followCount from './follow-count';
 import pollWinningChoiceName from './poll-winning-choice-name';
 import pollWinningChoiceVotes from './poll-winning-choice-votes';
 import predictionWinningOutcomeName from './prediction-winning-outcome-name';
-import raidViewerCounter from './raid-viewer-count';
 import twitchChannelUrl from './twitch-channel-url';
 import viewerCount from './viewer-count';
 
@@ -27,6 +27,7 @@ export default [
     ...cheerVariables,
     ...cheermoteVariables,
     ...hypetrainVariables,
+    ...raidVariables,
     ...rewardVariables,
     ...streamVariables,
     ...subVariables,
@@ -36,7 +37,6 @@ export default [
     pollWinningChoiceName,
     pollWinningChoiceVotes,
     predictionWinningOutcomeName,
-    raidViewerCounter,
     twitchChannelUrl,
     viewerCount
 ];

--- a/src/backend/variables/builtin/twitch/raid/index.ts
+++ b/src/backend/variables/builtin/twitch/raid/index.ts
@@ -1,0 +1,11 @@
+import raidViewerCount from './raid-viewer-count';
+import raidTargetUserDisplayName from './raid-target-user-display-name';
+import raidTargetUserId from './raid-target-user-id';
+import raidTargetUsername from './raid-target-username';
+
+export default [
+    raidViewerCount,
+    raidTargetUserDisplayName,
+    raidTargetUsername,
+    raidTargetUserId
+];

--- a/src/backend/variables/builtin/twitch/raid/raid-target-user-display-name.ts
+++ b/src/backend/variables/builtin/twitch/raid/raid-target-user-display-name.ts
@@ -1,0 +1,22 @@
+import { ReplaceVariable } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:raid-sent-off"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "raidTargetUserDisplayName",
+        description: "Gets the formatted display name for the raid target",
+        triggers: triggers,
+        categories: [VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async (trigger) => {
+        return trigger.metadata.eventData?.raidTargetUserDisplayName ?? "";
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/raid/raid-target-user-id.ts
+++ b/src/backend/variables/builtin/twitch/raid/raid-target-user-id.ts
@@ -1,0 +1,22 @@
+import { ReplaceVariable } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:raid-sent-off"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "raidTargetUserId",
+        description: "Gets the user ID for the raid target.",
+        triggers: triggers,
+        categories: [VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async (trigger) => {
+        return trigger.metadata.eventData?.raidTargetUserId ?? "";
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/raid/raid-target-username.ts
+++ b/src/backend/variables/builtin/twitch/raid/raid-target-username.ts
@@ -1,0 +1,23 @@
+import { ReplaceVariable, Trigger } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = ["twitch:raid-sent-off"];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "raidTargetUsername",
+        description: "The associated user (if there is one) for the given trigger",
+        triggers: triggers,
+        categories: [VariableCategory.COMMON, VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (trigger: Trigger) => {
+        return trigger.metadata.eventData?.raidTargetUsername;
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/raid/raid-viewer-count.ts
+++ b/src/backend/variables/builtin/twitch/raid/raid-viewer-count.ts
@@ -1,9 +1,9 @@
-import { ReplaceVariable } from "../../../../types/variables";
-import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
-import { EffectTrigger } from "../../../../shared/effect-constants";
+import { ReplaceVariable } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+import { EffectTrigger } from "../../../../../shared/effect-constants";
 
 const triggers = {};
-triggers[EffectTrigger.EVENT] = ["twitch:raid"];
+triggers[EffectTrigger.EVENT] = ["twitch:raid", "twitch:raid-sent-off"];
 triggers[EffectTrigger.MANUAL] = true;
 
 
@@ -16,7 +16,7 @@ const model : ReplaceVariable = {
         possibleDataOutput: [OutputDataType.NUMBER]
     },
     evaluator: async (trigger) => {
-        return trigger.metadata.eventData.viewerCount || 0;
+        return trigger.metadata.eventData?.viewerCount || 0;
     }
 };
 

--- a/src/gui/app/services/settings.service.js
+++ b/src/gui/app/services/settings.service.js
@@ -266,6 +266,7 @@
                 const events = getDataFromFile("/settings/allowedActivityEvents");
                 return events == null ? [
                     "twitch:raid",
+                    "twitch:raid-sent-off",
                     "twitch:follow",
                     "twitch:sub",
                     "twitch:subs-gifted",


### PR DESCRIPTION
### Description of the Change
Added Raid Sent off event to the event list. 
Created accompanying variable changes and activity feed changes 

### Applicable Issues
#2767 


### Testing
Manual:
Raid Sent Off:

1. Add Event for Raid Sent Off 
2. Raid a given channel 
3. Once raid is completed effects are fired off and message appears in activity feed

Regression:
Incoming raid

1. Add Event for Incoming Raid
2. Receive a Raid from a different channel
3. Once raid is completed effects are fired off and message appears in activity feed


### Screenshots
activity feed
![image](https://github.com/user-attachments/assets/2054e497-a0bb-40cd-96df-0f033fc808b6)

Event Names
![image](https://github.com/user-attachments/assets/35e3db2e-94ed-4cb0-b07d-041b746f329a)

Filter Hint Message
![image](https://github.com/user-attachments/assets/17f8e50e-301d-43aa-af67-a5c5c6531ac8)


