### PR TITLE
feat (vars): Add Custom Role filtering to $activeChatUserCount

### DIFF
--- a/src/backend/variables/builtin/misc/active-chat-user-count.ts
+++ b/src/backend/variables/builtin/misc/active-chat-user-count.ts
@@ -1,20 +1,43 @@
 import { ReplaceVariable } from "../../../../types/variables";
 import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
-
-const logger = require("../../../logwrapper");
-const activeViewerHandler = require("../../../chat/chat-listeners/active-user-handler");
+import { getActiveUserCount, getAllActiveUsers } from "../../../chat/chat-listeners/active-user-handler";
+import customRolesManager from "../../../roles/custom-roles-manager";
+import logger from "../../../logwrapper";
 
 const model : ReplaceVariable = {
     definition: {
         handle: "activeChatUserCount",
         description: "Get the number of active viewers in chat.",
         categories: [VariableCategory.NUMBERS],
-        possibleDataOutput: [OutputDataType.NUMBER]
+        possibleDataOutput: [OutputDataType.NUMBER],
+        examples: [
+            {
+                usage: "activeChatUserCount[CustomRole]",
+                description: "Gets the number of active viewers in the specified custom role."
+            }
+        ]
     },
-    evaluator: async () => {
+    evaluator: async (_, ...args: unknown[]) => {
         logger.debug("Getting number of active viewers in chat.");
 
-        return activeViewerHandler.getActiveUserCount() || 0;
+        if (args && args.length >= 1 && args[0] && args[0] !== "" && `${args[0]}`.toLowerCase() !== "null") {
+            const customRole = customRolesManager.getRoleByName(`${args[0]}`);
+            if (customRole == null) {
+                logger.warn(`Unable to get custom role from name ${args[0]}`);
+                return 0;
+            }
+
+            const customRoleUsers = customRole.viewers.map(crv => crv.username);
+            if (customRoleUsers.length === 0) {
+                logger.warn(`Custom role named ${customRole.name} appears to be empty`);
+                return 0;
+            }
+
+            const activeCustomRoleUsers = getAllActiveUsers().filter(user => customRoleUsers.includes(user.username));
+            return activeCustomRoleUsers.length;
+        }
+
+        return getActiveUserCount() || 0;
     }
 };
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Adds `$activeChatUserCount[customRole]` for filtering the count of active chat users by the custom role.
- Changed some `require`-syntax imports to actual `import`-syntax.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2750

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Verified operational with several groups with three differing accounts over various activity states.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![active_chat_user_count](https://github.com/user-attachments/assets/1fb017c2-4a2f-408e-b093-333c98812eec)



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
