### PR TITLE
feat: Remember Active Dashboard Chat User, Message Text, and Replying-To

### DIFF
--- a/src/gui/app/controllers/chat-messages.controller.js
+++ b/src/gui/app/controllers/chat-messages.controller.js
@@ -11,15 +11,11 @@
             utilityService,
             activityFeedService
         ) {
+            $scope.afs = activityFeedService;
+            $scope.cms = chatMessagesService;
             $scope.settings = settingsService;
 
-            $scope.afs = activityFeedService;
-
-            $scope.chatMessage = "";
-            $scope.chatSender = "Streamer";
             $scope.disabledMessage = "";
-
-            $scope.cms = chatMessagesService;
 
             $scope.selectedUserData = {};
 
@@ -126,7 +122,7 @@
             };
 
             $scope.updateChatInput = function(text) {
-                $scope.chatMessage = text;
+                chatMessagesService.chatMessage = text;
                 focusMessageInput();
             };
 
@@ -169,13 +165,13 @@
             const chatHistory = [];
             let currrentHistoryIndex = -1;
             $scope.submitChat = function() {
-                if ($scope.chatMessage == null || $scope.chatMessage.length < 1) {
+                if (chatMessagesService.chatMessage == null || chatMessagesService.chatMessage.length < 1) {
                     return;
                 }
-                chatMessagesService.submitChat($scope.chatSender, $scope.chatMessage, $scope.threadDetails?.replyToMessageId);
-                chatHistory.unshift($scope.chatMessage);
+                chatMessagesService.submitChat(chatMessagesService.chatSender, chatMessagesService.chatMessage, $scope.threadDetails?.replyToMessageId);
+                chatHistory.unshift(chatMessagesService.chatMessage);
                 currrentHistoryIndex = -1;
-                $scope.chatMessage = "";
+                chatMessagesService.chatMessage = "";
                 $scope.threadDetails = null;
             };
 
@@ -188,23 +184,23 @@
                 if (keyCode === 38) {
                     //up arrow
                     if (
-                        $scope.chatMessage.length < 1 ||
-            $scope.chatMessage === chatHistory[currrentHistoryIndex]
+                        chatMessagesService.chatMessage.length < 1 ||
+                        chatMessagesService.chatMessage === chatHistory[currrentHistoryIndex]
                     ) {
                         if (currrentHistoryIndex + 1 < chatHistory.length) {
                             currrentHistoryIndex++;
-                            $scope.chatMessage = chatHistory[currrentHistoryIndex];
+                            chatMessagesService.chatMessage = chatHistory[currrentHistoryIndex];
                         }
                     }
                 } else if (keyCode === 40) {
                     //down arrow
                     if (
-                        $scope.chatMessage.length > 0 ||
-            $scope.chatMessage === chatHistory[currrentHistoryIndex]
+                        chatMessagesService.chatMessage.length > 0 ||
+                        chatMessagesService.chatMessage === chatHistory[currrentHistoryIndex]
                     ) {
                         if (currrentHistoryIndex - 1 >= 0) {
                             currrentHistoryIndex--;
-                            $scope.chatMessage = chatHistory[currrentHistoryIndex];
+                            chatMessagesService.chatMessage = chatHistory[currrentHistoryIndex];
                         }
                     }
                 } else if (keyCode === 13) {

--- a/src/gui/app/controllers/chat-messages.controller.js
+++ b/src/gui/app/controllers/chat-messages.controller.js
@@ -30,8 +30,6 @@
                 $scope.hideEventLabel = () => ((parseInt(settings.dashboardActivityFeed.replace("%", "") / 100 * $parent.width())) < 180 ? true : false);
             };
 
-            $scope.threadDetails = null;
-
             function getThreadMessages(threadOrReplyMessageId) {
                 return chatMessagesService.chatQueue.filter((chatItem) => {
                     return chatItem.type === "message" && (chatItem.data.id === threadOrReplyMessageId || chatItem.data.replyParentMessageId === threadOrReplyMessageId || chatItem.data.threadParentMessageId === threadOrReplyMessageId);
@@ -39,10 +37,10 @@
             }
 
             $scope.currentThreadMessages = () => {
-                if (!$scope.threadDetails?.threadParentMessageId) {
+                if (!chatMessagesService.threadDetails?.threadParentMessageId) {
                     return [];
                 }
-                return getThreadMessages($scope.threadDetails.threadParentMessageId);
+                return getThreadMessages(chatMessagesService.threadDetails.threadParentMessageId);
             };
 
             $scope.updateLayoutSettings = (updatedSettings) => {
@@ -134,7 +132,7 @@
 
                 const threadParentId = parentReplyMessage.threadParentMessageId || parentReplyMessage.replyParentMessageId || parentReplyMessage.id;
 
-                $scope.threadDetails = {
+                chatMessagesService.threadDetails = {
                     threadParentMessageId: threadParentId,
                     replyToMessageId: threadOrReplyMessageId,
                     replyToUserDisplayName: parentReplyMessage.username
@@ -142,7 +140,7 @@
             };
 
             $scope.closeThreadPanel = () => {
-                $scope.threadDetails = null;
+                chatMessagesService.threadDetails = null;
             };
 
             $scope.onReplyClicked = function(threadOrReplyMessageId) {
@@ -168,11 +166,11 @@
                 if (chatMessagesService.chatMessage == null || chatMessagesService.chatMessage.length < 1) {
                     return;
                 }
-                chatMessagesService.submitChat(chatMessagesService.chatSender, chatMessagesService.chatMessage, $scope.threadDetails?.replyToMessageId);
+                chatMessagesService.submitChat(chatMessagesService.chatSender, chatMessagesService.chatMessage, chatMessagesService.threadDetails?.replyToMessageId);
                 chatHistory.unshift(chatMessagesService.chatMessage);
                 currrentHistoryIndex = -1;
                 chatMessagesService.chatMessage = "";
-                $scope.threadDetails = null;
+                chatMessagesService.threadDetails = null;
             };
 
             $scope.onMessageFieldUpdate = () => {

--- a/src/gui/app/controllers/chat-messages.controller.js
+++ b/src/gui/app/controllers/chat-messages.controller.js
@@ -16,7 +16,7 @@
             $scope.afs = activityFeedService;
 
             $scope.chatMessage = "";
-            $scope.chatSender = settingsService.getChatSender("Streamer");
+            $scope.chatSender = "Streamer";
             $scope.disabledMessage = "";
 
             $scope.cms = chatMessagesService;
@@ -128,11 +128,6 @@
             $scope.updateChatInput = function(text) {
                 $scope.chatMessage = text;
                 focusMessageInput();
-            };
-
-            $scope.setChatSender = function(chatter) {
-                $scope.chatSender = chatter;
-                settingsService.setChatSender(chatter);
             };
 
             $scope.setThreadDetails = (threadOrReplyMessageId) => {

--- a/src/gui/app/controllers/chat-messages.controller.js
+++ b/src/gui/app/controllers/chat-messages.controller.js
@@ -16,7 +16,7 @@
             $scope.afs = activityFeedService;
 
             $scope.chatMessage = "";
-            $scope.chatSender = "Streamer";
+            $scope.chatSender = settingsService.getChatSender("Streamer");
             $scope.disabledMessage = "";
 
             $scope.cms = chatMessagesService;
@@ -128,6 +128,11 @@
             $scope.updateChatInput = function(text) {
                 $scope.chatMessage = text;
                 focusMessageInput();
+            };
+
+            $scope.setChatSender = function(chatter) {
+                $scope.chatSender = chatter;
+                settingsService.setChatSender(chatter);
             };
 
             $scope.setThreadDetails = (threadOrReplyMessageId) => {

--- a/src/gui/app/services/chat-messages.service.js
+++ b/src/gui/app/services/chat-messages.service.js
@@ -21,6 +21,11 @@
 
             service.autodisconnected = false;
 
+            // The active chat sender identifier, either "Streamer" or "Bot"
+            service.chatSender = "Streamer";
+            // The pending but unsent outgoing chat message text
+            service.messageText = "";
+
             // Tells us if we should process in app chat or not.
             service.getChatFeed = function() {
                 return settingsService.getRealChatFeed();

--- a/src/gui/app/services/chat-messages.service.js
+++ b/src/gui/app/services/chat-messages.service.js
@@ -25,6 +25,8 @@
             service.chatSender = "Streamer";
             // The pending but unsent outgoing chat message text
             service.messageText = "";
+            // The message/thread currently being replied to
+            service.threadDetails = null;
 
             // Tells us if we should process in app chat or not.
             service.getChatFeed = function() {

--- a/src/gui/app/services/settings.service.js
+++ b/src/gui/app/services/settings.service.js
@@ -837,6 +837,16 @@
                 pushDataToFile("/settings/webOnlineCheckin", value);
             };
 
+            service.getChatSender = (defaultValue) => {
+                if (settingsCache['/settings/chatSender'] == null) {
+                    settingsCache['/settings/chatSender'] = defaultValue;
+                }
+                return settingsCache['/settings/chatSender'];
+            };
+            service.setChatSender = (value) => {
+                settingsCache['/settings/chatSender'] = value;
+            };
+
             return service;
         });
 }());

--- a/src/gui/app/services/settings.service.js
+++ b/src/gui/app/services/settings.service.js
@@ -837,16 +837,6 @@
                 pushDataToFile("/settings/webOnlineCheckin", value);
             };
 
-            service.getChatSender = (defaultValue) => {
-                if (settingsCache['/settings/chatSender'] == null) {
-                    settingsCache['/settings/chatSender'] = defaultValue;
-                }
-                return settingsCache['/settings/chatSender'];
-            };
-            service.setChatSender = (value) => {
-                settingsCache['/settings/chatSender'] = value;
-            };
-
             return service;
         });
 }());

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -42,7 +42,7 @@
         >
       </div>
       <button
-        ng-hide="scrollGlued || threadDetails != null"
+        ng-hide="scrollGlued || cms.threadDetails != null"
         ng-click="scrollGlued = true"
         class="chat-scroll-paused-btn btn-sm clickable mb-4"
       >
@@ -89,7 +89,7 @@
       <div class="chat-autodisconnected" ng-show="cms.autodisconnected">
         Disconnected from chat, trying to reconnect...
       </div>
-      <div ng-if="threadDetails != null" class="thread-wrapper" ng-class="{ 'mt-5': alternateBackgrounds}">
+      <div ng-if="cms.threadDetails != null" class="thread-wrapper" ng-class="{ 'mt-5': alternateBackgrounds}">
         <div class="thread-header">
           <h4><i class="fas" ng-class="currentThreadMessages().length < 2 ? 'fa-reply' : 'fa-comment-alt-lines'" style="margin-right: 10px;"></i>{{currentThreadMessages().length < 2 ? "Reply to" : "Thread"}}</h4>
           <button type="button" class="thread-close-btn clickable" aria-label="Close" ng-click="closeThreadPanel()"><i class="far fa-times"></i></button>
@@ -112,9 +112,9 @@
               chat-size-style="{{customFontSizeStyle}}"
             />
         </div>
-        <div class="thread-replying-to" ng-if="threadDetails.replyToMessageId != threadDetails.threadParentMessageId">
-          <span>Replying to <span style="font-weight: 800">@{{threadDetails.replyToUserDisplayName}}</span></span>
-          <button class="btn btn-link" ng-click="threadDetails.replyToMessageId = threadDetails.threadParentMessageId">Cancel</button>
+        <div class="thread-replying-to" ng-if="cms.threadDetails.replyToMessageId != cms.threadDetails.threadParentMessageId">
+          <span>Replying to <span style="font-weight: 800">@{{cms.threadDetails.replyToUserDisplayName}}</span></span>
+          <button class="btn btn-link" ng-click="cms.threadDetails.replyToMessageId = cms.threadDetails.threadParentMessageId">Cancel</button>
         </div>
       </div>
     </div>

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -139,10 +139,8 @@
             <div class="fb-arrow down mx-4 mb-1"></div>
           </span>
           <ul class="dropdown-menu">
-            <li ng-click="chatSender = 'Streamer'"><a href>Streamer</a></li>
-            <li ng-click="chatSender = 'Bot'" ng-show="botLoggedIn">
-              <a href>Bot</a>
-            </li>
+            <li ng-click="setChatSender('Streamer')"><a>Streamer</a></li>
+            <li ng-click="setChatSender('Bot')" ng-show="botLoggedIn"><a>Bot</a></li>
           </ul>
         </div>
 

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -139,8 +139,10 @@
             <div class="fb-arrow down mx-4 mb-1"></div>
           </span>
           <ul class="dropdown-menu">
-            <li ng-click="setChatSender('Streamer')"><a>Streamer</a></li>
-            <li ng-click="setChatSender('Bot')" ng-show="botLoggedIn"><a>Bot</a></li>
+            <li ng-click="chatSender = 'Streamer'"><a href>Streamer</a></li>
+            <li ng-click="chatSender = 'Bot'" ng-show="botLoggedIn">
+              <a href>Bot</a>
+            </li>
           </ul>
         </div>
 

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -126,7 +126,7 @@
         input-id="chatMessageInput"
       >
         <div class="dropup">
-          <span
+          <div
             class="dropdown-toggle chatter-dropdown"
             data-toggle="dropdown"
             uib-tooltip="Chat as"
@@ -135,7 +135,7 @@
           >
             <span class="ml-4" style="width: 100%; text-align: center">{{cms.chatSender}}</span>
             <div class="fb-arrow down mx-4 mb-1"></div>
-          </span>
+          </div>
           <ul class="dropdown-menu">
             <li ng-click="cms.chatSender = 'Streamer'"><a>Streamer</a></li>
             <li ng-click="cms.chatSender = 'Bot'" ng-show="botLoggedIn">
@@ -204,7 +204,6 @@
       </div>
       <div uib-dropdown>
         <a
-          href
           uib-dropdown-toggle
           class="clickable"
           style="color: white; font-size: 20px; line-height: 1"
@@ -214,7 +213,7 @@
         </a>
         <ul class="dropdown-menu right-justified-dropdown" uib-dropdown-menu>
           <li ng-class="{'disabled': afs.activities.length < 1}">
-            <a href ng-click="afs.toggleMarkAllAcknowledged()"
+            <a ng-click="afs.toggleMarkAllAcknowledged()"
               ><i
                 class="far fa-check-square mr-4"
                 aria-label="Mark all events as acknowledged"
@@ -224,7 +223,7 @@
             >
           </li>
           <li>
-            <a href ng-click="afs.showEditActivityFeedEventsModal()"
+            <a ng-click="afs.showEditActivityFeedEventsModal()"
               ><i class="far fa-toggle-off mr-4" aria-label="Edit events"></i>
               Edit events</a
             >

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -122,7 +122,7 @@
       <div
         class="text-input"
         chat-auto-complete-menu
-        ng-model="chatMessage"
+        ng-model="cms.chatMessage"
         input-id="chatMessageInput"
       >
         <div class="dropup">
@@ -133,15 +133,13 @@
             tooltip-placement="left"
             tooltip-append-to-body="true"
           >
-            <span class="ml-4" style="width: 100%; text-align: center"
-              >{{chatSender}}</span
-            >
+            <span class="ml-4" style="width: 100%; text-align: center">{{cms.chatSender}}</span>
             <div class="fb-arrow down mx-4 mb-1"></div>
           </span>
           <ul class="dropdown-menu">
-            <li ng-click="chatSender = 'Streamer'"><a href>Streamer</a></li>
-            <li ng-click="chatSender = 'Bot'" ng-show="botLoggedIn">
-              <a href>Bot</a>
+            <li ng-click="cms.chatSender = 'Streamer'"><a>Streamer</a></li>
+            <li ng-click="cms.chatSender = 'Bot'" ng-show="botLoggedIn">
+              <a>Bot</a>
             </li>
           </ul>
         </div>
@@ -153,7 +151,7 @@
           class="text-input-field"
           style="height: 100%"
           ng-maxlength="360"
-          ng-model="chatMessage"
+          ng-model="cms.chatMessage"
           ng-change="onMessageFieldUpdate()"
           ng-keydown="onMessageFieldKeypress($event)"
           ng-trim="false"


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Caches the active chat sender, outgoing chat message text, and reply/thread information in the dashboard when the chat-messages controller gets reloaded.
- This intentionally **does not** get saved to disk, and the application will always start back up with "Streamer" as the active chat sender.
- Does not add any actual settings, checkboxes, nor UI. It just remembers the thing you already changed while the application stays active.
- Previously, changing component tabs then changing back would cause the chat sender to get reset to Streamer, the message text to be blank, and the reply-to/thread information to be dropped. This was *not* cool.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2353

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Yup, video evidence of functionality:
[![Video Of Tests](https://github.com/user-attachments/assets/919dc509-61cd-4b98-9901-55ce343ad0de)](https://github.com/user-attachments/assets/befc6419-af88-44f3-a308-9f4d2a7ee129)

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
