### PR TITLE
Feat: `arraySlice` replace variable

### DIFF
--- a/src/backend/variables/builtin/array/array-slice.ts
+++ b/src/backend/variables/builtin/array/array-slice.ts
@@ -1,0 +1,35 @@
+import { ReplaceVariable, Trigger } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "arraySlice",
+        description: "Returns a slice of an array",
+        usage: "arraySlice[array, start, end]",
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: (
+        trigger: Trigger,
+        subject: string | unknown[],
+        start?: string,
+        end?: string
+    ) : unknown[] => {
+        if (typeof subject === 'string' || subject instanceof String) {
+            try {
+                subject = JSON.parse(`${subject}`);
+            } catch (ignore) {
+                return [];
+            }
+        }
+        if (!Array.isArray(subject)) {
+            return [];
+        }
+        return [...subject].slice(
+            start ? Number(start) : 0,
+            end ? Number(end) : subject.length
+        );
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/array/array-slice.ts
+++ b/src/backend/variables/builtin/array/array-slice.ts
@@ -12,8 +12,8 @@ const model : ReplaceVariable = {
     evaluator: (
         trigger: Trigger,
         subject: string | unknown[],
-        start?: string,
-        end?: string
+        start?: string | number,
+        end?: string | number
     ) : unknown[] => {
         if (typeof subject === 'string' || subject instanceof String) {
             try {
@@ -25,10 +25,18 @@ const model : ReplaceVariable = {
         if (!Array.isArray(subject)) {
             return [];
         }
-        return [...subject].slice(
-            start ? Number(start) : 0,
-            end ? Number(end) : subject.length
-        );
+
+        start = start ? Number(start) : 0;
+        if (Number.isNaN(start)) {
+            start = 0;
+        }
+
+        end = end ? Number(end) : subject.length;
+        if (Number.isNaN(end)) {
+            end = subject.length;
+        }
+
+        return [...subject].slice(start, end);
     }
 };
 

--- a/src/backend/variables/builtin/array/index.ts
+++ b/src/backend/variables/builtin/array/index.ts
@@ -1,5 +1,5 @@
 import arrayAdd from './array-add';
-import arrayElemenet from './array-element';
+import arrayElement from './array-element';
 import arrayFilter from './array-filter';
 import arrayFindIndex from './array-find-index';
 import arrayFind from './array-find';
@@ -11,6 +11,7 @@ import arrayRandomItem from './array-random-item';
 import arrayRemove from './array-remove';
 import arrayReverse from './array-reverse';
 import arrayShuffle from './array-shuffle';
+import arraySlice from './array-slice';
 
 // Deprecated
 import rawArrayAdd from './raw-array-add';
@@ -27,7 +28,7 @@ import rawArrayShuffle from './raw-array-shuffle';
 
 export default [
     arrayAdd,
-    arrayElemenet,
+    arrayElement,
     arrayFilter,
     arrayFindIndex,
     arrayFind,
@@ -39,6 +40,7 @@ export default [
     arrayRemove,
     arrayReverse,
     arrayShuffle,
+    arraySlice,
 
     // Deprecated
     rawArrayAdd,


### PR DESCRIPTION
### Description of the Change
Adds an `arraySlice` replace variable that lets users easily get a truncated version of an array, also fixed a typo


### Applicable Issues
#2775 


### Testing
Tested the variable with various starts/ends including positive integers, negative integers, decimals, invalid strings, empty strings and undefined, including not including either start or end, and just including start


### Screenshots
n/a


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
