### PR TITLE
fix: Move clips to iframe

### DIFF
--- a/src/backend/effects/builtin/clips.js
+++ b/src/backend/effects/builtin/clips.js
@@ -282,13 +282,13 @@ const clip = {
                     (rotation ? `transform: rotate(${rotation});` : '');
 
                 const videoElement = `
-                    <video autoplay
-                        src="${clipVideoUrl}"
+                    <iframe "style="border: none;${styles}"
+                        src="${clipVideoUrl}&parent=${window.location.hostname}&autoplay=true"
                         height="${height || ""}"
                         width="${width || ""}"
-                        style="border: none;${styles}"
-                        onloadstart="this.volume=${volume}"
-                        allowfullscreen="false" />
+                        frameBorder=0
+                        allowfullscreen>
+                    </iframe>
                 `;
 
                 const positionData = {

--- a/src/backend/effects/builtin/clips.js
+++ b/src/backend/effects/builtin/clips.js
@@ -211,7 +211,7 @@ const clip = {
                 }
 
                 webServer.sendToOverlay("playTwitchClip", {
-                    clipSlug: clip.id,
+                    clipVideoUrl: clip.embedUrl,
                     width: effect.width,
                     height: effect.height,
                     duration: clipDuration,
@@ -277,15 +277,16 @@ const clip = {
                     rotation
                 } = event;
 
-                const styles = (width ? `width: ${width}px;` : '') +
-                    (height ? `height: ${height}px;` : '') +
-                    (rotation ? `transform: rotate(${rotation});` : '');
+                // eslint-disable-next-line prefer-template
+                const styles = `width: ${width || screen.width}px;
+                 height: ${height || screen.height}px;
+                 transform: rotate(${rotation || 0});`;
 
                 const videoElement = `
-                    <iframe "style="border: none;${styles}"
+                    <iframe style="border: none; ${styles}"
                         src="${clipVideoUrl}&parent=${window.location.hostname}&autoplay=true"
-                        height="${height || ""}"
-                        width="${width || ""}"
+                        height="${height || screen.height}"
+                        width="${width || screen.width}"
                         frameBorder=0
                         allowfullscreen>
                     </iframe>

--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -175,7 +175,7 @@ const playVideo = {
             </eos-container>
         </div>
 
-        <eos-container header="Volume" pad-top="true">
+        <eos-container ng-if="effect.videoType != 'Random Twitch Clip' && effect.videoType != 'Twitch Clip'" header="Volume" pad-top="true">
             <div class="volume-slider-wrapper">
                 <i class="fal fa-volume-down volume-low"></i>
                 <rzslider rz-slider-model="effect.volume" rz-slider-options="{floor: 0, ceil: 10, hideLimitLabels: true}"></rzslider>
@@ -486,7 +486,8 @@ const playVideo = {
                 }
             }
 
-            const clipVideoUrl = `${clip.thumbnailUrl.split("-preview-")[0]}.mp4`;
+            //const clipVideoUrl = `${clip.thumbnailUrl.split("-preview-")[0]}.mp4`;
+            const clipVideoUrl = clip.embedUrl;
             const clipDuration = clip.duration;
             const volume = parseInt(effect.volume) / 10;
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
move clips to use twitchs iFrame.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2768

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
tested clip playback in the overlay.

clips will now be gated by CCL [ContentDisplayPreferences](https://help.twitch.tv/s/article/how-to-customize-content?language=en_US#ContentDisplayPreferences)

if streamers would like the gated video to play they will need to interact in the browser object and allow it for the first time. obs then "should" save the choice as a cookie object. 
 
this is out of our control and we do not receive the CCL in the clip endpont data. 

this will not be affected by the https://www.twitch.tv/settings/content-preferences that is unless the browser source is logged in  to twitch in the browser source. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://github.com/user-attachments/assets/43c02f29-00bd-4ec1-8f40-24fdd0971f76)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
