### PR TITLE
fix: frontend error when saving quick action

### DIFF
--- a/src/backend/quick-actions/quick-action-manager.js
+++ b/src/backend/quick-actions/quick-action-manager.js
@@ -51,7 +51,8 @@ class QuickActionManager extends JsonDbManager {
     }
 
     saveQuickAction(quickAction, notify = true) {
-        if (!super.saveItem(quickAction)) {
+        const savedQuickAction = super.saveItem(quickAction);
+        if (!savedQuickAction) {
             return;
         }
         const quickActionSettings = settings.getQuickActionSettings();
@@ -62,7 +63,7 @@ class QuickActionManager extends JsonDbManager {
         if (notify) {
             this.triggerUiRefresh();
         }
-        return true;
+        return savedQuickAction;
     }
 
     deleteQuickAction(customQuickActionId) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Changes the quickActionManager to return the quick action on save, rather than `true | undefined`

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2507

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured quick actions save properly and no longer error into console

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
