### PR TITLE
fix(events): complex manualMetadata being malformed on test event button

### DIFF
--- a/src/backend/events/EventManager.js
+++ b/src/backend/events/EventManager.js
@@ -124,7 +124,7 @@ ipcMain.on("triggerManualEvent", function(_, data) {
         return;
     }
 
-    const meta = event.manualMetadata || {};
+    const meta = structuredClone(event.manualMetadata || {});
     for (const [key, value] of Object.entries(meta)) {
         if (typeof value !== 'object' || value == null || Array.isArray(value) || value.type == null || value.value == null) {
             continue;

--- a/src/backend/events/EventManager.js
+++ b/src/backend/events/EventManager.js
@@ -125,6 +125,12 @@ ipcMain.on("triggerManualEvent", function(_, data) {
     }
 
     const meta = event.manualMetadata || {};
+    for (const [key, value] of Object.entries(meta)) {
+        if (typeof value !== 'object' || value == null || Array.isArray(value) || value.type == null || value.value == null) {
+            continue;
+        }
+        meta[key] = value.value;
+    }
     if (meta.username == null) {
         const accountAccess = require("../common/account-access");
         meta.username = accountAccess.getAccounts().streamer.username;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
 complex manualMetadata eg:
 
           manualMetadata: {
               title: "Poll name"
               choices: {
                    type: "choice-list",
                    value:[
                    { id: "c0113c14-144e-475c-9647-a65f9177665d", title: "Test Choice 1" },
                    { id: "6d86797a-d88a-4fc2-b4f6-1895afdc503e", title: "Test Choice 2" },
                    { id: "791bc06c-c4d5-4c74-b950-8596c04dbb0d", title: "Test Choice 3" }
                ]
               }
            }
 
 
 being malformed on test event button
 this would cause variable data to return the variable name. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2783 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
made many events that leverage Enum and arbitrary data structs to see what the variable data would return in the console log  
 1000 Test message

 Firebot,User1, User2, User3, User4, User5,

 [{"id":"c0113c14-144e-475c-9647-a65f9177665d","index":1,"title":"Test Choice 1","points":62,"votes":125},{"id":"6d86797a-d88a-4fc2-b4f6-1895afdc503e","index":2,"title":"Test Choice 2","points":42,"votes":145},{"id":"791bc06c-c4d5-4c74-b950-8596c04dbb0d","index":3,"title":"Test Choice 3","points":72,"votes":85}]

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
