### PR TITLE
feat: add more events to Effect Queue

### DIFF
--- a/src/backend/effects/queues/effect-queue-runner.js
+++ b/src/backend/effects/queues/effect-queue-runner.js
@@ -142,6 +142,10 @@ class EffectQueue {
 
         logger.debug(`Added more effects to queue ${this.id}. Current length=${this._queue.length}`);
 
+        eventManager.triggerEvent("firebot", "effect-queue-added", {
+            effectQueueId: this.id
+        });
+
         this.sendQueueLengthUpdate();
 
         this.processEffectQueue();
@@ -169,11 +173,21 @@ class EffectQueue {
 
     pauseQueue() {
         logger.debug(`Pausing queue ${this.id}...`);
+
+        eventManager.triggerEvent("firebot", "effect-queue-status", {
+            effectQueueId: this.id
+        });
+
         this._paused = true;
     }
 
     resumeQueue() {
         logger.debug(`Resuming queue ${this.id}...`);
+
+        eventManager.triggerEvent("firebot", "effect-queue-status", {
+            effectQueueId: this.id
+        });
+
         this._paused = false;
         this.processEffectQueue();
     }

--- a/src/backend/events/builtin/firebot-event-source.js
+++ b/src/backend/events/builtin/firebot-event-source.js
@@ -114,6 +114,25 @@ const firebotEventSource = {
             }
         },
         {
+            id: "effect-queue-added",
+            name: "Effect Queue Added",
+            description: "When an new entry added to effect queue.",
+            cached: false,
+            manualMetadata: {
+                queueName: "Just Chatting"
+            }
+        },
+        {
+            id: "effect-queue-status",
+            name: "Effect Queue Status",
+            description: "When an effect queue status changes.",
+            cached: false,
+            manualMetadata: {
+                queueName: "Just Chatting",
+                status: "paused"
+            }
+        },
+        {
             id: "before-firebot-closed",
             name: "Before Firebot Closed",
             description: "Just before firebot is closed",

--- a/src/backend/events/filters/builtin-filter-loader.js
+++ b/src/backend/events/filters/builtin-filter-loader.js
@@ -13,6 +13,7 @@ exports.loadFilters = () => {
         'custom-variable-name',
         'donation-amount',
         'donation-from',
+        'effect-queue',
         'gift-count',
         'gift-duration',
         'is-anonymous',

--- a/src/backend/events/filters/builtin/effect-queue.js
+++ b/src/backend/events/filters/builtin/effect-queue.js
@@ -23,15 +23,13 @@ module.exports = {
         return new Promise((resolve) => {
             resolve(
                 effectQueuesService.getEffectQueues().find((c) => c.id === filterSettings.value)?.name ??
-                    "Unknown Currency"
+                    "Unknown Effect Queue"
             );
         });
     },
     predicate: (filterSettings, eventData) => {
         const { comparisonType, value } = filterSettings;
         const { eventMeta } = eventData;
-        console.log("-".repeat(50));
-        console.log(eventMeta);
 
         const actual = eventMeta.effectQueueId;
         const expected = value;

--- a/src/backend/events/filters/builtin/effect-queue.js
+++ b/src/backend/events/filters/builtin/effect-queue.js
@@ -1,0 +1,48 @@
+"use strict";
+
+module.exports = {
+    id: "firebot:effect-queue",
+    name: "Effect Queue",
+    description: "Filter to a Effect Queue",
+    events: [
+        { eventSourceId: "firebot", eventId: "effect-queue-added" },
+        { eventSourceId: "firebot", eventId: "effect-queue-cleared" },
+        { eventSourceId: "firebot", eventId: "effect-queue-status" }
+    ],
+    comparisonTypes: ["is", "is not"],
+    valueType: "preset",
+    presetValues: (effectQueuesService) => {
+        return effectQueuesService.getEffectQueues().map((c) => ({ value: c.id, display: c.name }));
+    },
+    valueIsStillValid: (filterSettings, effectQueuesService) => {
+        return new Promise((resolve) => {
+            resolve(effectQueuesService.getEffectQueues().some((c) => c.id === filterSettings.value));
+        });
+    },
+    getSelectedValueDisplay: (filterSettings, effectQueuesService) => {
+        return new Promise((resolve) => {
+            resolve(
+                effectQueuesService.getEffectQueues().find((c) => c.id === filterSettings.value)?.name ??
+                    "Unknown Currency"
+            );
+        });
+    },
+    predicate: (filterSettings, eventData) => {
+        const { comparisonType, value } = filterSettings;
+        const { eventMeta } = eventData;
+        console.log("-".repeat(50));
+        console.log(eventMeta);
+
+        const actual = eventMeta.effectQueueId;
+        const expected = value;
+
+        switch (comparisonType) {
+            case "is":
+                return actual === expected;
+            case "is not":
+                return actual !== expected;
+            default:
+                return false;
+        }
+    }
+};

--- a/src/backend/variables/builtin/metadata/effect-queue-name.ts
+++ b/src/backend/variables/builtin/metadata/effect-queue-name.ts
@@ -4,7 +4,7 @@ import { OutputDataType, VariableCategory } from "../../../../shared/variable-co
 import effectQueueManager from "../../../effects/queues/effect-queue-manager";
 
 const triggers = {};
-triggers[EffectTrigger.EVENT] = ["firebot:effect-queue-cleared"];
+triggers[EffectTrigger.EVENT] = ["firebot:effect-queue-cleared", "firebot:effect-queue-added", "firebot:effect-queue-status"];
 triggers[EffectTrigger.MANUAL] = true;
 
 const model: ReplaceVariable = {

--- a/src/backend/variables/builtin/metadata/effect-queue-status.ts
+++ b/src/backend/variables/builtin/metadata/effect-queue-status.ts
@@ -1,6 +1,7 @@
 import { ReplaceVariable } from "../../../../types/variables";
 import { EffectTrigger } from "../../../../shared/effect-constants";
 import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+import effectQueueManager from "../../../effects/queues/effect-queue-manager";
 
 const triggers = {};
 triggers[EffectTrigger.EVENT] = ["firebot:effect-queue-cleared", "firebot:effect-queue-added", "firebot:effect-queue-status"];
@@ -8,15 +9,17 @@ triggers[EffectTrigger.MANUAL] = true;
 
 const model: ReplaceVariable = {
     definition: {
-        handle: "effectQueueId",
-        description: "The ID of the effect queue.",
+        handle: "effectQueueStatus",
+        description: "The status of the effect queue.",
         triggers: triggers,
         categories: [VariableCategory.TRIGGER],
         possibleDataOutput: [OutputDataType.TEXT]
     },
     evaluator: (trigger) => {
         const queueId = trigger?.metadata?.eventData?.effectQueueId;
-        return queueId ?? "Unknown";
+        const effectQueue = effectQueueManager.getItem(queueId);
+
+        return effectQueue?.active ?? "Unknown";
     }
 };
 

--- a/src/backend/variables/builtin/metadata/effect-queue-status.ts
+++ b/src/backend/variables/builtin/metadata/effect-queue-status.ts
@@ -13,13 +13,13 @@ const model: ReplaceVariable = {
         description: "The status of the effect queue.",
         triggers: triggers,
         categories: [VariableCategory.TRIGGER],
-        possibleDataOutput: [OutputDataType.TEXT]
+        possibleDataOutput: [OutputDataType.BOOLEAN, OutputDataType.NULL]
     },
     evaluator: (trigger) => {
         const queueId = trigger?.metadata?.eventData?.effectQueueId;
         const effectQueue = effectQueueManager.getItem(queueId);
 
-        return effectQueue?.active ?? "Unknown";
+        return effectQueue?.active ?? null;
     }
 };
 

--- a/src/backend/variables/builtin/metadata/index.ts
+++ b/src/backend/variables/builtin/metadata/index.ts
@@ -7,6 +7,7 @@ import count from './count';
 import effectOutput from './effect-output';
 import effectQueueId from './effect-queue-id';
 import effectQueueName from './effect-queue-name';
+import effectQueueStatus from './effect-queue-status';
 import overlayInstance from './overlay-instance';
 import presetListArg from './preset-list-arg';
 import user from './user';
@@ -26,6 +27,7 @@ export default [
     effectOutput,
     effectQueueId,
     effectQueueName,
+    effectQueueStatus,
     overlayInstance,
     presetListArg,
     user,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Added `Effect Queue Status` as event that trigger when the status of a queue changes. 
- Added `Effect Queue Added` as a event that triggers when a new item are added to a effect queue.
- Added a filter for  `Effect Queue Status` , `Effect Queue Added` and existing `Effect Queue Cleared`.
- Added new `effectQueueStatus` ReplaceVariable that returns the `true` or `false` or `null` based of the status of the effect queue.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
None

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
- Setup test queue and Chat alert messages to see if it logs correctly
- Filter tested the same way and working


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
- Filters:
![image](https://github.com/user-attachments/assets/34a87c7d-8773-44cc-862b-445ee3ef71b8)
![image](https://github.com/user-attachments/assets/0b49145d-c4dd-483d-8964-9ccc78d76c70)
- Variables:
![image](https://github.com/user-attachments/assets/a5a0c5ed-f18a-4fe8-b899-3706d7ce0b76)
- Add new event
![image](https://github.com/user-attachments/assets/466d4d8f-e387-4505-abd3-f2dbf2967ca5)



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
