### PR TITLE
fix: $hasRole and $hasRoles Usage Examples

### DIFF
--- a/src/backend/variables/builtin/user/roles/has-role.ts
+++ b/src/backend/variables/builtin/user/roles/has-role.ts
@@ -17,12 +17,22 @@ const model : ReplaceVariable = {
     definition: {
         handle: "hasRole",
         usage: "hasRole[user, role]",
-        description: "Returns true if the user has the specified role. Only valid within $if",
+        description: "Returns true if the user has the specified role. Only valid within `$if`",
+        examples: [
+            {
+                usage: "hasRole[user, Moderator]",
+                description: "Returns true if user is a mod"
+            },
+            {
+                usage: "hasRole[user, VIP]",
+                description: "Returns true if user is a VIP"
+            }
+        ],
         triggers: triggers,
         categories: [VariableCategory.COMMON, VariableCategory.USER],
         possibleDataOutput: [OutputDataType.ALL]
     },
-    evaluator: async (trigger, username: string, role: string) => {
+    evaluator: async (_trigger, username: string, role: string) => {
         if (username == null || username === "") {
             return false;
         }
@@ -41,7 +51,7 @@ const model : ReplaceVariable = {
         } catch {
             // Silently fail
         }
-        
+
         return false;
     }
 };

--- a/src/backend/variables/builtin/user/roles/has-roles.ts
+++ b/src/backend/variables/builtin/user/roles/has-roles.ts
@@ -17,7 +17,7 @@ const model : ReplaceVariable = {
     definition: {
         handle: "hasRoles",
         usage: "hasRoles[user, any|all, role, role2, ...]",
-        description: "Returns true if the user has the specified roles. Only valid within $if",
+        description: "Returns true if the user has the specified roles. Only valid within `$if`",
         examples: [
             {
                 usage: "hasRoles[$user, any, Moderator, VIP]",

--- a/src/backend/variables/builtin/user/roles/has-roles.ts
+++ b/src/backend/variables/builtin/user/roles/has-roles.ts
@@ -20,11 +20,11 @@ const model : ReplaceVariable = {
         description: "Returns true if the user has the specified roles. Only valid within $if",
         examples: [
             {
-                usage: "hasRoles[$user, any, mod, vip]",
+                usage: "hasRoles[$user, any, Moderator, VIP]",
                 description: "returns true if $user is a mod OR VIP"
             },
             {
-                usage: "hasRoles[$user, all, mod, vip]",
+                usage: "hasRoles[$user, all, Moderator, VIP]",
                 description: "Returns true if $user is a mod AND a VIP"
             }
         ],
@@ -32,7 +32,7 @@ const model : ReplaceVariable = {
         categories: [VariableCategory.COMMON, VariableCategory.USER],
         possibleDataOutput: [OutputDataType.ALL]
     },
-    evaluator: async (trigger, username: string, respective, ...roles) => {
+    evaluator: async (_trigger, username: string, respective, ...roles) => {
         if (username == null || username === "") {
             return false;
         }
@@ -55,14 +55,14 @@ const model : ReplaceVariable = {
             if (user == null) {
                 return false;
             }
-    
+
             const userRoles = await roleHelpers.getAllRolesForViewer(user.id);
-    
+
             // any
             if (respective === "any") {
                 return userRoles.some(r => roles.includes(r.name));
             }
-    
+
             // all
             return roles.length === userRoles.filter(r => roles.includes(r.name)).length;
         } catch {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes usage examples for `$hasRoles` and adds examples for `$hasRole`.

- Role name comparisons are case-sensitive.
- Moderator and VIP being the actual names from Twitch.
- So reflect those accurately in the examples.
- ... and clear up a few lint warnings (white space, ignored params)

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
Discord #questions thread: [give VIP or Mod role based on metadata?](https://discord.com/channels/372817064034959370/1281786252558991490)

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Minimal

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![hasRoles](https://github.com/user-attachments/assets/8b02d352-a92a-4335-9fe5-015dcc5dc034)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
