### PR TITLE
Expand support for theme engine to support background color in more e…

### DIFF
--- a/src/gui/scss/Light.scss
+++ b/src/gui/scss/Light.scss
@@ -6,13 +6,16 @@ $dark-background-color: #25292a;
 $dark-background-border: #383d3f;
 $dark-background-box-shadow: $dark-background-border;
 
-$content-text-color: #25292a;
-$light-text-color: #808080;
 
 $bad-color: #ff0000;
 $good-color: #90ee90;
 $info-color: #30a6ce;
 $highlight-color: #ebb11f;
+
+$content-text-color: #25292a;
+$content-background-color: $light-background-color;
+$chat-alert-background-color: $info-color;
+$light-text-color: #808080;
 
 // Scrollbar
 $scrollbar-background-color: $medium-background-color;
@@ -42,7 +45,7 @@ $board-settings-btn-color: $light-text-color;
 $change-board-dropdown-color: $light-text-color;
 $downarrow-color: $light-text-color;
 $sort-tags-bg: #d3d3d3;
-
+$effect-def-background-color: #f3f5f5;
 $toggle-button-off-bg-color: #757373;
 
 $change-note-palette-title-color: $light-text-color;

--- a/src/gui/scss/Midnight.scss
+++ b/src/gui/scss/Midnight.scss
@@ -6,12 +6,16 @@ $dark-background-color: #141828;
 $dark-background-border: #2e3240;
 $dark-background-box-shadow: adjust-color($dark-background-color, $red: 7, $green: 7, $blue: 7);
 
-$content-text-color: #ffffff;
 
 $bad-color: #ff0000;
 $good-color: #90ee90;
 $info-color: #30a6ce;
 $highlight-color: #ebb11f;
+
+
+$content-text-color: #ffffff;
+$content-background-color: $light-background-color;
+$chat-alert-background-color: $info-color;
 
 // Scrollbar
 $scrollbar-background-color: rgba(97, 97, 105, 0.58);
@@ -41,7 +45,7 @@ $board-settings-btn-color: #a9a9a9;
 $change-board-dropdown-color: #a9a9a9;
 $downarrow-color: #a9a9a9;
 $sort-tags-bg: #808080;
-
+$effect-def-background-color: #43454A;
 $toggle-button-off-bg-color: #ffffff;
 
 $change-note-palette-title-color: orange;

--- a/src/gui/scss/Obsidian.scss
+++ b/src/gui/scss/Obsidian.scss
@@ -6,12 +6,14 @@ $dark-background-color: #1e2023; //sidebar 1
 $dark-background-border: #2e2f30; //sidebar 2
 $dark-background-box-shadow: adjust-color(#2d2b2b, $red: 7, $green: 7, $blue: 7);
 
-$content-text-color: #ffffff;
-
 $bad-color: #ff0000;
 $good-color: #90ee90;
 $info-color: #30a6ce;
 $highlight-color: #ebb11f;
+
+$content-text-color: #ffffff;
+$content-background-color: $light-background-color;
+$chat-alert-background-color: $info-color;
 
 // Scrollbar
 $scrollbar-background-color: #3e3e40;
@@ -41,7 +43,7 @@ $board-settings-btn-color: #a9a9a9;
 $change-board-dropdown-color: #a9a9a9;
 $downarrow-color: #a9a9a9;
 $sort-tags-bg: #808080;
-
+$effect-def-background-color: #2f3136;
 $toggle-button-off-bg-color: #ffffff;
 
 $change-note-palette-title-color: orange;

--- a/src/gui/scss/core/_chat.scss
+++ b/src/gui/scss/core/_chat.scss
@@ -43,7 +43,7 @@
     display: flex;
     padding: 6px;
     padding-left: 10px;
-    background: rgb(49, 49, 49);
+    background: $chat-alert-background-color;
     border-top: 1px solid #29292988;
 
     span {

--- a/src/gui/scss/core/_effects.scss
+++ b/src/gui/scss/core/_effects.scss
@@ -49,7 +49,7 @@
 
 .effect-def-wrapper {
     border-radius: 8px;
-    background: #43454A;
+    background: $effect-def-background-color;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -109,4 +109,3 @@
     border-radius: 8px;
     background: #68696C;
 }
-

--- a/src/gui/scss/core/_global.scss
+++ b/src/gui/scss/core/_global.scss
@@ -1767,6 +1767,7 @@ thead th{
   padding-bottom: 0;
   font-family: 'Open Sans', sans-serif !important;
   color:$content-text-color;
+  background-color: $content-background-color;
 }
 
 .CodeMirror {


### PR DESCRIPTION
### Description of the Change
Effect list options and chat alerts were not displaying the proper colors based on selected color scheme. Slightly expanded support of the theme system to support background colors for chat alerts and effect list items.

### Applicable Issues
N/A


### Testing
Manual testing by choosing each theme to verify the modified elements are properly displayed.


### Screenshots
![image](https://github.com/user-attachments/assets/24e368e2-37c0-4aba-a34b-7b597a163f7f)
![image](https://github.com/user-attachments/assets/d967d2b9-f795-4ce2-9bd8-e14210bc315f)

