### PR TITLE
fix: ffz and 7tv wide emotes overlap

### DIFF
--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -178,6 +178,7 @@
                                         class="chatEmoticon"
                                         uib-tooltip="{{part.origin}}: {{part.name}}"
                                         tooltip-append-to-body="true"
+                                        style="width: unset;"
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
@@ -188,6 +189,7 @@
                                         class="chatEmoticon"
                                         uib-tooltip="{{part.origin}}: {{part.name}}"
                                         tooltip-append-to-body="true"
+                                        style="width: unset;"
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
remove the width of ffz and 7tv emotes so they display proper
2842

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2842

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
