### PR TITLE
fix: frontend reading incorrect data folder

### DIFF
--- a/src/backend/app-management/electron/window-management.js
+++ b/src/backend/app-management/electron/window-management.js
@@ -13,6 +13,8 @@ const screenHelpers = require("./screen-helpers");
 const frontendCommunicator = require("../../common/frontend-communicator");
 const { settings } = require("../../common/settings-access");
 
+const argv = require('../../common/argv-parser');
+
 setupTitlebar();
 
 
@@ -144,6 +146,12 @@ async function createMainWindow() {
         event.returnValue = false;
     });
 
+    const additionalArguments = [];
+
+    if (Object.hasOwn(argv, 'fbuser-data-directory') && argv['fbuser-data-directory'] != null && argv['fbuser-data-directory'] !== '') {
+        additionalArguments.push(`--fbuser-data-directory=${argv['fbuser-data-directory']}`);
+    }
+
     // Create the browser window.
     const mainWindow = new BrowserWindow({
         x: mainWindowState.x,
@@ -165,7 +173,8 @@ async function createMainWindow() {
             worldSafeExecuteJavaScript: false,
             enableRemoteModule: true,
             sandbox: false,
-            preload: path.join(__dirname, './preload.js')
+            preload: path.join(__dirname, './preload.js'),
+            additionalArguments
         }
     });
     mainWindow.setBounds({
@@ -482,7 +491,7 @@ async function createMainWindow() {
                 type: "question",
                 buttons: ["Close Firebot", "Cancel"]
 
-            }).then(({response}) => {
+            }).then(({ response }) => {
                 if (response === 0) {
                     mainWindow.destroy();
                     global.renderWindow = null;


### PR DESCRIPTION
### Description of the Change
When `--fbuser-data-directory=/path/to/dataFolder` is passed into Firebot, the backend correctly uses this directory. However, the frontend doesn't. Because of this, some things like the profile selector use data from appdata, while the backend uses the specified data path. 

This PR passes the `fbuser-data-folder` parameter into the MainWindow to ensure both frontend and backend are always working on the same data folder.

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the profiles overview shows the profiles for the specified data folder, rather than the appdata folder.