### PR TITLE
fix: menu position for activity feed effect

### DIFF
--- a/src/backend/effects/builtin/activity-feed-alert.ts
+++ b/src/backend/effects/builtin/activity-feed-alert.ts
@@ -25,6 +25,7 @@ const effect: EffectType<{
             use-text-area="true"
             rows="4"
             cols="40"
+            menu-position="under"
         />
     </eos-container> 
     <eos-container header="Icon" pad-top="true">


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Move the variable menu on the "Activity Feed Alert" effect to the bottom position to mitigate any top-clipping

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2833

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the variables menu does not clip visually

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
