### PR TITLE
feat: clear custom role api

### DIFF
--- a/src/server/api/v1/controllers/customRolesApiController.ts
+++ b/src/server/api/v1/controllers/customRolesApiController.ts
@@ -139,3 +139,28 @@ export async function removeUserFromCustomRole(req: Request, res: Response): Pro
 
     return res.status(204).send();
 }
+
+export async function removeAllViewersFromRole(req: Request, res: Response): Promise<Response> {
+    const { customRoleId } = req.params;
+
+
+    if (customRoleId == null) {
+        return res.status(400).send({
+            status: "error",
+            message: `No customRoleId provided`
+        });
+    }
+
+    const customRole = customRolesManager.getCustomRoles().find(cr => cr.id.toLowerCase() === customRoleId.toLowerCase());
+
+    if (customRole == null) {
+        return res.status(404).send({
+            status: "error",
+            message: `Specified custom role does not exist`
+        });
+    }
+
+    customRolesManager.removeAllViewersFromRole(customRole.id);
+
+    return res.status(204).send();
+}

--- a/src/server/api/v1/v1Router.js
+++ b/src/server/api/v1/v1Router.js
@@ -99,6 +99,8 @@ router.route("/customRoles").get(customRoles.getCustomRoles);
 
 router.route("/customRoles/:customRoleId").get(customRoles.getCustomRoleById);
 
+router.route("/customRoles/:customRoleId/clear").get(customRoles.removeAllViewersFromRole);
+
 router
     .route("/customRoles/:customRoleId/viewer/:userId")
     .post(customRoles.addUserToCustomRole)


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adds an API route `/customRoles/:customRoleId/clear` that allows removing all viewers from the custom role

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2483

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured endpoint does proper error checking for role existing, and properly clears role of all viewers
<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
