### PR TITLE
fix: case sensitivity in !permit moderation command

### DIFF
--- a/src/backend/chat/moderation/chat-moderation-manager.js
+++ b/src/backend/chat/moderation/chat-moderation-manager.js
@@ -204,7 +204,12 @@ async function moderateMessage(chatMessage) {
     }
 
     const userExemptForUrlModeration = rolesManager.userIsInRole(chatMessage.userId, chatMessage.roles, chatModerationSettings.urlModeration.exemptRoles);
-    if (chatModerationSettings.urlModeration.enabled && !userExemptForUrlModeration && !permitCommand.hasTemporaryPermission(chatMessage.username)) {
+    if (
+        chatModerationSettings.urlModeration.enabled &&
+        !userExemptForUrlModeration &&
+        !permitCommand.hasTemporaryPermission(chatMessage.username) &&
+        !permitCommand.hasTemporaryPermission(chatMessage.userDisplayName.toLowerCase())
+    ) {
         let shouldDeleteMessage = false;
         const message = chatMessage.rawText;
         const regex = utils.getUrlRegex();

--- a/src/backend/chat/moderation/url-permit-command.ts
+++ b/src/backend/chat/moderation/url-permit-command.ts
@@ -65,7 +65,7 @@ class PermitManager {
                     return;
                 }
 
-                const target = args[0].replace("@", "");
+                const target = args[0].replace("@", "").toLowerCase();
                 if (!target) {
                     await twitchChat.sendChatMessage("Please specify a user to permit.");
                     return;

--- a/src/backend/chat/moderation/url-permit-command.ts
+++ b/src/backend/chat/moderation/url-permit-command.ts
@@ -65,13 +65,14 @@ class PermitManager {
                     return;
                 }
 
-                const target = args[0].replace("@", "").toLowerCase();
+                const target = args[0].replace("@", "");
+                const normalizedTarget = target.toLowerCase();
                 if (!target) {
                     await twitchChat.sendChatMessage("Please specify a user to permit.");
                     return;
                 }
 
-                this._tempPermittedUsers.push(target);
+                this._tempPermittedUsers.push(normalizedTarget);
                 logger.debug(`URL moderation: ${target} has been temporary permitted to post a URL.`);
 
                 const message = commandOptions.permitDisplayTemplate.replace("{target}", target).replace("{duration}", commandOptions.permitDuration.toString());
@@ -81,7 +82,7 @@ class PermitManager {
                 }
 
                 setTimeout(() => {
-                    this._tempPermittedUsers = this._tempPermittedUsers.filter(user => user !== target);
+                    this._tempPermittedUsers = this._tempPermittedUsers.filter(user => user !== normalizedTarget);
                     logger.debug(`URL moderation: Temporary URL permission for ${target} expired.`);
                 }, commandOptions.permitDuration * 1000);
             }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Update the behavior of the !permit command to support case-insensitive input and display names

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2862

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured case-insensitive usernames and displaynames work
Ensured displaynames that are different from the username work