### PR TITLE
fix: toggle-by-tag throwing error if sortTags prop is missing

### DIFF
--- a/src/backend/effects/builtin/cooldown-command.js
+++ b/src/backend/effects/builtin/cooldown-command.js
@@ -215,7 +215,7 @@ const model = {
 
         if (effect.sortTagId != null && effect.selectionType === "sortTag") {
             const commandManager = require("../../chat/commands/command-manager");
-            const commands = commandManager.getAllCustomCommands().filter(c => c.sortTags.includes(effect.sortTagId));
+            const commands = commandManager.getAllCustomCommands().filter(c => c.sortTags?.includes(effect.sortTagId));
             commands.forEach(c => commandIds.push(c.id));
         }
 

--- a/src/backend/effects/builtin/toggle-command.ts
+++ b/src/backend/effects/builtin/toggle-command.ts
@@ -120,7 +120,7 @@ const effect: EffectType<{
             commandManager.saveCustomCommand(customCommand, "System");
         } else if (commandType === "tag") {
             let commands = commandManager.getAllCustomCommands();
-            commands = commands.filter(c => c.sortTags.includes(sortTagId));
+            commands = commands.filter(c => c.sortTags?.includes(sortTagId));
 
             commands.forEach((customCommand) => {
                 customCommand.active = toggleType === "toggle" ? !customCommand.active : toggleType === "enable";

--- a/src/backend/effects/builtin/toggle-scheduled-task.ts
+++ b/src/backend/effects/builtin/toggle-scheduled-task.ts
@@ -103,7 +103,7 @@ const model: EffectType<{
             return true;
         }
 
-        const tasks = scheduledTaskManager.getAllItems().filter(task => task.sortTags.includes(effect.sortTagId));
+        const tasks = scheduledTaskManager.getAllItems().filter(task => task.sortTags?.includes(effect.sortTagId));
 
         tasks.forEach((scheduledTask) => {
             scheduledTask.enabled = effect.toggleType === "toggle" ? !scheduledTask.enabled : effect.toggleType === "enable";

--- a/src/backend/effects/builtin/toggle-timer.ts
+++ b/src/backend/effects/builtin/toggle-timer.ts
@@ -102,7 +102,7 @@ const model: EffectType<{
 
             return true;
         }
-        const timers = timerManager.getAllItems().filter(timer => timer.sortTags.includes(effect.sortTagId));
+        const timers = timerManager.getAllItems().filter(timer => timer.sortTags?.includes(effect.sortTagId));
         timers.forEach((timer) => {
             const isActive = effect.toggleType === "toggle" ? !timer.active : effect.toggleType === "enable";
             timerManager.updateTimerActiveStatus(timer.id, isActive);

--- a/src/backend/effects/builtin/update-channel-reward.ts
+++ b/src/backend/effects/builtin/update-channel-reward.ts
@@ -295,7 +295,7 @@ const model: EffectType<EffectMeta> = {
         }
 
         const rewards = Object.values(channelRewardsManager.channelRewards as Record<string, RewardWithTags>)
-            .filter(reward => reward.sortTags.includes(effect.sortTagId) && reward.manageable);
+            .filter(reward => reward.sortTags?.includes(effect.sortTagId) && reward.manageable);
 
         const promises: Promise<SavedChannelReward>[] = [];
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Update Toggle-by-tag and cooldown-by-tag functionality to handle possible missing sort tags

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2787
#2861 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured toggle-by tag and cooldown-by tag for commands, channel rewards, timers and scheduled effect lists properly ignore any items that are missing the sortTags property