### PR TITLE
fix: poll choice and poll choices showing twice on the UI for simulat…

### DIFF
--- a/src/gui/app/directives/controls/specialized/poll-choice-list.js
+++ b/src/gui/app/directives/controls/specialized/poll-choice-list.js
@@ -22,7 +22,7 @@
                         </span>
                     </div>
                     <p class="muted" ng-show="$ctrl.model.length == 0">No Choices added.</p>
-                    <p class="muted" ng-show="$ctrl.model.length < 2 ">Not enough Choices added.</p>
+                    <p class="muted" ng-show="$ctrl.model.length < 2 && $ctrl.model.length != 0 ">Not enough Choices added.</p>
                     <div class="mx-0 mt-2.5 mb-4">
                         <button ng-if="$ctrl.model.length < 5" class="filter-bar" ng-click="$ctrl.showAddOrEditPollChoiceModal()" uib-tooltip="Add Poll Choice" tooltip-append-to-body="true" aria-label="Add Poll Choice">
                             <i class="far fa-plus"></i>


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
my mistake 
![image](https://github.com/user-attachments/assets/84cdd343-58cd-41fb-a0e0-4c34763ff3e6)
how it should have looked 
![{5E32D9C8-4D3C-4CFA-9FE2-B365B373CFE2}](https://github.com/user-attachments/assets/dbef9e30-8c13-47e4-9525-d7c95cc3f308)

![{AE31411D-9331-43A6-95F1-75EFD78A81A4}](https://github.com/user-attachments/assets/e0887dd3-883b-4c43-9c97-0141044d305c)


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
none i just cought this and fixed it 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
checked that when no choices are added only the one context verbiage is used 
checked that when only 1 choice is added only the correct context verbiage is used. 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
