### PR TITLE
feat (vars): Add $customRoleUsers Property Selector Parameter

### DIFF
--- a/src/backend/variables/builtin/user/roles/custom-role-users.ts
+++ b/src/backend/variables/builtin/user/roles/custom-role-users.ts
@@ -8,7 +8,7 @@ const model : ReplaceVariable = {
         usage: "customRoleUsers[role]",
         description: "Returns an array of all the user display names in the specified custom role.",
         categories: [VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT],
+        possibleDataOutput: [OutputDataType.TEXT, OutputDataType.OBJECT],
         examples: [
             {
                 usage: "customRoleUsers[role, username]",

--- a/src/backend/variables/builtin/user/roles/custom-role-users.ts
+++ b/src/backend/variables/builtin/user/roles/custom-role-users.ts
@@ -8,7 +8,7 @@ const model : ReplaceVariable = {
         usage: "customRoleUsers[role]",
         description: "Returns an array of all the user display names in the specified custom role.",
         categories: [VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT, OutputDataType.OBJECT],
+        possibleDataOutput: [OutputDataType.ARRAY],
         examples: [
             {
                 usage: "customRoleUsers[role, username]",

--- a/src/backend/variables/builtin/user/roles/custom-role-users.ts
+++ b/src/backend/variables/builtin/user/roles/custom-role-users.ts
@@ -6,16 +6,34 @@ const model : ReplaceVariable = {
     definition: {
         handle: "customRoleUsers",
         usage: "customRoleUsers[role]",
-        description: "Returns an array of all the users in the specified custom role.",
+        description: "Returns an array of all the user display names in the specified custom role.",
         categories: [VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT]
+        possibleDataOutput: [OutputDataType.TEXT],
+        examples: [
+            {
+                usage: "customRoleUsers[role, username]",
+                description: "Returns an array of all the user names (instead of *display names*) in the specified custom role."
+            },
+            {
+                usage: "customRoleUsers[role, raw]",
+                description: "Returns an array of user objects (with `displayName`, `id`, and `username` properties) in the specified custom role."
+            }
+        ]
     },
-    evaluator: async (_, role: string) => {
+    evaluator: async (_, role: string, propertyName?: string) => {
         if (role == null || role === '') {
             return [];
         }
 
         const customRole = customRolesManager.getRoleByName(role);
+
+        if (propertyName?.toLowerCase() === "username") {
+            return customRole?.viewers?.map(v => v.username) || [];
+        } else if (propertyName?.toLowerCase() === "id") {
+            return customRole?.viewers?.map(v => v.id) || [];
+        } else if (propertyName?.toLowerCase() === "raw") {
+            return customRole?.viewers || [];
+        }
 
         return customRole?.viewers?.map(v => v.displayName) || [];
     }

--- a/src/backend/variables/builtin/user/roles/custom-role-users.ts
+++ b/src/backend/variables/builtin/user/roles/custom-role-users.ts
@@ -29,8 +29,6 @@ const model : ReplaceVariable = {
 
         if (propertyName?.toLowerCase() === "username") {
             return customRole?.viewers?.map(v => v.username) || [];
-        } else if (propertyName?.toLowerCase() === "id") {
-            return customRole?.viewers?.map(v => v.id) || [];
         } else if (propertyName?.toLowerCase() === "raw") {
             return customRole?.viewers || [];
         }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
`$customRoleUsers` is hard-coded to return user display names for back-compat reasons. This PR adds a property path selector parameter to the `$customRoleUsers` variable to allow for selecting:
- `username` to get the raw usernames, capable of being utilized with `$userMetadata` or for any other purpose.
- `raw` to get raw viewer objects: { `id`: string, `username`: string, `displayName`: string }.

`raw` selectors provides zero immediate benefits to my eye, but *might* be useful someday to someone. You're welcome hypothetical person reading this later. 😆

Additionally, changed the example description for the default usage example to highlight that it yields display names, instead of usernames.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A. Made an untested decision in my Phasmophobia guessing game custom setup, and am trying to correct it.

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
"Yes."

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![customroleusers](https://github.com/user-attachments/assets/a40a9a92-62e7-451b-9ae6-3c02533e7303)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
