### PR TITLE
css: Light Theme Sort Tags Contrast

### DIFF
--- a/src/gui/scss/core/_controls.scss
+++ b/src/gui/scss/core/_controls.scss
@@ -892,7 +892,7 @@ table.fb-table-alt {
         display: flex;
 
         span {
-            background: #808080;
+            background: $sort-tags-bg;
             font-size: 10px;
             line-height: 1.9;
             border-radius: 15px;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
> The start of my CSS arc...
- Expanded sort tags in Light theme were previously #25292a on #808080 which is rather jarring, and somewhat difficult to read.
- Changed them to be #25292a on #d3d3d3 to match the Add Tag button and the collapsed tags button.
- Obsidian and Midnight themes remain entirely unchanged by this.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Verified to the best of my abilities that there were zero side effects of this outside of the intended expanded tags background change.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![sort tags](https://github.com/user-attachments/assets/cfc0b3ab-7c14-4dc9-8f55-73d6f06b604d)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
