### PR TITLE
css: Darken Light Theme $good-color, and Use It

### DIFF
--- a/src/gui/app/directives/modals/backups/restoreBackupModal.js
+++ b/src/gui/app/directives/modals/backups/restoreBackupModal.js
@@ -17,7 +17,7 @@
                     <i class="fad fa-sad-tear" style="font-size: 150px;"></i>
                 </div>
                 <div ng-if="$ctrl.restoreComplete" style="height: 220px;display:flex;justify-content:center;align-items:center;">
-                    <i class="fad fa-check-circle" style="font-size: 150px; color:lightgreen"></i>
+                    <i class="fad fa-check-circle restore-succeeded-check" style="font-size: 150px;"></i>
                 </div>
                 <p ng-if="$ctrl.restoreHasError" style="color:#ed5e5e;">
                     <b>Restore failed because:</b><br>{{$ctrl.errorMessage}}

--- a/src/gui/scss/Light.scss
+++ b/src/gui/scss/Light.scss
@@ -8,7 +8,7 @@ $dark-background-box-shadow: $dark-background-border;
 
 
 $bad-color: #ff0000;
-$good-color: #90ee90;
+$good-color: #10a010;
 $info-color: #30a6ce;
 $highlight-color: #ebb11f;
 

--- a/src/gui/scss/core/_connection-panel.scss
+++ b/src/gui/scss/core/_connection-panel.scss
@@ -69,7 +69,7 @@
         justify-content: center;
         align-items: center;
         &.connected {
-            background: lightgreen;
+            background: $good-color;
         }
         &.disconnected {
             background: grey;

--- a/src/gui/scss/core/_controls.scss
+++ b/src/gui/scss/core/_controls.scss
@@ -655,7 +655,7 @@ table.fb-table-alt {
     border-radius: 10px;
     display: inline-block;
     &.unpaused {
-        background: lightgreen;
+        background: $good-color;
     }
     &.paused {
         background: orange;
@@ -668,7 +668,7 @@ table.fb-table-alt {
     border-radius: 10px;
     display: inline-block;
     &.active {
-        background: lightgreen;
+        background: $good-color;
     }
     &.notactive {
         background: gray;

--- a/src/gui/scss/core/_global.scss
+++ b/src/gui/scss/core/_global.scss
@@ -1940,3 +1940,7 @@ column-resizer {
 .markdown-container > *:last-child {
     margin-bottom: 0;
 }
+
+.restore-succeeded-check {
+  color: $good-color;
+}


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
> My second step into the depths of CSS.

- Darkened the light theme $good-color from #90ee90 to #10a010.
- Added $good-color to restore backup modal success icon.
- Changed connection panel background from lightgreen to $good-color
- Changed (un)paused table-alt background from lightgreen to $good-color
- I DID NOT TEST CHANNEL POINT REWARDS INDICATOR, AS I'M NOT AFFILIATED.
  - But those were impacted by this, and I'm blindly pushing it up regardless.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
# THIS NEEDS FURTHER TESTING
Tested as thoroughly as possible. However, I *can not* verify that the change in channel point rewards status icon color is appropriate.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Connection Status Icons:
![status icons](https://github.com/user-attachments/assets/cc456343-3549-4c94-b8b7-a2ba643c9785)

Command Status Icons:
![command status](https://github.com/user-attachments/assets/c784577d-f324-49b3-8899-725da45a3b49)

Backup Restoration Successful:
![restore success](https://github.com/user-attachments/assets/bde22013-1ed3-4564-9ede-0a9a4c28273c)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
