### PR TITLE
chore: tone down the brightness of the chat alert bg color

### DIFF
--- a/src/gui/scss/Light.scss
+++ b/src/gui/scss/Light.scss
@@ -9,7 +9,7 @@ $dark-background-box-shadow: $dark-background-border;
 
 $bad-color: #ff0000;
 $good-color: #90ee90;
-$info-color: #30a6ce;
+$info-color: #30a6ce40;
 $highlight-color: #ebb11f;
 
 $content-text-color: #25292a;

--- a/src/gui/scss/Midnight.scss
+++ b/src/gui/scss/Midnight.scss
@@ -9,7 +9,7 @@ $dark-background-box-shadow: adjust-color($dark-background-color, $red: 7, $gree
 
 $bad-color: #ff0000;
 $good-color: #90ee90;
-$info-color: #30a6ce;
+$info-color: #30a7ce40;
 $highlight-color: #ebb11f;
 
 

--- a/src/gui/scss/Obsidian.scss
+++ b/src/gui/scss/Obsidian.scss
@@ -8,7 +8,7 @@ $dark-background-box-shadow: adjust-color(#2d2b2b, $red: 7, $green: 7, $blue: 7)
 
 $bad-color: #ff0000;
 $good-color: #90ee90;
-$info-color: #30a6ce;
+$info-color: #30a6ce40;
 $highlight-color: #ebb11f;
 
 $content-text-color: #ffffff;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
the chat alert was WAY to bright and hard to read. 

reducing the alpha of the color while maintaining the color helped with the brightness 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![{BF7BA8E9-A4D1-4C25-A513-036351FEA594}](https://github.com/user-attachments/assets/d507e9e0-2052-4acd-b33c-7f0cc69d102c)
![{5DC37909-47FC-49D2-9562-E1061B91F58A}](https://github.com/user-attachments/assets/13e1125f-d66e-4457-911d-43c61e73af74)
![{9DB1F4B5-3979-4529-B834-39309C272421}](https://github.com/user-attachments/assets/0f276dd0-6c17-4ae3-9586-ea3a381c4b6a)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
