### PR TITLE
fix: url chat Moderation view time

### DIFF
--- a/src/backend/chat/moderation/chat-moderation-manager.js
+++ b/src/backend/chat/moderation/chat-moderation-manager.js
@@ -248,7 +248,7 @@ async function moderateMessage(chatMessage) {
                     const viewerDatabase = require('../../viewers/viewer-database');
                     const viewer = await viewerDatabase.getViewerByUsername(chatMessage.username);
 
-                    const viewerViewTime = viewer.minutesInChannel / 60;
+                    const viewerViewTime = viewer?.minutesInChannel ? viewer?.minutesInChannel / 60 : 0;
                     const minimumViewTime = settings.viewTime.viewTimeInHours;
 
                     if (viewerViewTime <= minimumViewTime) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
fixes 


```
[2024-10-11 05:39:51.0843] - error: [v5.63.2] Unhandled promise rejection 
{
  message: "Cannot read properties of null (reading 'minutesInChannel')",
  stack: "TypeError: Cannot read properties of null (reading 'minutesInChannel')\n" +
    '    at Object.moderateMessage (C:\\Users\\bradt\\AppData\\Local\\firebot\\app-5.63.2\\resources\\app.asar\\build\\backend\\chat\\moderation\\chat-moderation-manager.js:199:51)\n' +
    '    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n' +
    '    at async C:\\Users\\bradt\\AppData\\Local\\firebot\\app-5.63.2\\resources\\app.asar\\build\\backend\\chat\\chat-listeners\\twitch-chat-listeners.js:37:9'
}
```
this only corrects the view time part of this error. 
there is another aspect that i am still trying to figure out

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
part of and only part of #2857

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
posted links from a new account with no view time 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
