### PR TITLE
chore: launch timeout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "request": "attach",
             "port": 9223,
             "webRoot": "${workspaceFolder}",
-            "timeout": 30000
+            "timeout": 90000
         }
     ],
     "compounds": [


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
updates the render debug timeout to be 90 seconds instead of 30
makes sure the debugging can connect, 
Firebots source is on a plater drive for me and sometimes takes just a little longer to connect to the render debug

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
