### PR TITLE
fix: remove carriage return in write to file effect

### DIFF
--- a/src/backend/common/handlers/fileWriterProcessor.js
+++ b/src/backend/common/handlers/fileWriterProcessor.js
@@ -15,7 +15,6 @@ const doesFileExist = (filepath) => {
 
 function removeLines(filepath, lines = []) {
     const contents = fs.readFileSync(filepath, { encoding: "utf8" });
-
     return `${contents
         .split('\n')
         .filter(l => l != null && l.trim() !== "")
@@ -27,7 +26,7 @@ function removeLinesWithText(filepath, text) {
     const contents = fs.readFileSync(filepath, { encoding: "utf8" });
     return `${contents
         .split('\n')
-        .map(l => {
+        .map((l) => {
             return l.replace('\r', "");
         })
         .filter(l => l != null && l.trim() !== "")
@@ -51,14 +50,17 @@ function replaceLinesWithText(filepath, text, replacement) {
     const contents = fs.readFileSync(filepath, { encoding: "utf8" });
     return `${contents
         .split('\n')
+        .map((l) => {
+            return l.replace('\r', "");
+        })
         .filter(l => l != null && l.trim() !== "")
-        .map(l => {
+        .map((l) => {
             return l === text ? replacement : l;
         })
         .join('\n')}\n`;
 }
 
-exports.run = async effect => {
+exports.run = async (effect) => {
     if (effect == null || effect.filepath == null) {
         return;
     }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
remove trailing carriage return in write to file effect for replace line by text where there is an unexpected "\r" on some files. 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2891

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
loaded a file with 
```
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 33 0D 0A 
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 31 0D 0A
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 32 0D 0A
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 39 0D 0A 
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 34 0D 0A
```
```
Test Argument: 3
Test Argument: 1
Test Argument: 2
Test Argument: 5
Test Argument: 4
```
replaced Test Argument: 5  with Test Argument: 9
```
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 33 0A
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 31 0A 
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 32 0A 
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 39 0A 
54 65 73 74 20 41 72 67 75 6D 65 6E 74 3A 20 34 0A
```
```
Test Argument: 3
Test Argument: 1
Test Argument: 2
Test Argument: 9
Test Argument: 4
```
as expected all carriage returns (0D) where removed 
### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![{1C0ED40D-893C-4024-A862-DD49B14AADA1}](https://github.com/user-attachments/assets/2da54620-7f76-46c7-898d-ff973394dbdb)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
