### PR TITLE
feat: Add Some Arg-Less Examples for $user... Variables

### DIFF
--- a/src/backend/variables/builtin/user/user-display-name.ts
+++ b/src/backend/variables/builtin/user/user-display-name.ts
@@ -21,11 +21,11 @@ const model : ReplaceVariable = {
     },
     evaluator: async (trigger, username: string) => {
         if (username == null) {
-            const userDisplayName = trigger.metadata.userDisplayName ?? trigger.metadata.userDisplayName;
+            const userDisplayName = trigger.metadata?.eventData?.userDisplayName ?? trigger.metadata?.userDisplayName;
             if (userDisplayName != null) {
                 return userDisplayName;
             }
-            username = trigger.metadata.username;
+            username = trigger.metadata?.eventData?.username ?? trigger.metadata?.username;
             if (username == null) {
                 return "[No username available]";
             }

--- a/src/backend/variables/builtin/user/user-display-name.ts
+++ b/src/backend/variables/builtin/user/user-display-name.ts
@@ -11,7 +11,13 @@ const model : ReplaceVariable = {
         usage: "userDisplayName[username]",
         description: "Gets the formatted display name for the given username. Searches local viewer DB first, then Twitch API.",
         categories: [VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT]
+        possibleDataOutput: [OutputDataType.TEXT],
+        examples: [
+            {
+                usage: "userDisplayName",
+                description: "The formatted display name of the associated user (if there is one) for the given trigger."
+            }
+        ]
     },
     evaluator: async (trigger, username: string) => {
         if (username == null) {

--- a/src/backend/variables/builtin/user/user-display-name.ts
+++ b/src/backend/variables/builtin/user/user-display-name.ts
@@ -8,14 +8,14 @@ import twitchApi from "../../../twitch-api/api";
 const model : ReplaceVariable = {
     definition: {
         handle: "userDisplayName",
-        usage: "userDisplayName[username]",
-        description: "Gets the formatted display name for the given username. Searches local viewer DB first, then Twitch API.",
+        usage: "userDisplayName",
+        description: "Gets the formatted display name of the associated user (if there is one) for the given trigger.",
         categories: [VariableCategory.USER],
         possibleDataOutput: [OutputDataType.TEXT],
         examples: [
             {
-                usage: "userDisplayName",
-                description: "The formatted display name of the associated user (if there is one) for the given trigger."
+                usage: "userDisplayName[username]",
+                description: "The formatted display name for the given username. Searches local viewer DB first, then Twitch API."
             }
         ]
     },

--- a/src/backend/variables/builtin/user/user-id.ts
+++ b/src/backend/variables/builtin/user/user-id.ts
@@ -21,11 +21,11 @@ const model : ReplaceVariable = {
     },
     evaluator: async (trigger, username: string) => {
         if (username == null) {
-            const userId = trigger.metadata.userid ?? trigger.metadata.userId;
+            const userId = trigger.metadata?.eventData?.userid ?? trigger.metadata?.userId;
             if (userId != null) {
                 return userId;
             }
-            username = trigger.metadata.username;
+            username = trigger.metadata?.eventData?.username ?? trigger.metadata?.username;
             if (username == null) {
                 return "[No username available]";
             }

--- a/src/backend/variables/builtin/user/user-id.ts
+++ b/src/backend/variables/builtin/user/user-id.ts
@@ -8,14 +8,14 @@ import twitchApi from "../../../twitch-api/api";
 const model : ReplaceVariable = {
     definition: {
         handle: "userId",
-        usage: "userId[username]",
-        description: "Gets the user ID for the given username. Searches local viewer DB first, then Twitch API.",
+        usage: "userId",
+        description: "Gets the user ID of the associated user (if there is one) for the given trigger.",
         categories: [VariableCategory.USER],
         possibleDataOutput: [OutputDataType.TEXT],
         examples: [
             {
-                usage: "userId",
-                description: "The user ID of the associated user (if there is one) for the given trigger."
+                usage: "userId[username]",
+                description: "The user ID for the given username. Searches local viewer DB first, then Twitch API."
             }
         ]
     },

--- a/src/backend/variables/builtin/user/user-id.ts
+++ b/src/backend/variables/builtin/user/user-id.ts
@@ -11,7 +11,13 @@ const model : ReplaceVariable = {
         usage: "userId[username]",
         description: "Gets the user ID for the given username. Searches local viewer DB first, then Twitch API.",
         categories: [VariableCategory.USER],
-        possibleDataOutput: [OutputDataType.TEXT]
+        possibleDataOutput: [OutputDataType.TEXT],
+        examples: [
+            {
+                usage: "userId",
+                description: "The user ID of the associated user (if there is one) for the given trigger."
+            }
+        ]
     },
     evaluator: async (trigger, username: string) => {
         if (username == null) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Add argument-less examples to both of the `$userId` and `$userDisplayName` variables, and list them first.
- Break everything about these variables by defaulting to `metadata.eventData...` and falling back to `metadata...`. -Dennis

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2903

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
"Yes"

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![userDisplayName](https://github.com/user-attachments/assets/89091b50-0c4c-40c7-9471-8f289515cedf)
![userID](https://github.com/user-attachments/assets/7497401d-bfdb-418b-8dd8-9cb897d194cd)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
