### PR TITLE
fix: split typo in filters

### DIFF
--- a/src/backend/utility.js
+++ b/src/backend/utility.js
@@ -301,7 +301,7 @@ const findIndexIgnoreCase = (array, element) => {
  * @returns {*|undefined} value at path, defaultValue or undefined
  */
 const extractPropertyWithPath = (obj, path, defaultValue = undefined) => {
-    const propertyPath = path.split("");
+    const propertyPath = path.split(".");
     let data = structuredClone(obj);
     try {
         for (const item of propertyPath) {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->

fixes typo in filters to to prevent the entire name from being an array
### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
