### PR TITLE
feat: Awaitable System TTS

### DIFF
--- a/src/gui/app/directives/settings/categories/tts-settings.js
+++ b/src/gui/app/directives/settings/categories/tts-settings.js
@@ -127,8 +127,8 @@
                     `I'm sorry, ${streamerName}. I'm afraid I can't do that.`
                 ];
 
-                $scope.testTTS = () => {
-                    ttsService.readText(testTTSMessages[Math.floor(Math.random() * testTTSMessages.length)], "default");
+                $scope.testTTS = async () => {
+                    await ttsService.readText(testTTSMessages[Math.floor(Math.random() * testTTSMessages.length)], "default", false);
                 };
 
                 $scope.refreshSliders = function() {


### PR DESCRIPTION
### Awaitable Text-to-Speech
<!-- Please describe your change here -->
- Convert the system Text-to-Speech effect from JS to TS.
  - Add a `boolean | undefined` "wait" property to its effect model, and UI for it.
    - `true`: the speech synthesis is await-able.
      - Enables the effect to mostly work properly in Firebot effect queues.
      - ...excepting queue priorities: SpeechSynthesis API appears to lack insert or reorder functionality.
      - But it *will* wait until after the speech has played out, or been cancelled mid-sentence/removed from the queue by a "Clear Effects" effect.
    - `false | undefined`: current behavior.
- Add a `boolean` "wait" param to the TTS service `readText()` function, and `await` when `true`.
- ~~Add a "read-tts-async" communicator event that behaves much like "read-tts" but await-able.~~

### Revision 2
- Lean into the async.
- Convert "read-tts" communicator event to use async behavior.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
Discord #questions [thread](<https://discord.com/channels/372817064034959370/1323345703279267900>)

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested with a variety of Text-to-Speech effects using mixed TTS sync, TTS async, and "stop-all-sounds" effects, with reasonable results.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![await TTS](https://github.com/user-attachments/assets/6d5a48fe-0b41-4cb7-b47f-8d853399820a)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
