### PR TITLE
fix: Empty Conditional Effects Showing Empty Conditions

### DIFF
--- a/src/gui/app/directives/conditional-effect/conditionDisplay.js
+++ b/src/gui/app/directives/conditional-effect/conditionDisplay.js
@@ -47,7 +47,7 @@
 
                 function getRightSideValueDisplay() {
                     return $q(async resolve => {
-                        if ($ctrl.condition == null || $ctrl.condition.rightSideValue == null) {
+                        if ($ctrl.condition == null || $ctrl.condition.rightSideValue == null || $ctrl.condition.rightSideValue === "") {
                             resolve("[Not Set]");
                         } else {
                             const value = await $injector.invoke($ctrl.conditionType.getRightSideValueDisplay, {}, {
@@ -60,7 +60,7 @@
 
                 function getLeftSideValueDisplay() {
                     return $q(async resolve => {
-                        if ($ctrl.condition == null || $ctrl.condition.leftSideValue == null) {
+                        if ($ctrl.condition == null || $ctrl.condition.leftSideValue == null || $ctrl.condition.leftSideValue === "") {
                             resolve("[Not Set]");
                         } else {
                             const value = await $injector.invoke($ctrl.conditionType.getLeftSideValueDisplay, {}, {
@@ -73,19 +73,19 @@
 
                 $ctrl.$onInit = function() {
                     getRightSideValueDisplay().then(value => {
-                        $ctrl.rightSideValueDisplay = value;
+                        $ctrl.rightSideValueDisplay = value || "[Not Set]";
                     });
                     getLeftSideValueDisplay().then(value => {
-                        $ctrl.leftSideValueDisplay = value;
+                        $ctrl.leftSideValueDisplay = value || "[Not Set]";
                     });
                 };
 
                 $ctrl.$onChanges = function() {
-                    getRightSideValueDisplay().then(value => {
-                        $ctrl.rightSideValueDisplay = value;
+                    getRightSideValueDisplay().then((value) => {
+                        $ctrl.rightSideValueDisplay = value || "[Not Set]";
                     });
-                    getLeftSideValueDisplay().then(value => {
-                        $ctrl.leftSideValueDisplay = value;
+                    getLeftSideValueDisplay().then((value) => {
+                        $ctrl.leftSideValueDisplay = value || "[Not Set]";
                     });
                 };
             }

--- a/src/gui/app/directives/conditional-effect/conditionDisplay.js
+++ b/src/gui/app/directives/conditional-effect/conditionDisplay.js
@@ -46,7 +46,7 @@
                 $ctrl.leftSideValueDisplay = "[Not Set]";
 
                 function getRightSideValueDisplay() {
-                    return $q(async resolve => {
+                    return $q(async (resolve) => {
                         if ($ctrl.condition == null || $ctrl.condition.rightSideValue == null || $ctrl.condition.rightSideValue === "") {
                             resolve("[Not Set]");
                         } else {
@@ -59,7 +59,7 @@
                 }
 
                 function getLeftSideValueDisplay() {
-                    return $q(async resolve => {
+                    return $q(async (resolve) => {
                         if ($ctrl.condition == null || $ctrl.condition.leftSideValue == null || $ctrl.condition.leftSideValue === "") {
                             resolve("[Not Set]");
                         } else {
@@ -72,10 +72,10 @@
                 }
 
                 $ctrl.$onInit = function() {
-                    getRightSideValueDisplay().then(value => {
+                    getRightSideValueDisplay().then((value) => {
                         $ctrl.rightSideValueDisplay = value || "[Not Set]";
                     });
-                    getLeftSideValueDisplay().then(value => {
+                    getLeftSideValueDisplay().then((value) => {
                         $ctrl.leftSideValueDisplay = value || "[Not Set]";
                     });
                 };


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Adding a conditional effect then clearing the text of the condition used to display "[Not Set]" for the condition. This was changed, at some point in time (I'll leave it up to you to track down *when* this change occurred), and the conditions now appear as empty space, at least since Firebot v.5.63.2.

This PR changes it back to how it used to be, and instead displays "[Not Set]" again for empty conditions.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2985 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Thoroughly tested with numerous condition types and values. Only formerly empty display values appear to have been changed, which is a promising sight.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Before:
![before](https://github.com/user-attachments/assets/77a6e7c2-284b-4c23-91c5-d1ab776f6889)

After:
![after](https://github.com/user-attachments/assets/77092dd0-3635-43fb-ad18-69a0615a138c)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
