### PR TITLE
fix: Update Notification className

### DIFF
--- a/src/gui/app/services/notification.service.js
+++ b/src/gui/app/services/notification.service.js
@@ -67,7 +67,7 @@
                         break;
 
                     case NotificationType.UPDATE:
-                        toastClass = "warn";
+                        toastClass = "warning";
                         break;
 
                     case NotificationType.TIP:


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Changes the notification manager service's "update" toast to use the ngToast className of "warning" instead of "warn".

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2997

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
None.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A.

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
