### PR TITLE
feat(variables): Overlay-Resources folder variable. (#2988)

### DIFF
--- a/src/backend/variables/builtin/utility/index.ts
+++ b/src/backend/variables/builtin/utility/index.ts
@@ -12,6 +12,7 @@ import fileRead from './file-read';
 import filesInDirectory from './files-in-directory';
 import loopCount from './loop-count';
 import loopItem from './loop-item';
+import overlayResourcesPath from './overlay-resources-path';
 import quickstore from './quick-store';
 import randomUUID from './random-uuid';
 import runEffect from './run-effect';
@@ -32,6 +33,7 @@ export default [
     filesInDirectory,
     loopCount,
     loopItem,
+    overlayResourcesPath,
     quickstore,
     randomUUID,
     runEffect,

--- a/src/backend/variables/builtin/utility/overlay-resources-path.ts
+++ b/src/backend/variables/builtin/utility/overlay-resources-path.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+import dataAccess from "../../../common/data-access";
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "overlayResourcesPath",
+        usage: "overlayResourcesPath",
+        description: "Evaluate the full path to the overlay-resources folder as a text string. Useful for for when images/sounds/videos are stored in the overlay-resources folder.",
+        examples: [
+            {
+                usage: "overlayResourcesPath[sub, dir, path, image.gif]",
+                description: "Gets the full path to the `/sub/dir/path/image.gif` in the overlay-resources folder as a text string."
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async (trigger, ...values: unknown[]) =>
+        (
+            (values != null || values.length > 0)
+                ? `${path.resolve(dataAccess.getPathInUserData("/overlay-resources"), values.join("/"))}`
+                : dataAccess.getPathInUserData("/overlay-resources")
+        )
+};
+
+export default model;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
add a variable to get the system path of the overlay-resources path
allow traversal of array of paths to be used in play video, play sound, show image and obs;s path effects.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2988

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
$overlayResourcesPath/audio/ding.wav
$overlayResourcesPath[audio, ding.wav]
$overlayResourcesPath[audio/ding.wav]
slash oriantiation dont matter on windows but could be affected on other systems 
both return 

"C:\Users\cky\AppData\Roaming\Firebot\v5\overlay-resources\audio/ding.wav"


path.resolve is um dumb and allows you to go where you should not 
$overlayResourcesPath[/etc/passwd]
n
### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
