### PR TITLE
fix: Toggle Event Effect Chooser Data Typing

### DIFF
--- a/src/backend/effects/builtin/toggle-event.js
+++ b/src/backend/effects/builtin/toggle-event.js
@@ -23,7 +23,7 @@ const chat = {
         </eos-container>
 
         <eos-container header="Event" pad-top="true" ng-show="effect.selectedGroupName">
-            <dropdown-select options="eventOptions[effect.selectedGroupName]" selected="effect.selectedEventId"></dropdown-select>
+            <dropdown-select options="eventOptions[effect.selectedGroupName]" selected="effect.selectedEventId" value-mode="object"></dropdown-select>
         </eos-container>
 
         <eos-container header="Toggle Action" pad-top="true">
@@ -48,6 +48,11 @@ const chat = {
 
             for (const groupEvent of groups[groupId].events) {
                 $scope.eventOptions[group.name][groupEvent.id] = groupEvent.name;
+
+                // Update the effect should the event set have been renamed
+                if ($scope.effect.selectedEventId === groupEvent.id) {
+                    $scope.effect.selectedGroupName = group.name;
+                }
             }
         }
 
@@ -63,14 +68,14 @@ const chat = {
             $scope.effect.toggleType = "disable";
         }
     },
-    optionsValidator: effect => {
+    optionsValidator: (effect) => {
         const errors = [];
         if (effect.selectedEventId == null) {
             errors.push("Please select an event.");
         }
         return errors;
     },
-    onTriggerEvent: async event => {
+    onTriggerEvent: async (event) => {
         const { effect } = event;
         const selectedEvent = eventAccess.getEvent(effect.selectedEventId);
         const isActive = effect.toggleType === "toggle" ? !selectedEvent.active : effect.toggleType === "enable";

--- a/src/gui/app/directives/controls/firebot-select.js
+++ b/src/gui/app/directives/controls/firebot-select.js
@@ -12,7 +12,8 @@
             onUpdate: '&',
             isDisabled: '<',
             rightJustify: "<?",
-            ariaLabel: "@?"
+            ariaLabel: "@?",
+            valueMode: "@?"
         },
         template: `
         <div class="btn-group" uib-dropdown>
@@ -73,8 +74,12 @@
             };
 
             function loadOptions() {
+                if (ctrl.valueMode === "string") {
+                    ctrl.objectMode = false;
+                    return;
+                }
                 const options = ctrl.options;
-                if (!Array.isArray(options) && options instanceof Object) {
+                if (ctrl.valueMode === "object" || !Array.isArray(options) && options instanceof Object) {
                     ctrl.objectMode = true;
                 }
             }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Loading a dropdown-select element with no values available to bind to it previously locked it into string-handling mode.
- This broke the Toggle Event effect on initial creation, which expected object-handling mode, but supplied no initial binding values.
  - As such, the initially saved effect data used the name of the event, instead of the unique ID of it.
- Added an optional one-way "value-mode" attribute to dropdown-select to force it to operate in either object or string mode, or default to prior behavior when unspecified.
- Fixed two arrow-parens.
- Beyond original scope:
  - Have the effect's group name track renaming of event sets, which would cause similar problems in the effect's UI.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3006

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested Toggle Event creation and editing thoroughly, plus a handful of others. I still need to verify whether a similar issue could occur in approximately 4 other places, at which point I'll just tack them on to here sometime tonight.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->

Newly-created effect before:
> {"id":"c99f52f9-2875-48e5-b1c2-3295988887a1","type":"firebot:toggle-event","active":true,"toggleType":"disable","selectedGroupName":"General Events","selectedEventId":"Sub"}

Newly-created effect after:
> {"id":"1fad718c-0da3-4416-aeff-d9894407f0e9","type":"firebot:toggle-event","active":true,"toggleType":"toggle","selectedGroupName":"General Events","selectedEventId":"0eaf3180-ae07-11ed-a61c-31cd9d099aeb"}

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
