### PR TITLE
fix(settings): PersistCustomVariables advanced settings show selection

### DIFF
--- a/src/gui/app/directives/settings/categories/advanced-settings.js
+++ b/src/gui/app/directives/settings/categories/advanced-settings.js
@@ -68,11 +68,11 @@
                     >
                         <firebot-select
                             options="{ true: 'On', false: 'Off' }"
-                            ng-init="persistVariables = settings.getSettings('PersistCustomVariables')"
+                            ng-init="persistVariables = settings.getSetting('PersistCustomVariables')"
                             selected="persistVariables"
                             on-update="settings.saveSetting('PersistCustomVariables', option === 'true')"
                             right-justify="true"
-                            aria-label="enable or disabel persistent Custom Variables"
+                            aria-label="enable or disable persistent Custom Variables"
                         />
                     </firebot-setting>
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
pesky typo removed an extra s 

we dont have a function called `settings.getSettings`


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3011

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
opened the settings menu 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
