### PR TITLE
fix(events): Don't Cache Simulated Events (#2672)

### DIFF
--- a/src/backend/events/EventManager.js
+++ b/src/backend/events/EventManager.js
@@ -146,9 +146,9 @@ ipcMain.on("triggerManualEvent", function(_, data) {
 
 frontendCommunicator.on("simulateEvent", (eventData) => {
     if (Object.keys(eventData.metadata).length > 0) {
-        manager.triggerEvent(eventData.sourceId, eventData.eventId, eventData.metadata, true, eventData.forceRetrigger, true);
+        manager.triggerEvent(eventData.sourceId, eventData.eventId, eventData.metadata, true, false, true);
     } else {
-        manager.triggerEvent(eventData.sourceId, eventData.eventId, null, true, eventData.forceRetrigger, true);
+        manager.triggerEvent(eventData.sourceId, eventData.eventId, null, true, false, true);
     }
 });
 

--- a/src/backend/events/events-router.js
+++ b/src/backend/events/events-router.js
@@ -95,7 +95,7 @@ async function onEventTriggered(event, source, meta, isManual = false, isRetrigg
             }
         }
 
-        if (!isRetrigger && (isSimulation || !isManual) && (eventSetting.customCooldown || event.cached)) {
+        if (!isRetrigger && !isSimulation && !isManual && (eventSetting.customCooldown || event.cached)) {
             let cacheTtlInSecs;
             let cacheMetaKey;
 

--- a/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
+++ b/src/gui/app/directives/modals/events/simulateGroupEventsModal.js
@@ -21,13 +21,6 @@
                         ></searchable-event-dropdown>
                     </div>
 
-                    <div>
-                        <label class="control-fb control--checkbox"> Force event to run <tooltip text="'This will ensure that the simulated event will run, even if a similar event was recently triggered.'"></tooltip>
-                            <input type="checkbox" ng-model="$ctrl.eventData.forceRetrigger">
-                            <div class="control__indicator"></div>
-                        </label>
-                    </div>
-
                     <div ng-if="$ctrl.metadata">
                         <command-option
                             ng-repeat="data in $ctrl.metadata"
@@ -54,8 +47,7 @@
                 $ctrl.eventData = {
                     eventId: null,
                     sourceId: null,
-                    metadata: {},
-                    forceRetrigger: false
+                    metadata: {}
                 };
                 $ctrl.eventError = false;
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Revert #1889
  - Removes the "Force event to run" checkbox in the Simulate Event modal.
- Disable event caching for simulated events.
  - This impacts only simulation of: follow, raid, reward redemption, and viewer arrived event types. Nothing else was using the event cache (in core).

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2672
#1782

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
~~Minimal (it works), but I need to submit this first and rouse some troops together for more depth and breadth of testing.~~
Live events and simulated events behave appropriately. Follow/unfollow/follow (and raid) spam hits the caching layer (one event gets through per 12 hrs), before and/or after a simulation with the same data.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
New (old) simulate dialog:
![2672](https://github.com/user-attachments/assets/8788f473-ab18-4aae-a06b-b3ada5b41ee6)

Log of simulating two raids from the same user in quick succession:
![2672-multi-simulate-log](https://github.com/user-attachments/assets/e39872be-d734-4162-ba55-e09010cb813b)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
