### PR TITLE
feat(chat UI): Custom Chat Message Fonts (#2955)

### DIFF
--- a/src/backend/font-manager.ts
+++ b/src/backend/font-manager.ts
@@ -3,7 +3,9 @@ import path from "path";
 import logger from "./logwrapper";
 import frontendCommunicator from "./common/frontend-communicator";
 import profileManager from "./common/profile-manager";
+import { SettingsManager } from "./common/settings-manager";
 import webServer from "../server/http-server-manager";
+import { FirebotSettingsDefaults } from "../types/settings";
 
 export enum FontFormat {
     TrueType = "truetype",
@@ -133,6 +135,11 @@ class FontManager {
         const font = this.cachedFonts.find(f => f.name === name);
 
         if (font != null) {
+            if (SettingsManager.getSetting("ChatCustomFontFamily") === name) {
+                SettingsManager.saveSetting("ChatCustomFontFamily", FirebotSettingsDefaults.ChatCustomFontFamily);
+                SettingsManager.saveSetting("ChatCustomFontFamilyEnabled", false);
+            }
+
             try {
                 await fsp.unlink(font.path);
                 this.cachedFonts.splice(this.cachedFonts.indexOf(font), 1);

--- a/src/gui/app/controllers/chat-messages.controller.js
+++ b/src/gui/app/controllers/chat-messages.controller.js
@@ -85,6 +85,10 @@
                 $scope.customFontSize = settingsService.getSetting("ChatCustomFontSize");
                 $scope.customFontSizeStyle = $scope.customFontSizeEnabled ?
                     `font-size: ${$scope.customFontSize}px !important;` : "";
+                $scope.customFontFamilyEnabled = settingsService.getSetting("ChatCustomFontFamilyEnabled");
+                $scope.customFontFamily = settingsService.getSetting("ChatCustomFontFamily");
+                $scope.customFontFamilyStyle = $scope.customFontFamilyEnabled ?
+                    `font-family: '${$scope.customFontFamily}', 'Open Sans', sans-serif !important;` : "";
             }
             getUpdatedChatSettings();
 

--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -17,7 +17,8 @@
                 disableInteractions: "<?",
                 updateChatInput: "&?",
                 onReplyClicked: "&?",
-                chatSizeStyle: "@?"
+                chatSizeStyle: "@?",
+                fontFamilyStyle: "@?"
             },
             template: `
                 <div class="chat-message-wrapper">
@@ -137,7 +138,7 @@
                             <div class="chatContent">
                                 <span ng-repeat="part in $ctrl.message.parts" class="chat-content-wrap">
 
-                                    <span ng-if="part.type === 'text'" style="{{$ctrl.chatSizeStyle}}" ng-class="{ highlightText: part.flagged }">{{part.text}}</span>
+                                    <span ng-if="part.type === 'text'" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}" ng-class="{ highlightText: part.flagged }">{{part.text}}</span>
 
                                     <a ng-if="part.type === 'link'" style="{{$ctrl.chatSizeStyle}}" ng-href="{{part.url}}" target="_blank">{{part.text}}</a>
 
@@ -150,7 +151,7 @@
                                         <img ng-if="part.animatedUrl != '' && part.animatedUrl != null" ng-src="{{part.animatedUrl}}" style="height: 100%;">
                                         <img ng-if="part.animatedUrl == '' || part.animatedUrl == null" ng-src="{{part.url}}" style="height: 100%;">
                                     </span>
-                                    <span ng-if="part.type === 'cheer'" style="{{$ctrl.chatSizeStyle}}; font-weight: bold;" ng-style="{ color: part.color }" >{{part.amount}}</span>
+                                    <span ng-if="part.type === 'cheer'" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}; font-weight: bold;" ng-style="{ color: part.color }" >{{part.amount}}</span>
 
                                     <span
                                         ng-if="part.type === 'emote'"
@@ -171,7 +172,7 @@
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
-                                    <span ng-if="part.origin === 'BTTV' && !$ctrl.showBttvEmotes" style="{{$ctrl.chatSizeStyle}}">{{part.name}}</span>
+                                    <span ng-if="part.origin === 'BTTV' && !$ctrl.showBttvEmotes" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}">{{part.name}}</span>
 
                                     <span
                                         ng-if="part.origin === 'FFZ' && $ctrl.showFfzEmotes"
@@ -182,7 +183,7 @@
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
-                                    <span ng-if="part.origin === 'FFZ' && !$ctrl.showFfzEmotes" style="{{$ctrl.chatSizeStyle}}">{{part.name}}</span>
+                                    <span ng-if="part.origin === 'FFZ' && !$ctrl.showFfzEmotes" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}">{{part.name}}</span>
 
                                     <span
                                         ng-if="part.origin === '7TV' && $ctrl.showSevenTvEmotes"
@@ -193,7 +194,7 @@
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
-                                    <span ng-if="part.origin === '7TV' && !$ctrl.showSevenTvEmotes" style="{{$ctrl.chatSizeStyle}}">{{part.name}}</span>
+                                    <span ng-if="part.origin === '7TV' && !$ctrl.showSevenTvEmotes" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}">{{part.name}}</span>
                                 </span>
                             </div>
                             <div ng-show="$ctrl.message.whisper" class="muted">(Whispered to {{ $ctrl.message.whisperTarget }})</div>

--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -140,7 +140,7 @@
 
                                     <span ng-if="part.type === 'text'" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}" ng-class="{ highlightText: part.flagged }">{{part.text}}</span>
 
-                                    <a ng-if="part.type === 'link'" style="{{$ctrl.chatSizeStyle}}" ng-href="{{part.url}}" target="_blank">{{part.text}}</a>
+                                    <a ng-if="part.type === 'link'" style="{{$ctrl.chatSizeStyle}}{{$ctrl.fontFamilyStyle}}" ng-href="{{part.url}}" target="_blank">{{part.text}}</a>
 
                                     <span
                                         ng-if="part.type === 'cheer'"

--- a/src/gui/app/directives/modals/chat/chat-settings-modal.js
+++ b/src/gui/app/directives/modals/chat/chat-settings-modal.js
@@ -107,17 +107,6 @@
                         ></chat-settings-toggle>
 
                         <chat-settings-toggle
-                            setting="settings.getSetting('ChatCustomFontSizeEnabled')"
-                            title="Show Custom Font Size"
-                            input-id="showCustomFontSize"
-                            on-update="toggleCustomFontEnabled()"
-                        ></chat-settings-toggle>
-
-                        <div class="volume-slider-wrapper" ng-show="settings.getSetting('ChatCustomFontSizeEnabled')">
-                            <rzslider rz-slider-model="customFontSize" rz-slider-options="fontSliderOptions"></rzslider>
-                        </div>
-
-                        <chat-settings-toggle
                             setting="settings.getSetting('ChatCustomFontFamilyEnabled')"
                             title="Use Custom Font"
                             input-id="showCustomFontFamily"
@@ -136,6 +125,17 @@
                                 </ui-select-choices>
                             </ui-select>
                             <p class="muted mt-1"><small>You can add or remove custom fonts via Settings > Overlay > Manage Fonts.</small></p>
+                        </div>
+
+                        <chat-settings-toggle
+                            setting="settings.getSetting('ChatCustomFontSizeEnabled')"
+                            title="Show Custom Font Size"
+                            input-id="showCustomFontSize"
+                            on-update="toggleCustomFontEnabled()"
+                        ></chat-settings-toggle>
+
+                        <div class="volume-slider-wrapper" ng-show="settings.getSetting('ChatCustomFontSizeEnabled')">
+                            <rzslider rz-slider-model="customFontSize" rz-slider-options="fontSliderOptions"></rzslider>
                         </div>
                     </div>
 

--- a/src/gui/app/directives/modals/chat/chat-settings-modal.js
+++ b/src/gui/app/directives/modals/chat/chat-settings-modal.js
@@ -116,6 +116,27 @@
                         <div class="volume-slider-wrapper" ng-show="settings.getSetting('ChatCustomFontSizeEnabled')">
                             <rzslider rz-slider-model="customFontSize" rz-slider-options="fontSliderOptions"></rzslider>
                         </div>
+
+                        <chat-settings-toggle
+                            setting="settings.getSetting('ChatCustomFontFamilyEnabled')"
+                            title="Use Custom Font"
+                            input-id="showCustomFontFamily"
+                            on-update="toggleCustomFontFamilyEnabled()"
+                        ></chat-settings-toggle>
+
+                        <div ng-show="settings.getSetting('ChatCustomFontFamilyEnabled')">
+                            <ui-select ng-model="customFontFamily" on-select="fontFamilyUpdated($item)" class="mt-3" theme="bootstrap">
+                                <ui-select-match placeholder="Select or search for a font…">{{customFontFamily}}</ui-select-match>
+                                <ui-select-choices style="position; relative;" repeat="fontName in fontFamilies | filter: $select.search">
+                                    <div style="display: flex; align-items: center;">
+                                        <span class="mr-2" ng-bind-html="fontName | highlight: $select.search"></span>
+                                        &mdash;
+                                        <span class="ml-2" style="{{chatFontSampleStyle(fontName)}}">{{fontName}}</span>
+                                    </div>
+                                </ui-select-choices>
+                            </ui-select>
+                            <p class="muted mt-1"><small>You can add or remove custom fonts via Settings > Overlay > Manage Fonts.</small></p>
+                        </div>
                     </div>
 
                     <!-- Emote Settings -->
@@ -191,7 +212,7 @@
                 close: "&",
                 dismiss: "&"
             },
-            controller: function($scope, $rootScope, $timeout, settingsService, soundService, chatMessagesService) {
+            controller: function($scope, $rootScope, $timeout, settingsService, soundService, chatMessagesService, fontManager) {
                 const $ctrl = this;
 
                 $scope.settings = settingsService;
@@ -285,6 +306,23 @@
                     ceil: 30,
                     translate: value => `${value}px`,
                     onChange: $scope.fontSizeUpdated
+                };
+
+                $scope.fontFamilies = ['Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Helvetica', 'Impact', 'Inter', 'Open Sans', 'Roboto', 'Tahoma', 'Times New Roman', 'Verdana']
+                    .concat(fontManager.getInstalledFonts().map(f => f.name))
+                    .sort((a, b) => a.localeCompare(b));
+                $scope.customFontFamily = settingsService.getSetting("ChatCustomFontFamily");
+                $scope.toggleCustomFontFamilyEnabled = function () {
+                    settingsService.saveSetting("ChatCustomFontFamilyEnabled", !settingsService.getSetting("ChatCustomFontFamilyEnabled"));
+                };
+                $scope.chatFontSampleStyle = function (fontName) {
+                    const fontStyle = `font-family: '${fontName}', 'Open Sans', sans-serif !important;`;
+                    const sizeStyle = settingsService.getSetting('ChatCustomFontSizeEnabled')
+                        ? `font-size: ${$scope.customFontSize}px !important;` : "";
+                    return `${fontStyle}${sizeStyle}`;
+                };
+                $scope.fontFamilyUpdated = function(fontName) {
+                    settingsService.saveSetting("ChatCustomFontFamily", fontName);
                 };
 
                 $ctrl.$onInit = () => {

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -75,6 +75,7 @@
             update-chat-input="updateChatInput(text)"
             on-reply-clicked="onReplyClicked(threadOrReplyMessageId)"
             chat-size-style="{{customFontSizeStyle}}"
+            font-family-style="{{customFontFamilyStyle}}"
           />
           <reward-redemption
             ng-if="chatItem.type === 'redemption'"
@@ -110,6 +111,7 @@
               hide-reply-banner="true"
               disable-interactions="true"
               chat-size-style="{{customFontSizeStyle}}"
+              font-family-style="{{customFontFamilyStyle}}"
             />
         </div>
         <div class="thread-replying-to" ng-if="cms.threadDetails.replyToMessageId != cms.threadDetails.threadParentMessageId">

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -29,6 +29,8 @@ export type FirebotSettingsTypes = {
     ChatAlternateBackgrounds: boolean;
     ChatAvatars: boolean;
     ChatCompactMode: boolean;
+    ChatCustomFontFamily: string;
+    ChatCustomFontFamilyEnabled: boolean;
     ChatCustomFontSize: number;
     ChatCustomFontSizeEnabled: boolean;
     ChatHideBotAccountMessages: boolean;
@@ -135,6 +137,8 @@ export const FirebotSettingsDefaults: FirebotSettingsTypes = {
     ChatAlternateBackgrounds: true,
     ChatAvatars: true,
     ChatCompactMode: false,
+    ChatCustomFontFamily: "Open Sans",
+    ChatCustomFontFamilyEnabled: false,
     ChatCustomFontSize: 17,
     ChatCustomFontSizeEnabled: false,
     ChatHideBotAccountMessages: false,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Add a Use Custom Font toggle to chat settings. This expands to reveal a searching ui-select font chooser for chat message text.
- This custom font is used for message text, and not URLs, alerts, usernames, or in any other areas besides message and replying-to text.
- The ui-select-choices displays the font name, an emdash, and the stylized font name in *that* font face, in the custom size when enabled.
- Added two settings:
  - `ChatCustomFontFamily` string, with the name of the font to use.
  - `ChatCustomFontFamilyEnabled` boolean, whether or not to use a custom font face.
- The 12 default fonts are included in the available list, and more can be added through the Overlay Settings.
- Without more ancillary work in font manager, there's no way to choose font-style for the default fonts, and summernote is out of place here.
  - Custom font styles (bold, italic, bold-italic, etc.) can be loaded and work, but no 'Open Sans' Bold, or the like.


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#2955

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
- Deleted in-use font in-app resets back to Open Sans
- Deleted font file from appdata profile, font remains loaded and usable
  - Restarting Firebot then falls back to Open Sans
- Long font names/excessive sizes truncate appropriately in the modal
- Replies and threading all appear appropriate
- Chat alerts, pronouns, time stamps, tooltips, URLs, and user names are all unchanged
- Spaces in font file names
- A lot of other edge cases that I can't even recall to enumerate here

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Chat Settings Modal:
![modal preview](https://github.com/user-attachments/assets/be5dfa17-541e-4ec4-95e0-d31fea44709a)

Replying:
![reply-preview](https://github.com/user-attachments/assets/aa79acfd-7a2c-48d0-845e-45593784b7cd)

Adjustable, and Modern/Compact friendly:
![changed preview](https://github.com/user-attachments/assets/9aa46283-6f11-4b28-8e5f-454d5725a321)

Edit: URLs are now included in the custom font:
![URLS](https://github.com/user-attachments/assets/73f02c1e-8cdd-4400-a283-a9a589a10c76)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
