### PR TITLE
fix(effects): File Writer Newline Escapes (#3025)

### DIFF
--- a/src/backend/common/handlers/fileWriterProcessor.js
+++ b/src/backend/common/handlers/fileWriterProcessor.js
@@ -66,7 +66,9 @@ exports.run = async (effect) => {
     }
 
     let text = effect.text || "";
+    text = text.replace(/\\\\n/g, "␚");
     text = effect.writeMode === "suffix" ? text.replace(/\\n/g, "\n") : text.replace(/\\n/g, "\n").trim();
+    text = text.replace(/␚/g, "\\n");
 
     try {
         if (effect.writeMode === "suffix") {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Update the Write to File effect's newline mangling:
- Replaces `backlash n` in the effect text with a literal newline.
- Replaces `backslash backslash n` in the text with a `backslash n`.
- Temporarily uses the `sub`, ASCII 1A (base 16) 26 (base 10), or html `&#26;` character for temporary staging to skip over the newline regex.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3025

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Thoroughly wrote several newlines and `backslash n` characters to files, as desired.
Only downside: no one will be able to intentionally write a `sub` / html `&#26;` character to a file afterwards.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
