### PR TITLE
fix(sortTags): sort tag row for channel rewards. (#3031)

### DIFF
--- a/src/gui/app/directives/controls/sort-tags-row.js
+++ b/src/gui/app/directives/controls/sort-tags-row.js
@@ -97,14 +97,17 @@
                 };
 
                 $ctrl.addSortTag = (sortTag) => {
-                    if (!$ctrl.item.sortTags.some(id => id === sortTag.id)) {
+                    if (!$ctrl.item.sortTags?.some(id => id === sortTag.id)) {
+                        if ($ctrl.item.sortTags == null) {
+                            $ctrl.item.sortTags = [];
+                        }
                         $ctrl.item.sortTags.push(sortTag.id);
                         $ctrl.onUpdate();
                     }
                 };
 
                 $ctrl.toggleSortTag = (sortTag) => {
-                    if ($ctrl.item.sortTags.some(id => id === sortTag.id)) {
+                    if ($ctrl.item.sortTags?.some(id => id === sortTag.id)) {
                         $ctrl.removeSortTag(sortTag.id);
                     } else {
                         $ctrl.addSortTag(sortTag);


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
after the sort tag lift [6a9006a](https://github.com/crowbartools/Firebot/commit/6a9006ad5270d66b7aac508616f1035f16f26634) (to be clear all commits prior to this one work as expected)
"new" channel rewards or rewards that dont have the `"sortTags": []` value already saved in the channel-rewards.json would fail to set the new tags. 

there is something else going on here but i could not find why 
if on initialize of the control we are setting 
[$ctrl.item.sortTags = [];](https://github.com/crowbartools/Firebot/blob/837111e087333515c4e7c7e880e2a367e0fe2c26/src/gui/app/directives/controls/sort-tags-row.js#L116)
but its forgetting that we set the empty string array at [L107](https://github.com/crowbartools/Firebot/blob/837111e087333515c4e7c7e880e2a367e0fe2c26/src/gui/app/directives/controls/sort-tags-row.js#L107)

while this works i feel there is a more severe underlying issue that i'm unable to see 
### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3031

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->

removed all `"sortTags": []` from the channel-rewards.json and tried to add back a tag.
the tag was added and saved appropatly 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
