### PR TITLE
fix: regressions in filter rework (#3060) (#3064)

### DIFF
--- a/src/backend/events/filters/builtin/twitch/gift-count.ts
+++ b/src/backend/events/filters/builtin/twitch/gift-count.ts
@@ -6,7 +6,7 @@ const filter = createNumberFilter({
     description: "Filter by the number of subs gifted",
     eventMetaKey: "subCount",
     events: [
-        { eventSourceId: "twitch", eventId: "subs-gifted" }
+        { eventSourceId: "twitch", eventId: "community-subs-gifted" }
     ]
 });
 

--- a/src/backend/events/filters/builtin/twitch/sub-type.ts
+++ b/src/backend/events/filters/builtin/twitch/sub-type.ts
@@ -12,6 +12,7 @@ const filter = createPresetFilter({
         { eventSourceId: "twitch", eventId: "gift-sub-upgraded" }
     ],
     eventMetaKey: "subPlan",
+    allowIsNot: true,
     presetValues: () => [
         {
             value: "Prime",


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Restore the 'is not' comparison for the sub tier event filter
Restore the gift count filter event ID

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3060
#3064

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured both the 'is' and 'is not' comparisons function as expected by simulating the "Sub" event and going through all tiers