### PR TITLE
fix(queue): Effect Errors Shouldn't Break Queues (#3066)

### DIFF
--- a/src/backend/common/effect-runner.js
+++ b/src/backend/common/effect-runner.js
@@ -106,16 +106,20 @@ function triggerEffect(effect, trigger, outputs, manualAbortSignal, listAbortSig
 
         logger.debug(`Running ${effect.type}(${effect.id}) effect...`);
 
-        const result = await effectDef.onTriggerEvent({
-            effect,
-            trigger,
-            sendDataToOverlay,
-            outputs,
-            abortSignal: AbortSignal.any([signal, listAbortSignal])
-        });
+        try {
+            const result = await effectDef.onTriggerEvent({
+                effect,
+                trigger,
+                sendDataToOverlay,
+                outputs,
+                abortSignal: AbortSignal.any([signal, listAbortSignal])
+            });
 
-        if (!signal.aborted) {
-            return resolve(result);
+            if (!signal.aborted) {
+                return resolve(result);
+            }
+        } catch (error) {
+            return reject(error);
         }
     });
 }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Propagate effect errors by rejecting them.
- Previous behavior broke queues anytime an effect excepted inside of one without a duration specified.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3066 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
"yes" -#firebot-experts

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
