### PR TITLE
fix(ui): Emote Overlaps Text (#3069)

### DIFF
--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -168,7 +168,6 @@
                                         class="chatEmoticon"
                                         uib-tooltip="{{part.origin}}: {{part.name}}"
                                         tooltip-append-to-body="true"
-                                        style="width: unset;"
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
@@ -179,7 +178,6 @@
                                         class="chatEmoticon"
                                         uib-tooltip="{{part.origin}}: {{part.name}}"
                                         tooltip-append-to-body="true"
-                                        style="width: unset;"
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>
@@ -190,7 +188,6 @@
                                         class="chatEmoticon"
                                         uib-tooltip="{{part.origin}}: {{part.name}}"
                                         tooltip-append-to-body="true"
-                                        style="width: unset;"
                                     >
                                         <img ng-src="{{part.url}}" style="height: 100%;" />
                                     </span>

--- a/src/gui/scss/core/_chat.scss
+++ b/src/gui/scss/core/_chat.scss
@@ -156,7 +156,6 @@
         .chatEmoticon {
             position: relative;
             height: 28px;
-            width: 28px;
             display: inline-block;
         }
         .highlightText {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Twitch revised certain global emotes to be rectangular.
- This broke our fixed-width CSS for it, causing emotes to overlap text.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3069 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested with numerous emotes around packed text.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Twitch web chat view:
![twitch-view](https://github.com/user-attachments/assets/02e6a481-92e3-4ea4-9356-8acb3e268a8e)

Firebot (condensed) view:
![firebot-view](https://github.com/user-attachments/assets/53cc720e-b12b-4175-a931-879422a7b141)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
