### PR TITLE
chore: De-duplicate Parens for Malformed AutoMod Reasons

### DIFF
--- a/src/backend/chat/chat-helpers.ts
+++ b/src/backend/chat/chat-helpers.ts
@@ -540,7 +540,7 @@ class FirebotChatHelpers {
             roles: [],
             isAutoModHeld: true,
             autoModStatus: "pending",
-            autoModReason: (msg.reason === "automod" ? msg.automod?.category : msg.reason === "blocked_term" ? "blocked term" : null) ?? "(unknown)",
+            autoModReason: (msg.reason === "automod" ? msg.automod?.category : msg.reason === "blocked_term" ? "blocked term" : null) ?? "unknown",
             isSharedChatMessage: false // todo: check if automod messages have a way to associate them with shared chat
         };
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Parens are added in the [frontend](<https://github.com/crowbartools/Firebot/blob/8ccad4702fdcb4766262d95325149dd9a20f9d9c/src/gui/app/directives/chat/feed%20items/chat-message.js#L203>), there's no need to duplicate them here.
- This shouldn't actually be seen, but ~~if~~ *when* something breaks, it'll look a smidge better.
- "Move fast and break things" can unfortunately result in some broken things.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A