### PR TITLE
fix(variables): `$arraySlice` "end" parameter can misinterpret the number `0` (#3078)

### DIFF
--- a/src/backend/variables/builtin/array/array-slice.ts
+++ b/src/backend/variables/builtin/array/array-slice.ts
@@ -1,5 +1,5 @@
-import { ReplaceVariable, Trigger } from "../../../../types/variables";
 import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+import { ReplaceVariable, Trigger } from "../../../../types/variables";
 
 const model : ReplaceVariable = {
     definition: {
@@ -15,7 +15,7 @@ const model : ReplaceVariable = {
         start?: string | number,
         end?: string | number
     ) : unknown[] => {
-        if (typeof subject === 'string' || subject instanceof String) {
+        if (typeof subject === "string" || subject instanceof String) {
             try {
                 subject = JSON.parse(`${subject}`);
             } catch (ignore) {
@@ -26,12 +26,12 @@ const model : ReplaceVariable = {
             return [];
         }
 
-        start = start ? Number(start) : 0;
+        start = start !== "" ? Number(start) : 0;
         if (Number.isNaN(start)) {
             start = 0;
         }
 
-        end = end ? Number(end) : subject.length;
+        end = end !== "" ? Number(end) : subject.length;
         if (Number.isNaN(end)) {
             end = subject.length;
         }

--- a/src/backend/variables/builtin/array/array-slice.ts
+++ b/src/backend/variables/builtin/array/array-slice.ts
@@ -1,5 +1,5 @@
-import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
 import { ReplaceVariable, Trigger } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
 
 const model : ReplaceVariable = {
     definition: {
@@ -15,7 +15,7 @@ const model : ReplaceVariable = {
         start?: string | number,
         end?: string | number
     ) : unknown[] => {
-        if (typeof subject === "string" || subject instanceof String) {
+        if (typeof subject === 'string' || subject instanceof String) {
             try {
                 subject = JSON.parse(`${subject}`);
             } catch (ignore) {
@@ -26,12 +26,12 @@ const model : ReplaceVariable = {
             return [];
         }
 
-        start = start !== "" ? Number(start) : 0;
+        start = start ? Number(start) : 0;
         if (Number.isNaN(start)) {
             start = 0;
         }
 
-        end = end !== "" ? Number(end) : subject.length;
+        end = end ? Number(end) : subject.length;
         if (Number.isNaN(end)) {
             end = subject.length;
         }


### PR DESCRIPTION
### Description of the Change
A ternary operator in the renderer for `$arraySlice` was returning falsey when 0 was passed in as a parameter and causing incorrect outputs as a result, this simply fixes the method to properly check for empty strings.


### Applicable Issues
#3078 


### Testing
Tested with `0` in both "start" and "end" fields of `$arraySlice`, as well as checking other values to ensure no regressions


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
