### PR TITLE
fix(effects): Condition of 0 was displaying as [Not Set] (#3086)

### DIFF
--- a/src/gui/app/directives/conditional-effect/conditionDisplay.js
+++ b/src/gui/app/directives/conditional-effect/conditionDisplay.js
@@ -47,7 +47,7 @@
 
                 function getRightSideValueDisplay() {
                     return $q(async (resolve) => {
-                        if ($ctrl.condition == null || $ctrl.condition.rightSideValue == null || $ctrl.condition.rightSideValue === "") {
+                        if ($ctrl.condition == null || $ctrl.condition.rightSideValue === null || $ctrl.condition.rightSideValue === undefined || $ctrl.condition.rightSideValue === "") {
                             resolve("[Not Set]");
                         } else {
                             const value = await $injector.invoke($ctrl.conditionType.getRightSideValueDisplay, {}, {
@@ -60,7 +60,7 @@
 
                 function getLeftSideValueDisplay() {
                     return $q(async (resolve) => {
-                        if ($ctrl.condition == null || $ctrl.condition.leftSideValue == null || $ctrl.condition.leftSideValue === "") {
+                        if ($ctrl.condition == null || $ctrl.condition.leftSideValue === null || $ctrl.condition.leftSideValue === undefined || $ctrl.condition.leftSideValue === "") {
                             resolve("[Not Set]");
                         } else {
                             const value = await $injector.invoke($ctrl.conditionType.getLeftSideValueDisplay, {}, {
@@ -73,19 +73,19 @@
 
                 $ctrl.$onInit = function() {
                     getRightSideValueDisplay().then((value) => {
-                        $ctrl.rightSideValueDisplay = value || "[Not Set]";
+                        $ctrl.rightSideValueDisplay = value !== null && value !== undefined ? value : "[Not Set]";
                     });
                     getLeftSideValueDisplay().then((value) => {
-                        $ctrl.leftSideValueDisplay = value || "[Not Set]";
+                        $ctrl.leftSideValueDisplay = value !== null && value !== undefined ? value : "[Not Set]";
                     });
                 };
 
                 $ctrl.$onChanges = function() {
                     getRightSideValueDisplay().then((value) => {
-                        $ctrl.rightSideValueDisplay = value || "[Not Set]";
+                        $ctrl.rightSideValueDisplay = value !== null && value !== undefined ? value : "[Not Set]";
                     });
                     getLeftSideValueDisplay().then((value) => {
-                        $ctrl.leftSideValueDisplay = value || "[Not Set]";
+                        $ctrl.leftSideValueDisplay = value !== null && value !== undefined ? value : "[Not Set]";
                     });
                 };
             }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Condition values of literal zero no longer show `[Not Set]` in the overview.
- This was overlooked in #2986, but existed prior to it.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3086

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Tested numerous ways to potentially break it, some with absolutely atrocious conditions, and all appeared fine.

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![args count zero after](https://github.com/user-attachments/assets/d3b225e2-d8e9-48fd-a20f-9f3954c4fd73)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
