### PR TITLE
feat(plugins): add get/save/delete PluginSettings (#3084)

### DIFF
--- a/src/gui/app/services/settings.service.js
+++ b/src/gui/app/services/settings.service.js
@@ -19,6 +19,15 @@
                 return settingPathCache[settingName];
             }
 
+            function getPluginSettingPath(pluginName, settingName) {
+                const key = `${pluginName}:${settingName}`;
+                if (settingPathCache[key] == null) {
+                    settingPathCache[key] = backendCommunicator.fireEventSync("settings:get-plugin-setting-path", { pluginName, settingName });
+                }
+
+                return settingPathCache[key];
+            }
+
             backendCommunicator.on("settings:setting-updated", ({ settingPath, data }) => {
                 if (settingPath == null || settingPath === "") {
                     return;
@@ -55,6 +64,52 @@
 
             service.deleteSetting = function (settingName) {
                 backendCommunicator.fireEventAsync("settings:delete-setting", settingName);
+            };
+
+            service.getPluginSetting = function (pluginName, settingName) {
+                if (pluginName == null || typeof pluginName !== "string" || pluginName.trim() === "") {
+                    throw new Error("getPluginSetting called with empty or invalid pluginName");
+                }
+
+                if (settingName == null || typeof settingName !== "string" || settingName.trim() === "") {
+                    throw new Error("getPluginSetting called with empty or invalid settingName");
+                }
+
+                const settingPath = getPluginSettingPath(pluginName, settingName);
+
+                if (settingsCache[settingPath] == null) {
+                    settingsCache[settingPath] = backendCommunicator.fireEventSync("settings:get-plugin-setting", { pluginName, settingName });
+                }
+
+                return settingsCache[settingPath];
+            };
+
+            service.savePluginSetting = function (pluginName, settingName, data) {
+                if (pluginName == null || typeof pluginName !== "string" || pluginName.trim() === "") {
+                    throw new Error("savePluginSetting called with empty or invalid pluginName");
+                }
+
+                if (settingName == null || typeof settingName !== "string" || settingName.trim() === "") {
+                    throw new Error("savePluginSetting called with empty or invalid settingName");
+                }
+
+                backendCommunicator.fireEvent("settings:save-plugin-setting", {
+                    pluginName,
+                    settingName,
+                    data
+                });
+            };
+
+            service.deletePluginSetting = function (pluginName, settingName) {
+                if (pluginName == null || typeof pluginName !== "string" || pluginName.trim() === "") {
+                    throw new Error("deletePluginSetting called with empty or invalid pluginName");
+                }
+
+                if (settingName == null || typeof settingName !== "string" || settingName.trim() === "") {
+                    throw new Error("deletePluginSetting called with empty or invalid settingName");
+                }
+
+                backendCommunicator.fireEventAsync("settings:delete-plugin-setting", { pluginName, settingName });
             };
 
             service.flushSettingsCache = function () {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This PR adds `savePluginSettings` and `deletePluginSettings` functions to the SettingsManager, as well as adding the aforementioned and `getPluginSettings` to the frontend settingsService

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3084

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured in a startup script that get, save and delete functions on the backend properly set the plugin setting data
Ensured malformed input (either pluginName or settingName being null, not a string or an empty string results in a thrown error)
Ensured in a startup script that get, save and delete functions on the frontend properly set the plugin setting data