### PR TITLE
fix(summernote): Restore Ability to Select Custom Colors (#3100)

### DIFF
--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -69,10 +69,10 @@
 
     <!-- include summernote css/js -->
     <link
-      href="https://cdn.jsdelivr.net/npm/summernote@0.8.15/dist/summernote.min.css"
+      href="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote.min.css"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.15/dist/summernote.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote.min.js"></script>
 
     <script src="https://unpkg.com/ag-grid@17.1.1/dist/ag-grid.min.js"></script>
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Add back the ability to choose custom colors in Summernote (Show Text effect).
- The top-left frame placement is not ideal.
- The lack of alpha transparency is not ideal.
- But custom colors are better than none?

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3100

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Selected several colors (insert a *skittles.png* meme here).

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![3100](https://github.com/user-attachments/assets/fe493bf9-538e-4b46-ab57-fc5c70671291)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
