### PR TITLE
fix(audio): playback on virtual audio cables (#3105)

### DIFF
--- a/src/gui/app/directives/effect-option-settings/eosAudioOutputDevice.js
+++ b/src/gui/app/directives/effect-option-settings/eosAudioOutputDevice.js
@@ -25,7 +25,7 @@
                 </div>
             </eos-container>
             `,
-            controller: function($q, settingsService) {
+            controller: function($q, soundService, settingsService) {
                 const ctrl = this;
 
                 ctrl.settings = settingsService;
@@ -49,18 +49,7 @@
                         };
                     }
 
-                    $q.when(navigator.mediaDevices.enumerateDevices()).then((deviceList) => {
-                        deviceList = deviceList
-                            .filter(
-                                d =>
-                                    d.kind === "audiooutput" &&
-                d.deviceId !== "communications" &&
-                d.deviceId !== "default"
-                            )
-                            .map((d) => {
-                                return { label: d.label, deviceId: d.deviceId };
-                            });
-
+                    $q.when(soundService.getOutputDevices()).then((deviceList) => {
                         ctrl.audioOutputDevices = ctrl.audioOutputDevices.concat(deviceList);
                     });
 

--- a/src/gui/app/directives/settings/categories/general-settings.js
+++ b/src/gui/app/directives/settings/categories/general-settings.js
@@ -194,7 +194,7 @@
                     </firebot-setting>
                 </div>
           `,
-        controller: function ($rootScope, $scope, settingsService, $q) {
+        controller: function ($rootScope, $scope, soundService, settingsService, $q) {
             $scope.openLink = $rootScope.openLinkExternally;
             $scope.settings = settingsService;
 
@@ -205,15 +205,7 @@
                 }
             ];
 
-            $q.when(navigator.mediaDevices.enumerateDevices()).then((deviceList) => {
-                deviceList = deviceList
-                    .filter(
-                        d => d.kind === "audiooutput" && d.deviceId !== "communications" && d.deviceId !== "default"
-                    )
-                    .map((d) => {
-                        return { label: d.label, deviceId: d.deviceId };
-                    });
-
+            $q.when(soundService.getOutputDevices()).then((deviceList) => {
                 $scope.audioOutputDevices = $scope.audioOutputDevices.concat(deviceList);
             });
 

--- a/src/gui/app/services/sound.service.js
+++ b/src/gui/app/services/sound.service.js
@@ -94,6 +94,18 @@
                 }
             };
 
+            service.getOutputDevices = async function() {
+                const deviceList = await navigator.mediaDevices.enumerateDevices();
+                return deviceList
+                    .filter(
+                        d => d.kind === "audiooutput"
+                        && d.deviceId !== "default"
+                        && d.deviceId !== "communications"
+                    )
+                    .map((device) => {
+                        return { label: device.label, deviceId: device.deviceId };
+                    });
+            };
 
             service.playSound = function(path, volume, outputDevice, maxSoundLength = null) {
                 if (outputDevice == null) {
@@ -144,7 +156,7 @@
             };
 
             service.getSound = async function(path, volume, outputDevice = settingsService.getSetting("AudioOutputDevice"), usePool = true) {
-                const deviceList = await navigator.mediaDevices.enumerateDevices();
+                const deviceList = await service.getOutputDevices();
 
                 const filteredDevice = deviceList.find(d => d.label === outputDevice.label
                     || d.deviceId === outputDevice.deviceId);


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This Pull Request adds a centralized `audioService.getOutputDevices` and switches all prior usages of `navigator.mediaDevices.enumerateDevices()` to use it instead. This function filters out the `default`, `communication` and any non-`audiooutput` devices, as the `eosAudioOutputDevice` already did.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3105 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured play-sound still works on regular audio devices
Ensured play-sound now works on virtual audio cables
Ensured derivative effect (Amazon Polly TTS) still play audio to regular audio devices
Ensured derivative effect (Amazon Polly TTS) plays audio to virtual audio cable
Ensured Settings > Sound Output Device shows the list of proper audio devices.