### PR TITLE
feat: switch default queue type to Sequential (#3110)

### DIFF
--- a/src/gui/app/controllers/effect-queues.controller.js
+++ b/src/gui/app/controllers/effect-queues.controller.js
@@ -1,8 +1,8 @@
 "use strict";
-(function() {
+(function () {
     angular
         .module("firebotApp")
-        .controller("effectQueuesController", function(
+        .controller("effectQueuesController", function (
             $scope,
             effectQueuesService,
             utilityService,
@@ -15,8 +15,8 @@
             };
 
             $scope.getQueueModeName = (modeId) => {
-                const mode = effectQueuesService.queueModes.find(m => m.id === modeId);
-                return mode ? mode.display : "Unknown";
+                const mode = effectQueuesService.queueModes.find(m => m.value === modeId);
+                return mode ? mode.label : "Unknown";
             };
 
             $scope.headers = [
@@ -26,7 +26,7 @@
                     dataField: "name",
                     sortable: true,
                     cellTemplate: `{{data.name}}`,
-                    cellController: () => {}
+                    cellController: () => { }
                 },
                 {
                     name: "MODE",
@@ -36,8 +36,8 @@
                     cellTemplate: `{{getQueueModeName(data.mode)}}`,
                     cellController: ($scope) => {
                         $scope.getQueueModeName = (modeId) => {
-                            const mode = effectQueuesService.queueModes.find(m => m.id === modeId);
-                            return mode ? mode.display : "Unknown";
+                            const mode = effectQueuesService.queueModes.find(m => m.value === modeId);
+                            return mode ? mode.label : "Unknown";
                         };
                     }
                 },
@@ -47,7 +47,7 @@
                     dataField: "interval",
                     sortable: true,
                     cellTemplate: `{{(data.mode === 'interval' || data.mode === 'auto') ? (data.interval || 0) + 's' : 'n/a'}}`,
-                    cellController: () => {}
+                    cellController: () => { }
                 }
             ];
 

--- a/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
+++ b/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
@@ -1,5 +1,5 @@
 "use strict";
-(function() {
+(function () {
     angular.module("firebotApp").component("addOrEditEffectQueueModal", {
         template: `
             <scroll-sentinel element-class="edit-effect-queue-header"></scroll-sentinel>
@@ -66,14 +66,14 @@
             dismiss: "&",
             modalInstance: "<"
         },
-        controller: function(effectQueuesService, ngToast) {
+        controller: function (effectQueuesService, ngToast) {
             const $ctrl = this;
 
             $ctrl.isNewQueue = true;
 
             $ctrl.effectQueue = {
                 name: "",
-                mode: "custom",
+                mode: "auto",
                 sortTags: [],
                 active: true,
                 length: 0

--- a/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
+++ b/src/gui/app/directives/modals/effect-queues/addOrEditEffectQueueModal.js
@@ -23,27 +23,14 @@
                     </div>
                 </div>
 
-                <div class="mt-6">
-                    <div class="modal-subheader pb-2 pt-0 px-0">MODE</div>
-                    <div>
-                        <ui-select ng-model="$ctrl.effectQueue.mode" theme="bootstrap" class="control-type-list">
-                            <ui-select-match placeholder="Select queue mode">{{$select.selected.display}}</ui-select-match>
-                            <ui-select-choices repeat="mode.id as mode in $ctrl.queueModes | filter: { display: $select.search }" style="position:relative;">
-                                <div class="flex-row-center">
-                                    <div class="my-0 mx-5" style="width: 30px;height: 100%;font-size:20px;text-align: center;flex-shrink: 0;">
-                                        <i class="fas" ng-class="mode.iconClass"></i>
-                                    </div>
-                                    <div>
-                                        <div ng-bind-html="mode.display | highlight: $select.search"></div>
-                                        <small class="muted">{{mode.description}}</small>
-                                    </div>
-
-                                </div>
-
-                            </ui-select-choices>
-                        </ui-select>
-                    </div>
-                </div>
+                <div class="modal-subheader pb-2 pt-0 px-0">MODE</div>
+                <firebot-radio-cards
+                    options="$ctrl.queueModes"
+                    ng-model="$ctrl.effectQueue.mode"
+                    id="queueMode"
+                    name="queueMode"
+                    grid-columns="1"
+                ></firebot-radio-cards>
 
                 <div class="mt-6" ng-show="$ctrl.effectQueue.mode != null && ($ctrl.effectQueue.mode ==='interval' || $ctrl.effectQueue.mode ==='auto')">
                     <div class="modal-subheader pb-2 pt-0 px-0">Interval/Delay (secs)</div>

--- a/src/gui/app/services/effect-queues.service.js
+++ b/src/gui/app/services/effect-queues.service.js
@@ -1,10 +1,10 @@
 "use strict";
 
-(function() {
+(function () {
 
     angular
         .module("firebotApp")
-        .factory("effectQueuesService", function(backendCommunicator, utilityService,
+        .factory("effectQueuesService", function (backendCommunicator, utilityService,
             objectCopyHelper, ngToast) {
             const service = {};
 
@@ -26,20 +26,20 @@
                 }
             };
 
-            backendCommunicator.on("all-queues", effectQueues => {
+            backendCommunicator.on("all-queues", (effectQueues) => {
                 if (effectQueues != null) {
                     service.effectQueues = effectQueues;
                 }
             });
 
-            backendCommunicator.on("updateQueueLength", queue => {
+            backendCommunicator.on("updateQueueLength", (queue) => {
                 const index = service.effectQueues.findIndex(eq => eq.id === queue.id);
                 if (service.effectQueues[index] != null) {
                     service.effectQueues[index].length = queue.length;
                 }
             });
 
-            backendCommunicator.on("updateQueueStatus", queue => {
+            backendCommunicator.on("updateQueueStatus", (queue) => {
                 const index = service.effectQueues.findIndex(eq => eq.id === queue.id);
                 if (service.effectQueues[index] != null) {
                     service.effectQueues[index].active = queue.active;
@@ -48,16 +48,16 @@
 
             service.queueModes = [
                 {
-                    id: "custom",
-                    display: "Custom",
-                    description: "Wait the custom amount of time defined for each individual effect list.",
-                    iconClass: "fa-clock"
-                },
-                {
                     id: "auto",
                     display: "Sequential",
                     description: "Runs effect list in the queue sequentially. Priority items will be added before non-priority. Optional delay defaults to 0s.",
                     iconClass: "fa-sort-numeric-down"
+                },
+                {
+                    id: "custom",
+                    display: "Custom",
+                    description: "Wait the custom amount of time defined for each individual effect list.",
+                    iconClass: "fa-clock"
                 },
                 {
                     id: "interval",
@@ -118,7 +118,7 @@
                     copiedEffectQueue.name += " copy";
                 }
 
-                service.saveEffectQueue(copiedEffectQueue).then(successful => {
+                service.saveEffectQueue(copiedEffectQueue).then((successful) => {
                     if (successful) {
                         ngToast.create({
                             className: 'success',
@@ -136,7 +136,7 @@
             };
 
             service.showAddEditEffectQueueModal = (effectQueueId) => {
-                return new Promise(resolve => {
+                return new Promise((resolve) => {
                     let effectQueue;
 
                     if (effectQueueId != null) {
@@ -149,7 +149,7 @@
                         resolveObj: {
                             effectQueue: () => effectQueue
                         },
-                        closeCallback: response => {
+                        closeCallback: (response) => {
                             resolve(response.effectQueue.id);
                         }
                     });
@@ -157,7 +157,7 @@
             };
 
             service.showDeleteEffectQueueModal = (effectQueueId) => {
-                return new Promise(resolve => {
+                return new Promise((resolve) => {
                     if (effectQueueId == null) {
                         resolve(false);
                     }
@@ -174,7 +174,7 @@
                             confirmLabel: "Delete",
                             confirmBtnType: "btn-danger"
                         })
-                        .then(confirmed => {
+                        .then((confirmed) => {
                             if (confirmed) {
                                 service.deleteEffectQueue(effectQueueId);
                             }

--- a/src/gui/app/services/effect-queues.service.js
+++ b/src/gui/app/services/effect-queues.service.js
@@ -48,20 +48,20 @@
 
             service.queueModes = [
                 {
-                    id: "auto",
-                    display: "Sequential",
+                    value: "auto",
+                    label: "Sequential",
                     description: "Runs effect list in the queue sequentially. Priority items will be added before non-priority. Optional delay defaults to 0s.",
                     iconClass: "fa-sort-numeric-down"
                 },
                 {
-                    id: "custom",
-                    display: "Custom",
+                    value: "custom",
+                    label: "Custom",
                     description: "Wait the custom amount of time defined for each individual effect list.",
                     iconClass: "fa-clock"
                 },
                 {
-                    id: "interval",
-                    display: "Interval",
+                    value: "interval",
+                    label: "Interval",
                     description: "Runs effect lists on a set interval.",
                     iconClass: "fa-stopwatch"
                 }
@@ -145,7 +145,7 @@
 
                     utilityService.showModal({
                         component: "addOrEditEffectQueueModal",
-                        size: "sm",
+                        size: "md",
                         resolveObj: {
                             effectQueue: () => effectQueue
                         },


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Update default type for new Effect Queues to Sequential
- Resize addOrEditEffectQueueModal to medium size
- switch to firebot-radio-cards for Queue Mode

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3110

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the default selected queue mode is now Sequential
Ensured opening/editing an existing queue does not change its queue mode
Ensured Sequential, Custom and Interval queues can all be created properly
Ensured queues still display properly in the item-table
Ensured queues still function as expected

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![image](https://github.com/user-attachments/assets/949bdb19-df71-462b-8c10-69d3e670816e)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
