### PR TITLE
 feat: inject presetValues into getSelectedValueDisplay (#3083) 

### DIFF
--- a/src/backend/events/filters/builtin/twitch/chat-mode.ts
+++ b/src/backend/events/filters/builtin/twitch/chat-mode.ts
@@ -1,4 +1,4 @@
-import { EventFilter } from "../../../../../types/events";
+import { EventFilter, PresetValue } from "../../../../../types/events";
 import { ComparisonType } from "../../../../../shared/filter-constants";
 
 const filter: EventFilter = {
@@ -34,8 +34,8 @@ const filter: EventFilter = {
             }
         ];
     },
-    getSelectedValueDisplay: async (filterSettings) => {
-        return (await filter.presetValues())
+    getSelectedValueDisplay: async (filterSettings, presetValues: PresetValue[]) => {
+        return presetValues
             .find(pv => pv.value === filterSettings.value || (filterSettings.value === "r9kbeta" && pv.value === "uniquechat"))?.display ?? "[Not Set]";
     },
     predicate: async (filterSettings, eventData) => {

--- a/src/backend/events/filters/builtin/twitch/sub-kind.ts
+++ b/src/backend/events/filters/builtin/twitch/sub-kind.ts
@@ -1,4 +1,4 @@
-import { EventFilter } from "../../../../../types/events";
+import { EventFilter, PresetValue } from "../../../../../types/events";
 import { ComparisonType } from "../../../../../shared/filter-constants";
 
 const filter: EventFilter = {
@@ -20,15 +20,9 @@ const filter: EventFilter = {
             display: "Resub"
         }
     ],
-    getSelectedValueDisplay: (filterSettings) => {
-        switch (filterSettings.value) {
-            case "first":
-                return "First Sub";
-            case "resub":
-                return "Resub";
-            default:
-                return "[Not set]";
-        }
+    getSelectedValueDisplay: (filterSettings, presetValues: PresetValue[]) => {
+        return presetValues
+            .find(pv => pv.value === filterSettings.value)?.display ?? "[Not Set]";
     },
     predicate: (filterSettings, eventData) => {
         const { value } = filterSettings;

--- a/src/backend/events/filters/filter-factory.ts
+++ b/src/backend/events/filters/filter-factory.ts
@@ -1,7 +1,6 @@
 import { EventFilter, FilterSettings, PresetValue } from "../../../types/events";
 import { ComparisonType } from "../../../shared/filter-constants";
 import { extractPropertyWithPath } from "../../utility";
-import { auto } from "angular";
 
 type EventData = {
     eventSourceId: string;
@@ -202,9 +201,8 @@ export function createPresetFilter({
         comparisonTypes.push(ComparisonType.IS_NOT);
     }
 
-    const valueDisplay = getSelectedValueDisplay ?? (async (filterSettings, filterType: any, $injector: auto.IInjectorService) => {
-        return (await $injector.invoke(filterType.getPresetValues, {}, {}))
-            .find(pv => pv.value === filterSettings.value)?.display ?? "[Not Set]";
+    const valueDisplay = getSelectedValueDisplay ?? (async (filterSettings, presetValues?: PresetValue[]) => {
+        return presetValues.find(pv => pv.value === filterSettings.value)?.display ?? "[Not Set]";
     });
 
     return {

--- a/src/gui/app/directives/filters/filterDisplay.js
+++ b/src/gui/app/directives/filters/filterDisplay.js
@@ -1,5 +1,5 @@
 "use strict";
-(function() {
+(function () {
     angular.module("firebotApp")
         .component("filterDisplay", {
             bindings: {
@@ -11,23 +11,24 @@
                     <b class="condition-side" style="margin-right:5px">{{$ctrl.getFilterName()}}</b> {{$ctrl.filter.comparisonType}} <b class="condition-side" style="margin-left:5px">{{$ctrl.filterValueDisplay}}</b>
                 </span>
             `,
-            controller: function($injector, $q) {
+            controller: function ($injector, $q) {
                 const $ctrl = this;
 
-                $ctrl.getFilterName = function() {
+                $ctrl.getFilterName = function () {
                     return $ctrl.filterType ? $ctrl.filterType.name : "Unknown";
                 };
 
                 $ctrl.filterValueDisplay = "[Not Set]";
 
                 function getFilterValueDisplay() {
-                    return $q(async resolve => {
+                    return $q(async (resolve) => {
                         if ($ctrl.filter == null || $ctrl.filter.value == null) {
                             resolve("[Not Set]");
                         } else {
                             const value = await $injector.invoke($ctrl.filterType.getSelectedValueDisplay, {}, {
                                 filterSettings: $ctrl.filter,
-                                filterType: $ctrl.filterType
+                                filterType: $ctrl.filterType,
+                                presetValues: await $injector.invoke($ctrl.filterType.getPresetValues, {}, {})
                             });
                             resolve(value);
                         }
@@ -36,15 +37,15 @@
 
                 }
 
-                $ctrl.$onInit = function() {
-                    getFilterValueDisplay().then(value => {
+                $ctrl.$onInit = function () {
+                    getFilterValueDisplay().then((value) => {
                         $ctrl.filterValueDisplay = value;
                     });
                 };
 
-                $ctrl.$onChanges = function() {
+                $ctrl.$onChanges = function () {
 
-                    getFilterValueDisplay().then(value => {
+                    getFilterValueDisplay().then((value) => {
                         $ctrl.filterValueDisplay = value;
                     });
                 };


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Inject presetValues into the getSelectedValueDisplay function for event filters

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3083

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured both in-tree filters and plugin filters can access presetValues
Tested some builtin preset type filters to ensure they display the correct values