### PR TITLE
feat(effects): Add the Volume Slider Back for experimental clips (#3129)

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -173,7 +173,7 @@ const playVideo = {
             </eos-container>
         </div>
 
-        <eos-container ng-if="effect.videoType != 'Random Twitch Clip' && effect.videoType != 'Twitch Clip'" header="Volume" pad-top="true">
+        <eos-container ng-if="shouldShowVolumeControl()" header="Volume" pad-top="true">
             <div class="volume-slider-wrapper">
                 <i class="fal fa-volume-down volume-low"></i>
                 <rzslider rz-slider-model="effect.volume" rz-slider-options="{floor: 0, ceil: 10, hideLimitLabels: true}"></rzslider>
@@ -251,7 +251,7 @@ const playVideo = {
      * The controller for the front end Options
      * Port over from effectHelperService.js
      */
-    optionsController: ($scope, $rootScope, $timeout, utilityService) => {
+    optionsController: ($scope, $rootScope, $timeout, utilityService, settingsService) => {
         $scope.waitChange = () => {
             if ($scope.effect.videoType !== 'Random Twitch Clip' && $scope.effect.videoType !== 'Twitch Clip') {
                 if ($scope.effect.wait) {
@@ -262,6 +262,9 @@ const playVideo = {
         $scope.showOverlayInfoModal = function (overlayInstance) {
             utilityService.showOverlayInfoModal(overlayInstance);
         };
+
+        $scope.shouldShowVolumeControl = () => !['Random Twitch Clip', 'Twitch Clip'].includes($scope.effect.videoType) || settingsService.getSetting("UseExperimentalTwitchClipUrlResolver");
+
 
         $scope.videoPositions = [
             "Top Left",


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
show the volume slider when experimental clips is enabled 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3129

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
checked that the settings both enabling and disabling the slider was working for clips in experimental mode 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
