### PR TITLE
fix(UI): Revert Summernote Back To 0.8.18 To Fix Style Issues (#3131)

### DIFF
--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -69,10 +69,10 @@
 
     <!-- include summernote css/js -->
     <link
-      href="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote.min.css"
+      href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.css"
       rel="stylesheet"
     />
-    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.js"></script>
 
     <script src="https://unpkg.com/ag-grid@17.1.1/dist/ag-grid.min.js"></script>
 

--- a/src/gui/scss/core/_global.scss
+++ b/src/gui/scss/core/_global.scss
@@ -1791,13 +1791,15 @@ thead th{
 
 .text-editor-black-bg {
   .note-editable {
-    background-color: black !important;
+    background-color: #25292a !important;
+    color: #f5f5f5 !important;
   }
 }
 
 .text-editor-white-bg {
   .note-editable {
-    background-color: white !important;
+    background-color: #f5f5f5 !important;
+    color: #25292a !important;
   }
 }
 


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Summernote 0.8.20 has styling issues when toggling the code view twice, 0.8.19 has css issues where the buttons icons are missing.
- 0.8.16 resolved the custom color issue from #3104, but has table transparency issues.
- 0.8.18 is 0.8.17 but with better translations (that we'll never see)
- So settle with 0.8.18 which seems to be fully functional, and free of glaringly-obvious bugs, and as many non-obvious ones that I could think to check for.
- Add readable default foreground coloring regardless of background color, and soften the contrast a smidge.
  - The somewhat violates the ideals of a WYSIWYG editor, but we were *already* doing that by not specifying a default theme.
  - At least now it's usable regardless of the background color mode.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3131

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->


### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
Before (0.8.20):
![before](https://github.com/user-attachments/assets/f858261b-5b1b-4eb0-ac3d-c69cb4f0f01c)

After (0.8.18):
[rev.0](https://github.com/user-attachments/assets/d364c0e0-c597-41e7-95ce-e06947e8497f);
rev.1:
![after-2](https://github.com/user-attachments/assets/09271165-bf6d-4a51-97b0-ec011a5595b1)


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
