### PR TITLE
feat(vars): Add $isAnonymous Variable (#3127)

### DIFF
--- a/src/backend/variables/builtin/twitch/subs/index.ts
+++ b/src/backend/variables/builtin/twitch/subs/index.ts
@@ -6,7 +6,7 @@ import giftReceivers from './gift-receivers';
 import giftReceiversRaw from './gift-receivers-raw';
 import giftSubMonths from './gift-sub-months';
 import giftSubType from './gift-sub-type';
-
+import isAnonymous from './is-anonymous';
 import subCount from './sub-count';
 import subMessage from './sub-message';
 import subMonths from './sub-months';
@@ -24,7 +24,7 @@ export default [
     giftReceiversRaw,
     giftSubMonths,
     giftSubType,
-
+    isAnonymous,
     subCount,
     subMessage,
     subMonths,

--- a/src/backend/variables/builtin/twitch/subs/is-anonymous.ts
+++ b/src/backend/variables/builtin/twitch/subs/is-anonymous.ts
@@ -1,0 +1,23 @@
+import { ReplaceVariable } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: "isAnonymous",
+        description: "Whether or not the gift sub(s) were given anonymously.",
+        categories: [VariableCategory.TRIGGER, VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.BOOLEAN],
+        triggers: {
+            event: [
+                "twitch:community-subs-gifted",
+                "twitch:subs-gifted"
+            ],
+            manual: true
+        }
+    },
+    evaluator: async (trigger) => {
+        return trigger.metadata?.eventData?.isAnonymous === true;
+    }
+};
+
+export default model;


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
- Add an `$isAnonymous` variable.
  - We already had an event filter for this, but a variable unlocks more functionality such as conditional effects and inline `$if[$isAnonymous, ...]`-style evaluation.
- Limited solely to community/subs-gifted events, as cheering anonymously was removed circa October 2022, [for safety](<https://fixvx.com/TwitchSupport/status/1585408826257416192>).

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3127

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Simulated and manually ran both impacted events thoroughly (community-subs-gifted, subs-gifted).

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
N/A

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
