### PR TITLE
feat(overlay): add z-index to postion of overlay(#1789)

### DIFF
--- a/src/backend/effects/builtin/play-video.js
+++ b/src/backend/effects/builtin/play-video.js
@@ -375,7 +375,8 @@ const playVideo = {
             inbetweenRepeat: effect.inbetweenRepeat,
             customCoords: effect.customCoords,
             loop: effect.loop === true,
-            rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg"
+            rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg",
+            zIndex: effect.zIndex
         };
 
         // Get random sound
@@ -523,7 +524,8 @@ const playVideo = {
                 exitAnimation: effect.exitAnimation,
                 exitDuration: effect.exitDuration,
                 overlayInstance: data.overlayInstance,
-                rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg"
+                rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg",
+                zIndex: effect.zIndex
             });
 
             if (effect.wait) {
@@ -700,7 +702,9 @@ const playVideo = {
                 const sizeStyles =
                     (data.videoWidth ? `width: ${data.videoWidth}px;` : "") +
                     (data.videoHeight ? `height: ${data.videoHeight}px;` : "") +
-                    (data.rotation ? `transform: rotate(${data.rotation});` : '');
+                    (data.rotation ? `transform: rotate(${data.rotation});` : '') +
+                    (data.zIndex ? `position: relative; z-index: ${data.zIndex};` : '');
+
 
                 if (videoType === "Local Video") {
                     const loopAttribute = loop ? "loop" : "";

--- a/src/backend/effects/builtin/shoutout.js
+++ b/src/backend/effects/builtin/shoutout.js
@@ -313,7 +313,7 @@ const effect = {
 
                 const shoutoutElement = `
                 <div>
-                    <div class="firebot-shoutout-wrapper" style="background: linear-gradient(0deg, ${data.bgColor2} 0%, ${data.bgColor1} 100%); transform: scale(${scale});">
+                    <div class="firebot-shoutout-wrapper" style="background: linear-gradient(0deg, ${data.bgColor2} 0%, ${data.bgColor1} 100%); transform: scale(${scale});${data.zIndex ? ` position: relative; z-index: ${data.zIndex};` : ''}">
 
                         <div style="position:relative;">
                             <div class="firebot-shoutout-avatar-wrapper firebot-shoutout-padding">

--- a/src/backend/effects/builtin/show-image.js
+++ b/src/backend/effects/builtin/show-image.js
@@ -274,8 +274,6 @@ const showImage = {
                     (data.imageHeight ? `height: ${data.imageHeight};` : "") +
                     (data.imageRotation ? `transform: rotate(${data.imageRotation});` : "") +
                     (data.zIndex ? `position: relative; z-index: ${data.zIndex};` : '');
-                console.log(data.imageRotation);
-                console.log(styles);
                 const imageTag = `<img src="${filepathNew}" style="${styles}" />`;
 
                 showElement(imageTag, positionData, animationData); // eslint-disable-line no-undef

--- a/src/backend/effects/builtin/show-image.js
+++ b/src/backend/effects/builtin/show-image.js
@@ -184,7 +184,8 @@ const showImage = {
             exitAnimation: effect.exitAnimation,
             exitDuration: effect.exitDuration,
             customCoords: effect.customCoords,
-            imageRotation: effect.rotation ? effect.rotation + effect.rotType : "0deg"
+            imageRotation: effect.rotation ? effect.rotation + effect.rotType : "0deg",
+            zIndex: effect.zIndex
         };
 
         if (SettingsManager.getSetting("UseOverlayInstances")) {
@@ -271,7 +272,8 @@ const showImage = {
                 const styles =
                     (data.imageWidth ? `width: ${data.imageWidth};` : "") +
                     (data.imageHeight ? `height: ${data.imageHeight};` : "") +
-                    (data.imageRotation ? `transform: rotate(${data.imageRotation});` : "");
+                    (data.imageRotation ? `transform: rotate(${data.imageRotation});` : "") +
+                    (data.zIndex ? `position: relative; z-index: ${data.zIndex};` : '');
                 console.log(data.imageRotation);
                 console.log(styles);
                 const imageTag = `<img src="${filepathNew}" style="${styles}" />`;

--- a/src/backend/effects/builtin/show-text.js
+++ b/src/backend/effects/builtin/show-text.js
@@ -259,7 +259,8 @@ const showText = {
             debugBorder: effect.debugBorder,
             dropShadow: effect.dropShadow,
             overlayInstance: effect.overlayInstance,
-            rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg"
+            rotation: effect.rotation ? effect.rotation + effect.rotType : "0deg",
+            zIndex: effect.zIndex
         };
 
         const position = dto.position;
@@ -376,7 +377,7 @@ const showText = {
                 if (borderColor) {
                     styles += `border: 2px solid ${borderColor};`;
                 }
-
+                styles += data.zIndex ? `position: relative; z-index: ${data.zIndex};` : '';
                 const textDiv = `
                     <div class="text-container"
                         style="${styles}">

--- a/src/gui/app/directives/effect-option-settings/eosOverlayPosition.js
+++ b/src/gui/app/directives/effect-option-settings/eosOverlayPosition.js
@@ -115,10 +115,6 @@
                     }
                 };
 
-                // ctrl.updateZIndex = function() {
-                //     ctrl.effect.zIndex = ctrl.zIndex;
-                // };
-
                 ctrl.togglePresetCustom = function() {
                     if (ctrl.presetOrCustom === "custom") {
                         ctrl.effect.position = "Custom";

--- a/src/gui/app/directives/effect-option-settings/eosOverlayPosition.js
+++ b/src/gui/app/directives/effect-option-settings/eosOverlayPosition.js
@@ -54,6 +54,17 @@
                         </div>
                     </form>
                 </div>
+                <div style="margin-top: 15px;">
+                    <div class="input-group">
+                        <span class="input-group-addon">z-index <tooltip text="'Controls which items appear in front when things overlap. Items with a higher number are shown on top of items with a lower number.'"></tooltip></span>
+                        <input
+                            type="text"
+                            class="form-control"
+                            placeholder="Optional"
+                            replace-variables="number"
+                            ng-model="$ctrl.effect.zIndex">
+                    </div>
+                </div>
             </eos-container>
        `,
             controller: function() {
@@ -103,6 +114,10 @@
                         ctrl.effect.customCoords.right = ctrl.leftOrRightValue;
                     }
                 };
+
+                // ctrl.updateZIndex = function() {
+                //     ctrl.effect.zIndex = ctrl.zIndex;
+                // };
 
                 ctrl.togglePresetCustom = function() {
                     if (ctrl.presetOrCustom === "custom") {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
add z-index to position control and apply it to the 4 overlay effects 
shoutout 
play video 
show image 
show text 

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#1789

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
![image](https://github.com/user-attachments/assets/b22b13bf-0be4-46ff-b48c-54ccbb0f8109)
showed an image behind video over top of text 

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
![{1F299923-2C04-46EB-8578-B326FD07DFBB}](https://github.com/user-attachments/assets/f79f0f9a-2b38-4d5e-bbb2-0c76c7136d90)
![image](https://github.com/user-attachments/assets/041521d1-f31c-42d4-b93e-cbeea4ef570c)



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
