### PR TITLE
feat(effects): Make chat feed alert icon configurable (#3157)

### DIFF
--- a/src/backend/effects/builtin/chat-feed-alert.js
+++ b/src/backend/effects/builtin/chat-feed-alert.js
@@ -8,7 +8,7 @@ const effect = {
         id: "firebot:chat-feed-alert",
         name: "Chat Feed Alert",
         description: "Display an alert in Firebot's chat feed",
-        icon: "fad fa-comment-exclamation",
+        icon: "fad fa-exclamation-circle",
         categories: [EffectCategory.COMMON, EffectCategory.CHAT_BASED],
         dependencies: [EffectDependency.CHAT]
     },
@@ -26,13 +26,29 @@ const effect = {
             menu-position="under"
         />
     </eos-container>
-
+    <eos-container header="Icon" pad-top="true">
+        <input
+			maxlength="2"
+			type="text"
+			class="form-control"
+			ng-model="effect.icon"
+			icon-picker required
+		/>
+    </eos-container>
     `,
-    optionsController: () => {},
+    optionsController: ($scope) => {
+        // Backward compatibility from when the icon was hard-coded
+        if ($scope.effect.icon == null || $scope.effect.icon === "") {
+            $scope.effect.icon = "fad fa-exclamation-circle";
+        }
+    },
     optionsValidator: (effect) => {
         const errors = [];
         if (effect.message == null || effect.message === "") {
             errors.push("Alert message can't be blank.");
+        }
+        if (effect.icon == null || effect.icon === "") {
+            errors.push("Icon can't be blank.");
         }
         return errors;
     },
@@ -42,7 +58,8 @@ const effect = {
 
         frontendCommunicator.send("chatUpdate", {
             fbEvent: "ChatAlert",
-            message: effect.message
+            message: effect.message,
+            icon: effect.icon,
         });
 
         return true;

--- a/src/gui/app/directives/chat/feed items/chat-alert.js
+++ b/src/gui/app/directives/chat/feed items/chat-alert.js
@@ -4,13 +4,40 @@
         .module('firebotApp')
         .component("chatAlert", {
             bindings: {
-                message: "<"
+                alertMessage: "<",
+                alertIcon: "<"
             },
             template: `
                 <div class="chat-alert">
-                    <span style="font-size:25px;margin-right: 10px;"><i class="fad fa-exclamation-circle"></i></span>
+                    <span style="font-size:25px;margin-right: 10px;"><i ng-class="$ctrl.iconClass"></i></span>
                     <span style="margin-top: 8px;">{{$ctrl.message}}</span>
                 </div>
-            `
+            `,
+            controller: function() {
+                const $ctrl = this;
+
+                $ctrl.iconClass = "";
+                $ctrl.message = "No message";
+
+                const init = () => {
+                    if ($ctrl.alertMessage) {
+                        $ctrl.message = $ctrl.alertMessage;
+                    }
+
+                    var icon = $ctrl.alertIcon;
+                    if (!icon) {
+                        icon = "fad fa-exclamation-circle";
+                    }
+
+                    const classes = icon.split(" ");
+                    if (classes.length === 1) {
+                        $ctrl.iconClass = `far ${classes[0]}`;
+                    } else {
+                        $ctrl.iconClass = classes.join(" ");
+                    }
+                };
+
+                $ctrl.$onInit = init;
+            },
         });
 }());

--- a/src/gui/app/services/chat-messages.service.js
+++ b/src/gui/app/services/chat-messages.service.js
@@ -132,19 +132,19 @@
             };
 
             // Chat Alert Message
-            service.chatAlertMessage = function(message) {
-
+            service.chatAlertMessage = function(message, icon = "fad fa-exclamation-circle") {
                 const alertItem = {
                     id: uuid(),
                     type: "alert",
-                    data: message
+                    message: message,
+                    icon: icon
                 };
 
                 service.chatQueue.push(alertItem);
             };
 
-            backendCommunicator.on("chat-feed-system-message", (message) => {
-                service.chatAlertMessage(message);
+            backendCommunicator.on("chat-feed-system-message", (message, icon) => {
+                service.chatAlertMessage(message, icon);
             });
 
             // Chat Update Handler
@@ -194,7 +194,7 @@
                         break;
                     case "ChatAlert":
                         logger.debug("Chat alert from backend.");
-                        service.chatAlertMessage(data.message);
+                        service.chatAlertMessage(data.message, data.icon);
                         break;
                     default:
                     // Nothing

--- a/src/gui/app/templates/chat/_chat-messages.html
+++ b/src/gui/app/templates/chat/_chat-messages.html
@@ -83,7 +83,8 @@
           />
           <chat-alert
             ng-if="chatItem.type === 'alert'"
-            message="chatItem.data"
+            alert-message="chatItem.message"
+            alert-icon="chatItem.icon"
           />
         </div>
       </div>


### PR DESCRIPTION
### Description of the Change

This makes the icon displayed in the chat feed for the "Chat Feed Alert" effect configurable.

It uses the standard icon picker, and defaults to the old value (`fad fa-exclamation-circle`) when unspecified. (The icon picker widget always displays the little flag and not the actual selected icon, but that's the way it works on all the screens.)

The same code that powers the "Chat Feed Alert" command is also called under-the-hood for certain actions, such as clearing the chat. This now defaults to `fad fa-exclamation-circle`.

So in short this is now selectable when someone edits an existing "Chat Feed Alert" effect or creates a new one, and keeps the default behavior at all other times.

### Applicable Issues
Fixes https://github.com/crowbartools/Firebot/issues/3157


### Testing

Made a preset effect list that had a "Chat Feed Alert" with a selected icon. Ran it and observed the icon being shown in the chat feed.

I also ran a "Chat Feed Alert" effect created before this code was added, and it displayed with the exclamation circle.

I also edited a "Chat Feed Alert" effect created before this code was added, and the default shown in the icon picker was `fad fa-exclamation-circle`.

I also ran `/clear` to cause a default message to be added as a chat feed alert.

### Screenshots

![image](https://github.com/user-attachments/assets/726209b1-ed98-42f6-b035-fcbac721a790)

![image](https://github.com/user-attachments/assets/f23e6380-89ad-4829-8c2c-c8fa054d7971)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
