### PR TITLE
feat(effects): Add "shield mode" effect (#3160)

### DIFF
--- a/src/backend/effects/builtin-effect-loader.js
+++ b/src/backend/effects/builtin-effect-loader.js
@@ -71,6 +71,7 @@ exports.loadEffects = () => {
         'twitch/create-stream-marker',
         'twitch/raid',
         'twitch/set-chat-mode',
+        'twitch/shield-mode',
         'twitch/shoutout',
         'twitch/snooze-ad-break',
         'twitch/stream-title',

--- a/src/backend/effects/builtin/twitch/shield-mode.ts
+++ b/src/backend/effects/builtin/twitch/shield-mode.ts
@@ -1,0 +1,56 @@
+import { EffectType } from "../../../../types/effects";
+import { EffectCategory } from "../../../../shared/effect-constants";
+import accountAccess from "../../../common/account-access";
+import twitchApi from "../../../twitch-api/api";
+
+const model: EffectType<{
+    action: "Enable Shield Mode" | "Disable Shield Mode";
+}> = {
+    definition: {
+        id: "firebot:shield-mode",
+        name: "Enable/Disable Shield Mode",
+        description: "Enable or disable Shield Mode on your Twitch channel",
+        icon: "fad fa-shield",
+        categories: [EffectCategory.COMMON, EffectCategory.TWITCH],
+        dependencies: {
+            twitch: true
+        }
+    },
+    optionsTemplate: `
+        <eos-container header="Action">
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="list-effect-type">{{effect.action ? effect.action : 'Pick one'}}</span> <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li ng-click="effect.action = 'Enable Shield Mode'">
+                        <a href>Enable Shield Mode</a>
+                    </li>
+                    <li ng-click="effect.action = 'Disable Shield Mode'">
+                        <a href>Disable Shield Mode</a>
+                    </li>
+                </ul>
+            </div>
+        </eos-container>
+    `,
+    optionsValidator: (effect) => {
+        const errors: string[] = [];
+
+        if (effect.action == null) {
+            errors.push("You must select a Shield Mode action");
+        }
+
+        return errors;
+    },
+    optionsController: () => {},
+    getDefaultLabel: (effect) => {
+        return effect.action || "";
+    },
+    onTriggerEvent: async ({ effect }) => {
+        const activate = effect.action === "Enable Shield Mode";
+        const streamerUserId: string = accountAccess.getAccounts().streamer.userId;
+        await twitchApi.streamerClient.moderation.updateShieldModeStatus(streamerUserId, activate);
+    }
+};
+
+module.exports = model;


### PR DESCRIPTION
### Description of the Change

This PR adds an effect that can enable and disable "shield mode" for the broadcaster's channel.

This is supported by Twurple so this is just the typical firebot wrappers around:

```javascript
await twitchApi.streamerClient.moderation.updateShieldModeStatus(streamerUserId, activate);
```

### Applicable Issues

Fixes https://github.com/crowbartools/Firebot/issues/3160

### Testing

Ran the preset effect list shown in the screen shots and shield mode was enabled and then disabled in the channel.

### Screenshots

![image](https://github.com/user-attachments/assets/786935aa-f80b-4a4b-9291-1ba2c8a7fb49)

![image](https://github.com/user-attachments/assets/2f4fb6d7-2aec-493d-abcb-1b1777bfe4c5)

Result in my Twitch stream from running the above preset effect list:

![image](https://github.com/user-attachments/assets/83aad9f1-ede2-4737-af93-6622bbe03eca)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
