### PR TITLE
feat: Add base64 encode and decode variables (#3186)

### DIFF
--- a/src/backend/variables/builtin/text/atob.ts
+++ b/src/backend/variables/builtin/text/atob.ts
@@ -1,0 +1,26 @@
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+import base64Decode from './base64-decode';
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: 'atob',
+        usage: 'atob[string]',
+        description: 'Decodes a base64 encoded string. If the string is not valid base64, it will return an empty string.',
+        examples: [
+            {
+                usage: 'atob[SGVsbG8sIFdvcmxkIQ==]',
+                description: 'Decodes the base64 string "SGVsbG8sIFdvcmxkIQ==" back to "Hello, World!".'
+            },
+            {
+                usage: 'atob[test string]',
+                description: 'Returns an empty string because "test string" is not valid base64.'
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: base64Decode.evaluator
+};
+
+export default model;

--- a/src/backend/variables/builtin/text/base64-decode.ts
+++ b/src/backend/variables/builtin/text/base64-decode.ts
@@ -1,0 +1,36 @@
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+
+import { convertToString } from '../../../utility';
+import logger from '../../../logwrapper';
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: 'base64Decode',
+        usage: 'base64Decode[string]',
+        description: 'Decodes a base64 encoded string. If the string is not valid base64, it will return an empty string.',
+        examples: [
+            {
+                usage: 'base64Decode[SGVsbG8sIFdvcmxkIQ==]',
+                description: 'Decodes the base64 string "SGVsbG8sIFdvcmxkIQ==" back to "Hello, World!".'
+            },
+            {
+                usage: 'base64Decode[test string]',
+                description: 'Returns an empty string because "test string" is not valid base64.'
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    async evaluator(_, text: unknown): Promise<string> {
+        const decoder = new TextDecoder();
+        try {
+            return decoder.decode(Uint8Array.from(atob(convertToString(text)), c => c.charCodeAt(0)));
+        } catch {
+            logger.error(`Failed to decode base64 string: ${convertToString(text)}`);
+            return "";
+        }
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/text/base64-encode.ts
+++ b/src/backend/variables/builtin/text/base64-encode.ts
@@ -1,0 +1,26 @@
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+
+import { convertToString } from '../../../utility';
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: 'base64Encode',
+        usage: 'base64Encode[string]',
+        description: 'Encodes a string into base64.',
+        examples: [
+            {
+                usage: 'base64Encode["Hello, World!"]',
+                description: 'Encodes the string "Hello, World!" in to base64 (yielding "SGVsbG8sIFdvcmxkIQ==").'
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    async evaluator(_, text: unknown): Promise<string> {
+        const encoder = new TextEncoder();
+        return btoa(String.fromCharCode(...encoder.encode(convertToString(text))));
+    }
+};
+
+export default model;

--- a/src/backend/variables/builtin/text/btoa.ts
+++ b/src/backend/variables/builtin/text/btoa.ts
@@ -1,0 +1,22 @@
+import { ReplaceVariable } from "../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../shared/variable-constants";
+import base64Encode from '../text/base64-encode';
+
+const model: ReplaceVariable = {
+    definition: {
+        handle: 'btoa',
+        usage: 'btoa[string]',
+        description: 'Encodes a string into base64.',
+        examples: [
+            {
+                usage: 'btoa["Hello, World!"]',
+                description: 'Encodes the string "Hello, World!" in to base64 (yielding "SGVsbG8sIFdvcmxkIQ==").'
+            }
+        ],
+        categories: [VariableCategory.ADVANCED],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: base64Encode.evaluator
+};
+
+export default model;

--- a/src/backend/variables/builtin/text/index.ts
+++ b/src/backend/variables/builtin/text/index.ts
@@ -1,3 +1,8 @@
+import atob from './atob';
+import base64Decode from './base64-decode';
+import base64Encode from './base64-encode';
+import btoa from './btoa';
+
 import regexExec from './regex-exec';
 import regexMatches from './regex-matches';
 import regexMatchesRaw from './regex-matches-raw';
@@ -27,6 +32,10 @@ import textWord from './text-word';
 
 
 export default [
+    atob,
+    base64Decode,
+    base64Encode,
+    btoa,
     regexExec,
     regexMatches,
     regexMatchesRaw,


### PR DESCRIPTION
### Description of the Change
This PR adds two new base64 related variables: `$base64Encode` and `$base64Decode`, and two new variables that alias those: `$btoa` and `$atob` respectively.

Note: The implementation here should work properly with emojis or other multi-byte Unicode characters as well (tested this).

Note: The original issue (which I wrote) had these as `base64encode` and `base64decode`, but looking at the other variables in that directory, they seem to use camelCase, so I did too.

### Applicable Issues
Fixes https://github.com/crowbartools/Firebot/issues/3186


### Testing
Tested this in a chat feed alert. See screenshot.


### Screenshots

![image](https://github.com/user-attachments/assets/0dde93ee-386a-44a3-a418-6e71b10ea26c)

![image](https://github.com/user-attachments/assets/f37f4883-8dd8-48ab-9398-2b7f8f6db02a)

This is in the log:

```
[2025-06-19 06:32:11.0701] - error: Failed to decode base64 string: !
```

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
