### PR TITLE
fix: setup delete not working (#3191) 

### DIFF
--- a/src/backend/hotkeys/hotkey-manager.ts
+++ b/src/backend/hotkeys/hotkey-manager.ts
@@ -65,7 +65,7 @@ class HotkeyManager {
     }
 
     addHotkey(hotkey: FirebotHotkey) {
-        hotkey.id = uuid();
+        hotkey.id ??= uuid();
 
         this.hotkeys.push(hotkey);
         this.registerHotkey(hotkey.code);

--- a/src/backend/import/setups/setup-importer.js
+++ b/src/backend/import/setups/setup-importer.js
@@ -210,7 +210,7 @@ async function importSetup(setup, selectedCurrency) {
 function removeSetupComponents(components) {
     Object.entries(components)
         .forEach(([componentType, componentList]) => {
-            componentList.forEach((id) => {
+            componentList.forEach(({ id }) => {
                 switch (componentType) {
                     case "commands":
                         commandManager.deleteCustomCommand(id);

--- a/src/backend/import/setups/setup-importer.js
+++ b/src/backend/import/setups/setup-importer.js
@@ -219,7 +219,7 @@ function removeSetupComponents(components) {
                         CounterManager.deleteItem(id);
                         break;
                     case "currencies":
-                        currencyAccess.deleteCurrency(id);
+                        currencyAccess.deleteCurrency({ id });
                         break;
                     case "effectQueues":
                         effectQueueManager.deleteItem(id);


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fix the deletion of setup components not working
Improve setup handling for hotkeys


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3191

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
1. Created an item in each of the following categories:
  - commands
  - counters
  - currencies
  - effect queues
  - events
  - event sets
  - hotkeys
  - preset effect lists
  - timers
  - scheduled effect lists
  - variable macros
  - viewer roles
  - rank ladders
  - quick actions
2. Added each to the same setup
3. Used Remove Setup to remove components from the setup
4. Verified all components are gone
5. Imported the setup
6. Repeated steps 3 and 4