### PR TITLE
feat: Twitch Automatic Channel Point Redeems (#3151)

### DIFF
--- a/src/backend/events/builtin/twitch-event-source.js
+++ b/src/backend/events/builtin/twitch-event-source.js
@@ -498,6 +498,129 @@ module.exports = {
             }
         },
         {
+            id: "channel-points-redemption-single-message-bypass-sub-mode",
+            name: "Channel Points Redemption: Send a Message in Sub-Only Mode",
+            description: "When someone redeems \"Send a Message in Sub-Only Mode\" to post a message in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                channelPoints: 200,
+                messageText: "Test message"
+            },
+            activityFeed: {
+                icon: "fad fa-stopwatch",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    const message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **Send a Message in Sub-Only Mode**.`;
+                    return message;
+                }
+            }
+        },
+        {
+            id: "channel-points-redemption-send-highlighted-message",
+            name: "Channel Points Redemption: Highlight My Message",
+            description: "When someone redeems \"Highlight My Message\" in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                channelPoints: 200,
+                messageText: "Test message"
+            },
+            activityFeed: {
+                icon: "fad fa-stopwatch",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    const message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **Highlight My Message**.`;
+                    return message;
+                }
+            }
+        },
+        {
+            id: "channel-points-redemption-random-sub-emote-unlock",
+            name: "Channel Points Redemption: Unlock a Random Sub Emote",
+            description: "When someone redeems \"Unlock a Random Sub Emote\" to unlock an emote in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                channelPoints: 200,
+                emoteName: "PogChamp",
+                emoteUrl: "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
+            },
+            activityFeed: {
+                icon: "fad fa-stopwatch",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    const message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **Unlock a Random Sub Emote**.`;
+                    return message;
+                }
+            }
+        },
+        {
+            id: "channel-points-redemption-chosen-sub-emote-unlock",
+            name: "Channel Points Redemption: Choose an Emote to Unlock",
+            description: "When someone redeems \"Choose an Emote to Unlock\" to unlock an emote in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                channelPoints: 200,
+                emoteName: "PogChamp",
+                emoteUrl: "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
+            },
+            activityFeed: {
+                icon: "fad fa-stopwatch",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    const message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **Choose an Emote to Unlock**.`;
+                    return message;
+                }
+            }
+        },
+        {
+            id: "channel-points-redemption-chosen-modified-sub-emote-unlock",
+            name: "Channel Points Redemption: Modify a Single Emote",
+            description: "When someone redeems \"Modify a Single Emote\" to modify and unlock an emote in your channel",
+            cached: false,
+            queued: false,
+            manualMetadata: {
+                username: "firebot",
+                userDisplayName: "Firebot",
+                userId: "",
+                channelPoints: 200,
+                emoteName: "PogChamp",
+                emoteUrl: "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0"
+            },
+            activityFeed: {
+                icon: "fad fa-stopwatch",
+                getMessage: (eventData) => {
+                    const showUserIdName = eventData.username.toLowerCase() !== eventData.userDisplayName.toLowerCase();
+                    const message = `**${eventData.userDisplayName}${
+                        showUserIdName ? ` (${eventData.username})` : ""
+                    }** redeemed **Modify a Single Emote**.`;
+                    return message;
+                }
+            }
+        },
+        {
             id: "channel-reward-redemption",
             name: "Channel Reward Redemption",
             description: "When someone redeems a CUSTOM channel reward",

--- a/src/backend/events/twitch-events.js
+++ b/src/backend/events/twitch-events.js
@@ -11,6 +11,7 @@ exports.follow = require("./twitch-events/follow");
 exports.giftSub = require("./twitch-events/gift-sub");
 exports.goal = require("./twitch-events/goal");
 exports.hypeTrain = require("./twitch-events/hype-train");
+exports.pointsRedemption = require("./twitch-events/points-redemption");
 exports.poll = require("./twitch-events/poll");
 exports.prediction = require("./twitch-events/prediction");
 exports.raid = require("./twitch-events/raid");

--- a/src/backend/events/twitch-events/points-redemption.ts
+++ b/src/backend/events/twitch-events/points-redemption.ts
@@ -1,0 +1,97 @@
+import eventManager from "../../events/EventManager";
+
+export function triggerRedemptionSingleMessageBypassSubMode(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    channelPoints: number,
+    messageText: string
+): void {
+    const rewardDescription = "Send a Message in Sub-Only Mode";
+    eventManager.triggerEvent("twitch", "channel-points-redemption-single-message-bypass-sub-mode", {
+        username,
+        userId,
+        userDisplayName,
+        channelPoints,
+        messageText,
+        rewardDescription
+    });
+}
+
+export function triggerRedemptionSendHighlightedMessage(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    channelPoints: number,
+    messageText: string
+): void {
+    const rewardDescription = "Highlight My Message";
+    eventManager.triggerEvent("twitch", "channel-points-redemption-send-highlighted-message", {
+        username,
+        userId,
+        userDisplayName,
+        channelPoints,
+        messageText,
+        rewardDescription
+    });
+}
+
+export function triggerRedemptionRandomSubEmoteUnlock(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    channelPoints: number,
+    emoteName: string,
+    emoteUrl: string
+): void {
+    const rewardDescription = "Unlock a Random Sub Emote";
+    eventManager.triggerEvent("twitch", "channel-points-redemption-unlock-random-sub-emote", {
+        username,
+        userId,
+        userDisplayName,
+        channelPoints,
+        emoteName,
+        emoteUrl,
+        rewardDescription
+    });
+}
+
+export function triggerRedemptionChosenSubEmoteUnlock(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    channelPoints: number,
+    emoteName: string,
+    emoteUrl: string
+): void {
+    const rewardDescription = "Choose an Emote to Unlock";
+    eventManager.triggerEvent("twitch", "channel-points-redemption-chosen-sub-emote-unlock", {
+        username,
+        userId,
+        userDisplayName,
+        channelPoints,
+        emoteName,
+        emoteUrl,
+        rewardDescription
+    });
+}
+
+export function triggerRedemptionChosenModifiedSubEmoteUnlock(
+    username: string,
+    userId: string,
+    userDisplayName: string,
+    channelPoints: number,
+    emoteName: string,
+    emoteUrl: string
+): void {
+    const rewardDescription = "Modify a Single Emote";
+    eventManager.triggerEvent("twitch", "channel-points-redemption-chosen-modified-sub-emote-unlock", {
+        username,
+        userId,
+        userDisplayName,
+        channelPoints,
+        emoteName,
+        emoteUrl,
+        rewardDescription
+    });
+}

--- a/src/backend/twitch-api/eventsub/eventsub-client.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-client.ts
@@ -106,6 +106,62 @@ class TwitchEventSubClient {
         );
         this._subscriptions.push(autoModMessageUpdateSub);
 
+        // Channel automatic reward
+        const channelAutomaticRewardSubscription = this._eventSubListener.onChannelAutomaticRewardRedemptionAddV2(streamer.userId, async (event) => {
+            switch (event.reward.type) {
+                case "single_message_bypass_sub_mode":
+                    twitchEventsHandler.pointsRedemption.triggerRedemptionSingleMessageBypassSubMode(
+                        event.userName,
+                        event.userId,
+                        event.userDisplayName,
+                        event.reward.channelPoints,
+                        event.messageText
+                    );
+                    break;
+                case "send_highlighted_message":
+                    twitchEventsHandler.pointsRedemption.triggerRedemptionSendHighlightedMessage(
+                        event.userName,
+                        event.userId,
+                        event.userDisplayName,
+                        event.reward.channelPoints,
+                        event.messageText
+                    );
+                    break;
+                case "random_sub_emote_unlock":
+                    twitchEventsHandler.pointsRedemption.triggerRedemptionRandomSubEmoteUnlock(
+                        event.userName,
+                        event.userId,
+                        event.userDisplayName,
+                        event.reward.channelPoints,
+                        event.reward.emote.name,
+                        `https://static-cdn.jtvnw.net/emoticons/v2/${event.reward.emote.id}/default/dark/3.0`
+                    );
+                    break;
+                case "chosen_sub_emote_unlock":
+                    twitchEventsHandler.pointsRedemption.triggerRedemptionChosenSubEmoteUnlock(
+                        event.userName,
+                        event.userId,
+                        event.userDisplayName,
+                        event.reward.channelPoints,
+                        event.reward.emote.name,
+                        `https://static-cdn.jtvnw.net/emoticons/v2/${event.reward.emote.id}/default/dark/3.0`
+                    );
+                    break;
+                case "chosen_modified_sub_emote_unlock":
+                    twitchEventsHandler.pointsRedemption.triggerRedemptionChosenModifiedSubEmoteUnlock(
+                        event.userName,
+                        event.userId,
+                        event.userDisplayName,
+                        event.reward.channelPoints,
+                        event.reward.emote.name,
+                        `https://static-cdn.jtvnw.net/emoticons/v2/${event.reward.emote.id}/default/dark/3.0`
+                    );
+                    break;
+
+            }
+        });
+        this._subscriptions.push(channelAutomaticRewardSubscription);
+
         // Channel custom reward
         const customRewardRedemptionSubscription = this._eventSubListener.onChannelRedemptionAdd(streamer.userId, async (event) => {
             const reward = await twitchApi.channelRewards.getCustomChannelReward(event.rewardId);

--- a/src/backend/variables/builtin/twitch/index.ts
+++ b/src/backend/variables/builtin/twitch/index.ts
@@ -5,6 +5,7 @@ import charityVariables from './charity';
 import cheerVariables from './cheer';
 import cheermoteVariables from './cheermote';
 import hypetrainVariables from './hype-train';
+import pointsRedemptionVariables from './points-redemption';
 import pollVariables from './polls';
 import raidVariables from './raid';
 import rewardVariables from './reward';
@@ -27,6 +28,7 @@ export default [
     ...cheerVariables,
     ...cheermoteVariables,
     ...hypetrainVariables,
+    ...pointsRedemptionVariables,
     ...pollVariables,
     ...raidVariables,
     ...rewardVariables,

--- a/src/backend/variables/builtin/twitch/points-redemption/index.ts
+++ b/src/backend/variables/builtin/twitch/points-redemption/index.ts
@@ -1,0 +1,9 @@
+import redemptionMessage from "./redemption-message";
+import unlockedEmoteName from "./unlocked-emote-name";
+import unlockedEmoteUrl from "./unlocked-emote-url";
+
+export default [
+    redemptionMessage,
+    unlockedEmoteName,
+    unlockedEmoteUrl
+];

--- a/src/backend/variables/builtin/twitch/points-redemption/redemption-message.ts
+++ b/src/backend/variables/builtin/twitch/points-redemption/redemption-message.ts
@@ -1,0 +1,24 @@
+import { ReplaceVariable, Trigger } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = [
+    "twitch:channel-points-redemption-single-message-bypass-sub-mode",
+    "twitch:channel-points-redemption-send-highlighted-message"
+];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "redemptionMessage",
+        description: "The message associated with the channel points redemption",
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT],
+        triggers: triggers
+    },
+    evaluator: (trigger: Trigger) => trigger.metadata.eventData.messageText || ""
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/points-redemption/unlocked-emote-name.ts
+++ b/src/backend/variables/builtin/twitch/points-redemption/unlocked-emote-name.ts
@@ -1,0 +1,25 @@
+import { ReplaceVariable, Trigger } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = [
+    "twitch:channel-points-redemption-random-sub-emote-unlock",
+    "twitch:channel-points-redemption-chosen-sub-emote-unlock",
+    "twitch:channel-points-redemption-chosen-modified-sub-emote-unlock"
+];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "unlockedEmoteName",
+        description: "The name of the unlocked emote",
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT],
+        triggers: triggers
+    },
+    evaluator: (trigger: Trigger) => trigger.metadata.eventData.emoteName || ""
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/points-redemption/unlocked-emote-url.ts
+++ b/src/backend/variables/builtin/twitch/points-redemption/unlocked-emote-url.ts
@@ -1,0 +1,25 @@
+import { ReplaceVariable, Trigger } from "../../../../../types/variables";
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+
+import { EffectTrigger } from "../../../../../shared/effect-constants";
+
+const triggers = {};
+triggers[EffectTrigger.EVENT] = [
+    "twitch:channel-points-redemption-random-sub-emote-unlock",
+    "twitch:channel-points-redemption-chosen-sub-emote-unlock",
+    "twitch:channel-points-redemption-chosen-modified-sub-emote-unlock"
+];
+triggers[EffectTrigger.MANUAL] = true;
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "unlockedEmoteUrl",
+        description: "The URL of the unlocked emote",
+        categories: [VariableCategory.COMMON],
+        possibleDataOutput: [OutputDataType.TEXT],
+        triggers: triggers
+    },
+    evaluator: (trigger: Trigger) => trigger.metadata.eventData.emoteUrl || ""
+};
+
+export default model;

--- a/src/backend/variables/builtin/twitch/reward/reward-cost.ts
+++ b/src/backend/variables/builtin/twitch/reward/reward-cost.ts
@@ -49,7 +49,7 @@ const model : ReplaceVariable = {
             return -1;
         }
 
-        return rewardData.rewardCost;
+        return rewardData.rewardCost || rewardData.channelPoints;
     }
 };
 


### PR DESCRIPTION
### Description of the Change

This pull request adds support for the following Twitch Automatic channel point redeems:

- Send a message in sub-only mode
- Highlight my message
- Unlock a random emote
- Unlock a chosen emote
- Modify an emote

All of these events provide `$rewardCost` (Note 1) and `$rewardDescription` (Note 2)
Both message events provide `$redemptionMessage`
The three emote events provide `$unlockedEmoteUrl` and `$unlockedEmoteUrl`

Notes:

1. I chose to use the existing `$rewardCost` associated with custom redeems rather than implement a new variable for this. The underlying variable from Twurple is `channelPoints`.

2. `$rewardDescription` is available for the custom rewards but is not actually sent in the event. For the convenience of the user I just hard-coded this along with each of the events so things will be consistent with custom redeems.

### Applicable Issues

#3151 

### Testing

Tested all events on my channel. See screenshots.

### Screenshots

(Coming soon)

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
