### PR TITLE
chore: cache channel rewards & redemptions (#3094)

### DIFF
--- a/src/backend/auth/twitch-auth.ts
+++ b/src/backend/auth/twitch-auth.ts
@@ -4,6 +4,7 @@ import logger from "../logwrapper";
 import { SecretsManager } from "../secrets-manager";
 import { AuthProviderDefinition } from "./auth";
 import { getExpiryDateOfAccessToken } from "@twurple/auth";
+import channelRewardManager from "../channel-rewards/channel-reward-manager";
 
 class TwitchAuthProviders {
     private readonly _host = "https://id.twitch.tv";
@@ -184,6 +185,10 @@ authManager.on("auth-success", async (authData) => {
         };
 
         accountAccess.updateAccount(accountType, accountObject);
+
+        if (accountType === "streamer") {
+            channelRewardManager.loadChannelRewards(true);
+        }
     }
 });
 

--- a/src/backend/common/connection-manager.js
+++ b/src/backend/common/connection-manager.js
@@ -55,7 +55,9 @@ function emitServiceConnectionUpdateEvents(serviceId, connectionState) {
 twitchChat.on("connected", () => {
     emitServiceConnectionUpdateEvents("chat", ConnectionState.Connected);
     const rewardsManager = require("../channel-rewards/channel-reward-manager");
-    rewardsManager.refreshChannelRewardRedemptions();
+    rewardsManager.loadChannelRewards(true).then(() => {
+        rewardsManager.refreshChannelRewardRedemptions();
+    });
 });
 twitchChat.on("disconnected", () => emitServiceConnectionUpdateEvents("chat", ConnectionState.Disconnected));
 twitchChat.on("connecting", () => emitServiceConnectionUpdateEvents("chat", ConnectionState.Connecting));

--- a/src/backend/twitch-api/eventsub/eventsub-client.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-client.ts
@@ -11,6 +11,9 @@ import rewardManager from "../../channel-rewards/channel-reward-manager";
 import chatRolesManager from "../../roles/chat-roles-manager";
 import chatHelpers from "../../chat/chat-helpers";
 import viewerDatabase from "../../viewers/viewer-database";
+import { SavedChannelReward } from "../../../types/channel-rewards";
+import channelRewardManager from "../../channel-rewards/channel-reward-manager";
+import { getChannelRewardImageUrl, mapEventSubRewardToTwitchData } from "./eventsub-helpers";
 
 class TwitchEventSubClient {
     private _eventSubListener: EventSubWsListener;
@@ -88,26 +91,45 @@ class TwitchEventSubClient {
         });
         this._subscriptions.push(autoModMessageUpdateSub);
 
+
+        // Channel custom reward add
+        const customRewardAddSubscription = this._eventSubListener.onChannelRewardAdd(streamer.userId, async (event) => {
+            channelRewardManager.saveTwitchDataForChannelReward(mapEventSubRewardToTwitchData(event));
+        });
+        this._subscriptions.push(customRewardAddSubscription);
+
+        // Channel custom reward update
+        const customRewardUpdateSubscription = this._eventSubListener.onChannelRewardUpdate(streamer.userId, async (event) => {
+            channelRewardManager.saveTwitchDataForChannelReward(mapEventSubRewardToTwitchData(event));
+        });
+        this._subscriptions.push(customRewardUpdateSubscription);
+
+        // Channel custom reward remove
+        const customRewardRemoveSubscription = this._eventSubListener.onChannelRewardRemove(streamer.userId, async (event) => {
+            const firebotReward: SavedChannelReward | null = channelRewardManager.getChannelReward(event.id);
+
+            if (!firebotReward) {
+                return;
+            }
+
+            await channelRewardManager.deleteChannelReward(event.id, false, true);
+        });
+        this._subscriptions.push(customRewardRemoveSubscription);
+
         // Channel custom reward
         const customRewardRedemptionSubscription = this._eventSubListener.onChannelRedemptionAdd(streamer.userId, async (event) => {
-            const reward = await twitchApi.channelRewards.getCustomChannelReward(event.rewardId);
-            let imageUrl = "";
-
-            if (reward && reward.defaultImage) {
-                const images = reward.defaultImage;
-                if (images.url4x) {
-                    imageUrl = images.url4x;
-                } else if (images.url2x) {
-                    imageUrl = images.url2x;
-                } else if (images.url1x) {
-                    imageUrl = images.url1x;
-                }
+            const reward = channelRewardManager.getChannelReward(event.rewardId);
+            if (!reward) {
+                logger.debug(`Received a reward redemption for a reward that does not exist locally. Reward: ${event.rewardTitle}`, event);
+                return;
             }
+
+            const imageUrl = getChannelRewardImageUrl(reward.twitchData);
 
             twitchEventsHandler.rewardRedemption.handleRewardRedemption(
                 event.id,
                 event.status,
-                !reward.shouldRedemptionsSkipRequestQueue,
+                !reward.twitchData.shouldRedemptionsSkipRequestQueue,
                 event.input,
                 event.userId,
                 event.userName,
@@ -119,26 +141,33 @@ class TwitchEventSubClient {
                 imageUrl
             );
 
-            if (!reward.shouldRedemptionsSkipRequestQueue) {
-                rewardManager.refreshChannelRewardRedemptions();
+            if (!reward.twitchData.shouldRedemptionsSkipRequestQueue && reward.manageable) {
+                rewardManager.addRewardRedemption(event.rewardId, {
+                    id: event.id,
+                    rewardId: event.rewardId,
+                    redemptionDate: event.redemptionDate,
+                    userId: event.userId,
+                    userName: event.userName,
+                    userDisplayName: event.userDisplayName,
+                    rewardMessage: event.input
+                });
             }
         });
         this._subscriptions.push(customRewardRedemptionSubscription);
 
         const customRewardRedemptionUpdateSubscription = this._eventSubListener.onChannelRedemptionUpdate(streamer.userId, async (event) => {
-            const reward = await twitchApi.channelRewards.getCustomChannelReward(event.rewardId);
-            let imageUrl = "";
-
-            if (reward && reward.defaultImage) {
-                const images = reward.defaultImage;
-                if (images.url4x) {
-                    imageUrl = images.url4x;
-                } else if (images.url2x) {
-                    imageUrl = images.url2x;
-                } else if (images.url1x) {
-                    imageUrl = images.url1x;
-                }
+            const reward = channelRewardManager.getChannelReward(event.rewardId);
+            if (!reward) {
+                logger.debug(`Received a reward redemption update for a reward that does not exist locally. Reward: ${event.rewardTitle}`, event);
+                return;
             }
+
+            if (reward.twitchData.shouldRedemptionsSkipRequestQueue) {
+                logger.debug(`Received a reward redemption update for a reward that should skip the request queue. Reward: ${event.rewardTitle}`, event);
+                return;
+            }
+
+            const imageUrl = getChannelRewardImageUrl(reward.twitchData);
 
             twitchEventsHandler.rewardRedemption.handleRewardUpdated(
                 event.id,
@@ -154,7 +183,9 @@ class TwitchEventSubClient {
                 imageUrl
             );
 
-            rewardManager.refreshChannelRewardRedemptions();
+            if (reward.manageable) {
+                rewardManager.removeRewardRedemption(event.rewardId, event.id);
+            }
         });
         this._subscriptions.push(customRewardRedemptionUpdateSubscription);
 

--- a/src/backend/twitch-api/eventsub/eventsub-helpers.ts
+++ b/src/backend/twitch-api/eventsub/eventsub-helpers.ts
@@ -1,0 +1,47 @@
+import { EventSubChannelRewardEvent } from "@twurple/eventsub-base";
+import { CustomReward } from "../resource/channel-rewards";
+
+export function mapEventSubRewardToTwitchData(event: EventSubChannelRewardEvent): CustomReward {
+    const image = {
+        url1x: event.getImageUrl(1),
+        url2x: event.getImageUrl(2),
+        url4x: event.getImageUrl(4)
+    };
+
+    const customReward: CustomReward = {
+        broadcasterId: event.broadcasterId,
+        broadcasterLogin: event.broadcasterName,
+        broadcasterName: event.broadcasterDisplayName,
+        id: event.id,
+        title: event.title,
+        prompt: event.prompt,
+        cost: event.cost,
+        image: image,
+        defaultImage: image,
+        backgroundColor: event.backgroundColor,
+        isEnabled: event.isEnabled,
+        isUserInputRequired: event.userInputRequired,
+        maxPerStreamSetting: {
+            isEnabled: event.maxRedemptionsPerStream !== null,
+            maxPerStream: event.maxRedemptionsPerStream
+        },
+        maxPerUserPerStreamSetting: {
+            isEnabled: event.maxRedemptionsPerUserPerStream !== null,
+            maxPerUserPerStream: event.maxRedemptionsPerUserPerStream
+        },
+        globalCooldownSetting: {
+            isEnabled: event.globalCooldown !== null,
+            globalCooldownSeconds: event.globalCooldown ? Math.ceil((new Date(event.globalCooldown).getTime() - Date.now()) / 1000) : null
+        },
+        isPaused: event.isPaused,
+        isInStock: event.isInStock,
+        shouldRedemptionsSkipRequestQueue: event.autoApproved,
+        cooldownExpiresAt: event.cooldownExpiryDate
+    };
+
+    return customReward;
+}
+
+export function getChannelRewardImageUrl(reward: CustomReward): string {
+    return reward.image?.url4x || reward.image?.url2x || reward.image?.url1x || "";
+}

--- a/src/gui/app/services/channel-rewards.service.js
+++ b/src/gui/app/services/channel-rewards.service.js
@@ -1,10 +1,10 @@
 "use strict";
 
-(function() {
+(function () {
 
     angular
         .module("firebotApp")
-        .factory("channelRewardsService", function($q,
+        .factory("channelRewardsService", function ($q,
             backendCommunicator, utilityService, objectCopyHelper, ngToast) {
             const service = {};
 
@@ -64,7 +64,7 @@
                     resolveObj: {
                         reward: () => reward
                     },
-                    closeCallback: () => {}
+                    closeCallback: () => { }
                 });
             };
 
@@ -160,8 +160,17 @@
                 }));
             };
 
+            backendCommunicator.on("channel-rewards-updated", (channelRewards) => {
+                service.channelRewards = channelRewards;
+            });
+
             backendCommunicator.on("channel-reward-updated", (channelReward) => {
                 updateChannelReward(channelReward);
+            });
+
+            backendCommunicator.on("channel-reward-deleted", (channelRewardId) => {
+                service.channelRewards = service.channelRewards.filter(cr => cr.id !== channelRewardId);
+                delete service.redemptions[channelRewardId];
             });
 
             backendCommunicator.on("channel-reward-redemptions-updated", (redemptions) => {


### PR DESCRIPTION
### Description of the Change
This PR switches channel reward redemptions from using API requests to using cached data.
Additionally, channel reward create, update and delete events, as well as redemption events now update the cache.
Channel rewards are now loaded at 3 distinct times (startup, login and connect) while redemptions are still only loaded on connect.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3094 

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured that logging into an account that doesn't have access to channel points (currently judged by affiliate/partner check) produces a console 403 error and does not give access to channel rewards on the page.

Ensured that logging into a streamer account attempts to sync the channel reward list. If the streamer account has access to channel points, it populates the channel reward list, updating the UI if you're already on the channel rewards page.

Ensured that connecting to Twitch when logged into an eligible account, the list of rewards and redemptions is refreshed.

Ensured that adding or editing a reward from Firebot properly sets the reward as manageable

Ensured adding or a reward from Twitch properly saves it as not manageable

Ensured editing a reward from Twitch does not affect the manageable flag of the reward

Ensured editing a reward from Twitch or Firebot properly updates the reward in Twitch and Firebot

Ensured deleting a reward from either Twitch or Firebot works properly, removing the reward from the database and UI

Ensured new redemptions only add to the redemption cache if the reward is in Twitch Queue and manageable by Firebot

Ensured redemption updates properly remove the redemption from the cache

Ensured effects for On Redeem, On Approve and On Reject still work