### PR TITLE
feat(variables): :sparkles: Added filters and variables for if channel is live

### DIFF
--- a/src/backend/chat/commands/command-runner.ts
+++ b/src/backend/chat/commands/command-runner.ts
@@ -1,13 +1,14 @@
-import { CommandDefinition, UserCommand } from "../../../types/commands";
 import { FirebotChatMessage } from "../../../types/chat";
+import { CommandDefinition, UserCommand } from "../../../types/commands";
 import { Trigger } from "../../../types/triggers";
 import { TriggerType } from "../../common/EffectType";
 
-import logger from "../../logwrapper";
-import frontendCommunicator from "../../common/frontend-communicator";
 import accountAccess from "../../common/account-access";
-import chatHelpers from "../chat-helpers";
 import effectRunner from "../../common/effect-runner";
+import frontendCommunicator from "../../common/frontend-communicator";
+import logger from "../../logwrapper";
+import twitchStreamInfoManager from "../../twitch-api/stream-info-manager";
+import chatHelpers from "../chat-helpers";
 import commandManager from "./command-manager";
 
 interface TriggerWithArgs {
@@ -99,6 +100,10 @@ class CommandRunner {
     }
 
     private execute(command: CommandDefinition, userCommand: UserCommand, firebotChatMessage?: FirebotChatMessage, manual = false) {
+        if (command.onlyTriggerWhenChannelIsLive && !twitchStreamInfoManager.streamInfo.isLive && !manual) {
+            return;
+        }
+
         let effects = command.effects;
         if (command.subCommands && command.subCommands.length > 0 && userCommand.subcommandId != null) {
             if (userCommand.subcommandId === "fallback-subcommand" && command.fallbackSubcommand) {

--- a/src/backend/events/filters/builtin/twitch/channel-live.ts
+++ b/src/backend/events/filters/builtin/twitch/channel-live.ts
@@ -1,0 +1,53 @@
+import { ComparisonType } from "../../../../../shared/filter-constants";
+import { EventFilter } from "../../../../../types/events";
+import twitchStreamInfoManager from "../../../../twitch-api/stream-info-manager";
+
+const filter: EventFilter = {
+    id: "firebot:channel-live",
+    name: "Channel is Live",
+    description: "Filter by whether or not channel is live",
+    events: [
+        { eventSourceId: "firebot", eventId: "category-changed" },
+        { eventSourceId: "twitch", eventId: "announcement" },
+        { eventSourceId: "twitch", eventId: "bits-badge-unlocked" },
+        { eventSourceId: "twitch", eventId: "category-changed" },
+        { eventSourceId: "twitch", eventId: "channel-reward-redemption" },
+        { eventSourceId: "twitch", eventId: "chat-message" },
+        { eventSourceId: "twitch", eventId: "chat-mode-changed" },
+        { eventSourceId: "twitch", eventId: "cheer" },
+        { eventSourceId: "twitch", eventId: "community-subs-gifted" },
+        { eventSourceId: "twitch", eventId: "first-time-chat" },
+        { eventSourceId: "twitch", eventId: "gift-sub-upgraded" },
+        { eventSourceId: "twitch", eventId: "hype-train-end" },
+        { eventSourceId: "twitch", eventId: "hype-train-progress" },
+        { eventSourceId: "twitch", eventId: "hype-train-start" },
+        { eventSourceId: "twitch", eventId: "prime-sub-upgraded" },
+        { eventSourceId: "twitch", eventId: "raid" },
+        { eventSourceId: "twitch", eventId: "raid-sent-off" },
+        { eventSourceId: "twitch", eventId: "sub" },
+        { eventSourceId: "twitch", eventId: "subs-gifted" },
+        { eventSourceId: "twitch", eventId: "viewer-arrived" }
+    ],
+    comparisonTypes: [ComparisonType.IS],
+    valueType: "preset",
+    presetValues: async () => {
+        return [
+            {
+                value: "true",
+                display: "True"
+            },
+            {
+                value: "false",
+                display: "False"
+            }
+        ];
+    },
+    predicate: async (filterSettings) => {
+        const { value } = filterSettings;
+        const { isLive } = twitchStreamInfoManager.streamInfo;
+
+        return isLive.toString() === value;
+    }
+};
+
+export default filter;

--- a/src/backend/events/filters/builtin/twitch/index.ts
+++ b/src/backend/events/filters/builtin/twitch/index.ts
@@ -1,7 +1,8 @@
 import bitsBadgeTier from "./bits-badge-tier";
+import channelLive from "./channel-live";
+import chatMode from "./chat-mode";
 import chatModeDuration from "./chat-mode-duration";
 import chatModeSetting from "./chat-mode-setting";
-import chatMode from "./chat-mode";
 import cheerBitsAmount from "./cheer-bits-amount";
 import giftCount from "./gift-count";
 import giftDuration from "./gift-duration";
@@ -10,8 +11,8 @@ import isAnonymous from "./is-anonymous";
 import lifetimeGiftCount from "./lifetime-gift-count";
 import message from "./message";
 import raidViewerCount from "./raid-viewer-count";
-import rewardName from "./reward-name";
 import reward from "./reward";
+import rewardName from "./reward-name";
 import sharedChat from "./shared-chat";
 import sharedTrain from "./shared-train";
 import streamCategory from "./stream-category";
@@ -22,6 +23,7 @@ import username from "./username";
 
 export default [
     bitsBadgeTier,
+    channelLive,
     chatModeDuration,
     chatModeSetting,
     chatMode,

--- a/src/backend/variables/builtin/twitch/stream/index.ts
+++ b/src/backend/variables/builtin/twitch/stream/index.ts
@@ -1,11 +1,13 @@
 import category from './category';
 import categoryImageUrl from './category-image-url';
 import currentViewerCount from './current-viewer-count';
+import isChannelLive from './is-channel-live';
 import streamTitle from './stream-title';
 
 export default [
     category,
     categoryImageUrl,
     currentViewerCount,
+    isChannelLive,
     streamTitle
 ];

--- a/src/backend/variables/builtin/twitch/stream/is-channel-live.ts
+++ b/src/backend/variables/builtin/twitch/stream/is-channel-live.ts
@@ -1,0 +1,48 @@
+import { OutputDataType, VariableCategory } from "../../../../../shared/variable-constants";
+import { ReplaceVariable } from "../../../../../types/variables";
+import logger from "../../../../logwrapper";
+import twitchStreamInfoManager from "../../../../twitch-api/stream-info-manager";
+
+const TwitchApi = require("../../../../twitch-api/api");
+
+const model : ReplaceVariable = {
+    definition: {
+        handle: "isChannelLive",
+        usage: "isChannelLive",
+        description: "Outputs `true` if the Twitch channel is currently live, `false` if not",
+        examples: [
+            {
+                usage: "isChannelLive[$target]",
+                description: "When in a command, gets whether the associated user's channel is live."
+            },
+            {
+                usage: "isChannelLive[$user]",
+                description: "Gets whether the associated user's channel is live (Ie who triggered command, pressed button, etc)."
+            },
+            {
+                usage: "isChannelLive[Oceanity]",
+                description: "Gets whether a specific channel is live."
+            }
+        ],
+        categories: [VariableCategory.COMMON, VariableCategory.USER],
+        possibleDataOutput: [OutputDataType.TEXT]
+    },
+    evaluator: async (_trigger, username) => {
+        if (!username) {
+            return twitchStreamInfoManager.streamInfo.isLive;
+        }
+
+        let stream;
+
+        try {
+            stream = await TwitchApi.streamerClient.streams.getStreamByUserName(username);
+        } catch (error) {
+            logger.debug(`Unable to find channel with username "${username}"`, error);
+            return "[Channel not Found]";
+        }
+
+        return !!stream;
+    }
+};
+
+export default model;

--- a/src/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.html
+++ b/src/gui/app/directives/modals/commands/addOrEditCustomCommand/addOrEditCustomCommandModal.html
@@ -198,6 +198,18 @@
                                 />
                                 <div class="control__indicator"></div>
                             </label>
+                            <label class="control-fb control--checkbox"
+                                >Only trigger when channel is live
+                                <tooltip
+                                    text="'When this option is enabled, users will only be able to trigger this command when the channel is live.'"
+                                ></tooltip>
+                                <input
+                                    type="checkbox"
+                                    ng-model="$ctrl.command.onlyTriggerWhenChannelIsLive"
+                                    aria-label="..."
+                                />
+                                <div class="control__indicator"></div>
+                            </label>
                         </div>
                         <div class="controls-fb-inline mt-4">
                             <div class="settings-title">

--- a/src/types/commands.d.ts
+++ b/src/types/commands.d.ts
@@ -118,6 +118,7 @@ export type CommandDefinition = {
     subCommands?: SubCommand[] | undefined;
     fallbackSubcommand?: SubCommand | undefined;
     treatQuotedTextAsSingleArg?: boolean | undefined;
+    onlyTriggerWhenChannelIsLive?: boolean | undefined;
     minArgs?: number;
     options?: Record<keyof OptionsModel, CommandOption>;
     /**


### PR DESCRIPTION
### Description of the Change
Introduced a new `$isChannelLive`/`$isChannelLive[username]` variable and added filters to Commands and Events to only trigger when the channel is live


### Applicable Issues
#2703 


### Testing
Tested the filter working on commands and events by manually setting the `isLive` property in `streamInfo` in the `twitchStreamInfoManager`, tested the variable the same way to prove it worked without a passed username, and tested with various live and offline channels with the provided username.


### Screenshots
<img width="727" height="805" alt="Screenshot from 2025-09-13 00-20-56" src="https://github.com/user-attachments/assets/3aa308fd-8ebe-4a42-b081-166dfc2eff43" />

<img width="696" height="289" alt="Screenshot from 2025-09-13 00-21-25" src="https://github.com/user-attachments/assets/42ca091f-8986-4470-b577-4a0f1d6307bf" />

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
