### PR TITLE
feat(effects): "Highlight Message In Chat Feed" effect (#3190)

### DIFF
--- a/src/backend/effects/builtin-effect-loader.js
+++ b/src/backend/effects/builtin-effect-loader.js
@@ -10,6 +10,7 @@ exports.loadEffects = () => {
         'api',
         'celebration',
         'chat-feed-alert',
+        'chat-feed-custom-highlight',
         'chat-feed-message-hide',
         'chat',
         'clear-chat',

--- a/src/backend/effects/builtin/chat-feed-custom-highlight.ts
+++ b/src/backend/effects/builtin/chat-feed-custom-highlight.ts
@@ -1,0 +1,131 @@
+import { EffectCategory, EffectDependency, EffectTrigger } from '../../../shared/effect-constants';
+import { EffectType } from "../../../types/effects";
+import frontendCommunicator from "../../common/frontend-communicator";
+import logger from "../../logwrapper";
+
+const triggers = {};
+triggers[EffectTrigger.COMMAND] = true;
+triggers[EffectTrigger.EVENT] = ["twitch:chat-message", "twitch:viewer-arrived"];
+
+const model: EffectType<{
+    highlightEnabled: boolean;
+    bannerEnabled: boolean;
+    customHighlightColor?: string;
+    customBannerText?: string;
+    customBannerIcon?: string;
+}> = {
+    definition: {
+        id: "firebot:chat-feed-custom-highlight",
+        name: "Highlight Message In Chat Feed",
+        description: "Apply a custom highlight and/or banner to a message in the Firebot chat feed",
+        icon: "fas fa-highlighter",
+        categories: [EffectCategory.COMMON, EffectCategory.CHAT_BASED],
+        dependencies: [EffectDependency.CHAT],
+        triggers: triggers
+    },
+    optionsTemplate: `
+    <eos-container pad-top="true">
+        <p>This will highlight and/or add a banner to a chat message in the Firebot dashboard.</p>
+        <p>This does <b>not</b> affect how this message is displayed in Twitch chat, browser overlays, or any other chat client you may be using.</p>
+    </eos-container>
+
+    <eos-container header="Highlight" pad-top="true">
+        <firebot-checkbox
+            label="Highlight Message"
+            model="effect.highlightEnabled"
+        />
+
+        <p class="muted">Select the color for the highlight.</p>
+
+        <color-picker-input style="margin-top:10px" model="effect.customHighlightColor" label="Color"></color-picker-input>
+    </eos-container>
+
+    <eos-container header="Banner" pad-top="true">
+        <firebot-checkbox
+            label="Add a Banner"
+            model="effect.bannerEnabled"
+        />
+
+        <p class="muted">Enter the text for the banner.</p>
+
+        <firebot-input
+            model="effect.customBannerText"
+            placeholder-text="Enter banner text"
+            pad-top="true"
+            rows="4"
+            useTextArea="true"
+            cols="40"
+            menu-position="under"
+        />
+
+        <p class="muted" style="margin-top: 20px;">Select the icon for the banner.</p>
+
+        <input
+            maxlength="2"
+            type="text"
+            pad-top="true"
+            class="form-control"
+            ng-model="effect.customBannerIcon"
+            icon-picker required
+        />
+    </eos-container>
+    `,
+    optionsController: ($scope) => {
+        if ($scope.effect.customHighlightColor === undefined) {
+            $scope.effect.customHighlightColor = "#ffcc00"; // Default highlight color
+        }
+        if ($scope.effect.customBannerText === undefined) {
+            $scope.effect.customBannerText = ""; // Default banner text
+        }
+        if ($scope.effect.customBannerIcon === undefined) {
+            $scope.effect.customBannerIcon = "fas fa-circle-info"; // Default banner icon
+        }
+    },
+    optionsValidator: (effect) => {
+        const errors = [];
+        if (!effect.highlightEnabled && !effect.bannerEnabled) {
+            errors.push("At least one of 'Highlight Message' or 'Add a Banner' must be enabled, or this effect will not do anything.");
+        }
+        if (effect.highlightEnabled) {
+            if (!effect.customHighlightColor) {
+                errors.push("If 'Highlight Message' is enabled, you must provide a highlight color.");
+            } else if (!/^#[0-9A-Fa-f]{6}$/.test(effect.customHighlightColor)) {
+                errors.push("The highlight color must be a valid hex color code (e.g., #ffcc00).");
+            }
+        }
+        if (effect.bannerEnabled) {
+            if (!effect.customBannerIcon) {
+                errors.push("If 'Add a Banner' is enabled, you must provide a banner icon.");
+            }
+            if (!effect.customBannerText) {
+                errors.push("If 'Add a Banner' is enabled, you must provide banner text.");
+            }
+        }
+        return errors;
+    },
+    onTriggerEvent: async (event) => {
+        const { effect, trigger } = event;
+
+        let messageId: string | null = null;
+        if (trigger.type === EffectTrigger.COMMAND) {
+            messageId = trigger.metadata.chatMessage?.id;
+        } else if (trigger.type === EffectTrigger.EVENT) {
+            messageId = trigger.metadata.eventData?.chatMessage?.id;
+        }
+
+        if (messageId) {
+            const highlightData = {
+                messageId: messageId,
+                customHighlightColor: effect.highlightEnabled ? effect.customHighlightColor : undefined,
+                customBannerText: effect.bannerEnabled ? effect.customBannerText : undefined,
+                customBannerIcon: effect.bannerEnabled ? effect.customBannerIcon : undefined
+            };
+            logger.debug("chat-feed-custom-highlight: Highlighting message in chat feed: messageId=", messageId);
+            frontendCommunicator.send("chat-feed-custom-highlight", highlightData);
+        } else {
+            logger.warn("chat-feed-custom-highlight: No messageId found in trigger. Cannot highlight message.");
+        }
+    }
+};
+
+export = model;

--- a/src/gui/app/directives/chat/feed items/chat-message.js
+++ b/src/gui/app/directives/chat/feed items/chat-message.js
@@ -40,6 +40,11 @@
                         ng-class="{'first-chat': $ctrl.message.isFirstChat, returning: $ctrl.message.isReturningChatter, raider: $ctrl.message.isRaider, suspicious: $ctrl.message.isSuspiciousUser}"
                     >
                     </div>
+                    <div
+                        ng-if="$ctrl.message.customHighlightColor"
+                        class="chat-highlight-bar"
+                        ng-style="{'background-color': $ctrl.message.customHighlightColor}">
+                    </div>
                     <div ng-if="$ctrl.message.isAnnouncement" class="chat-message-banner">
                         <i class="fad fa-bullhorn"></i> Announcement
                     </div>
@@ -54,6 +59,10 @@
                     </div>
                     <div ng-if="$ctrl.message.isSuspiciousUser" class="chat-message-banner">
                         <i class="fad fa-exclamation-triangle"></i> Suspicious User
+                    </div>
+                    <div ng-if="$ctrl.message.customBannerText" class="chat-message-banner">
+                        <i ng-if="$ctrl.message.customBannerIcon" class="{{$ctrl.message.customBannerIcon}}"></i>
+                        {{$ctrl.message.customBannerText}}
                     </div>
                     <div ng-if="$ctrl.message.isReply && !$ctrl.hideReplyBanner" class="chat-message-banner mini-banner muted truncate" ng-click="$ctrl.replyBannerClicked()">
                         <i class="fad fa-comment-alt-dots"></i> Replying to @{{$ctrl.message.replyParentMessageSenderDisplayName}}: {{$ctrl.message.replyParentMessageText}}</span>
@@ -234,7 +243,7 @@
                             <span>Flagged by AutoMod ({{$ctrl.message.autoModReason}}): Expired</span>
                         </div>
                     </div>
-                    <div ng-if="$ctrl.message.isAnnouncement || $ctrl.message.isFirstChat || $ctrl.message.isReturningChatter || $ctrl.message.isRaider || $ctrl.message.isSuspiciousUser" style="margin-bottom:5px">
+                    <div ng-if="$ctrl.message.isAnnouncement || $ctrl.message.isFirstChat || $ctrl.message.isReturningChatter || $ctrl.message.isRaider || $ctrl.message.isSuspiciousUser || $ctrl.message.customBannerText || $ctrl.message.customBannerIcon" style="margin-bottom:5px">
                 </div>
             `,
             controller: function(chatMessagesService, utilityService, connectionService, pronounsService, backendCommunicator) {

--- a/src/gui/app/services/chat-messages.service.js
+++ b/src/gui/app/services/chat-messages.service.js
@@ -147,6 +147,22 @@
                 service.chatAlertMessage(message, icon);
             });
 
+            // Custom Highlight and Banner
+            service.customHighlightAndBanner = function(messageId, customHighlightColor, customBannerIcon, customBannerText) {
+                const messageItem = service.chatQueue.find(i => i.type === "message" && i.data.id === messageId);
+                if (messageItem == null) {
+                    return;
+                }
+
+                messageItem.data.customHighlightColor = customHighlightColor;
+                messageItem.data.customBannerIcon = customBannerIcon;
+                messageItem.data.customBannerText = customBannerText;
+            };
+
+            backendCommunicator.on("chat-feed-custom-highlight", (data) => {
+                service.customHighlightAndBanner(data.messageId, data.customHighlightColor, data.customBannerIcon, data.customBannerText);
+            });
+
             // Chat Update Handler
             // This handles all of the chat stuff that isn't a message.
             // This will only work when chat feed is turned on in the settings area.

--- a/src/types/chat.d.ts
+++ b/src/types/chat.d.ts
@@ -118,7 +118,10 @@ export type FirebotChatMessage = {
     sharedChatRoomId?: string;
     isHiddenFromChatFeed?: boolean;
     viewerRanks?: Record<string, string>;
-    viewerCustomRoles?: string[]
+    viewerCustomRoles?: string[];
+    customHighlightColor?: string;
+    customBannerIcon?: string;
+    customBannerText?: string;
 };
 
 export type FirebotEmote = {


### PR DESCRIPTION
### Description of the Change
This adds the effect "Highlight Message In Chat Feed" which allows a custom highlight and/or banner to be applied to a message in the Firebot chat feed. I use this on my own stream to mark "Viewer Arrived" messages with a banner and a highlight color.

<img width="1308" height="441" alt="image" src="https://github.com/user-attachments/assets/c84f3f87-da6e-49ca-a496-ac020a2889d2" />

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/3190

### Testing
See screen shot above. There are also more screen shots in the issue.

### Screenshots

<img width="599" height="658" alt="image" src="https://github.com/user-attachments/assets/17a367ee-90df-435e-8d8e-58a3a6bdd1cb" />

<img width="594" height="781" alt="image" src="https://github.com/user-attachments/assets/6390253b-02d5-40aa-aeba-f7269a33cd3d" />

<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
