### PR TITLE
feat(effects): Allow "hide message" from preset effect lists (#3286)

### DIFF
--- a/src/backend/effects/builtin/chat-feed-message-hide.ts
+++ b/src/backend/effects/builtin/chat-feed-message-hide.ts
@@ -6,6 +6,7 @@ import logger from "../../logwrapper";
 const triggers = {};
 triggers[EffectTrigger.COMMAND] = true;
 triggers[EffectTrigger.EVENT] = ["twitch:chat-message"];
+triggers[EffectTrigger.PRESET_LIST] = true;
 
 const model: EffectType<{
     hidden: boolean;
@@ -35,19 +36,18 @@ const model: EffectType<{
         const { trigger } = event;
 
         try {
-            let messageId = null;
-            if (trigger.type === EffectTrigger.COMMAND) {
+            let messageId = "";
+            if (typeof trigger.metadata.chatMessage?.id === "string" && trigger.metadata.chatMessage.id.length > 0) {
                 messageId = trigger.metadata.chatMessage.id;
-            } else if (trigger.type === EffectTrigger.EVENT) {
+            } else if (typeof trigger.metadata.eventData?.chatMessage?.id === "string" && trigger.metadata.eventData.chatMessage.id.length > 0) {
                 messageId = trigger.metadata.eventData.chatMessage.id;
-            }
-
-            if (messageId) {
-                logger.debug("chat-feed-message-hide: Hiding message in chat feed: messageId=", messageId);
-                frontendCommunicator.send("chat-feed-message-hide", { messageId: messageId });
             } else {
                 logger.warn("chat-feed-message-hide: No messageId found in trigger. Cannot hide message.");
+                return;
             }
+
+            logger.debug("chat-feed-message-hide: Hiding message in chat feed: messageId=", messageId);
+            frontendCommunicator.send("chat-feed-message-hide", { messageId: messageId });
         } catch (error) {
             logger.error("chat-feed-message-hide: Error hiding message in chat feed: ", error);
         }


### PR DESCRIPTION
### Description of the Change
This allows the "Hide Message In Chat Feed" effect to be used in preset effect lists. When called from either a command or a Twitch chat message effect, the metadata with the message ID will be present, and the message will be hidden as it should. When called without metadata containing a message ID, the effect will continue to log a warning and take no action. The implementation here is more robust, looking for the chat message ID in the expected places in the metadata without a dependency on the trigger type to tell it where to look.

### Applicable Issues
https://github.com/crowbartools/Firebot/issues/3286


### Testing
Local testing:
- :white_check_mark: Chat event + direct "Hide Message In Chat Feed" effect
- :white_check_mark: Chat event + preset effect list with effect
- :white_check_mark: Command + direct "Hide Message In Chat Feed" effect
- :white_check_mark: Command + preset effect list with effect
- (Warning + no action): "Twitch connected" + preset effect list

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
