### PR TITLE
fix: edit effect always disabled (#3287)

### DIFF
--- a/src/gui/app/directives/controls/effectList.js
+++ b/src/gui/app/directives/controls/effectList.js
@@ -399,7 +399,7 @@
                 };
 
                 ctrl.createEffectMenuOptions = (effect) => {
-                    const effectIsValid = !!effectDefinitions.find(e => e.id === effect.type);
+                    const effectIsValid = !!effectDefinitions.find(e => e.definition.id === effect.type);
                     const effectMenuOptions = [
                         {
                             html: `<a href ><i class="far fa-edit mr-4"></i> Edit Effect</a>`,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fixes a bug introduced in #3253 which always disabled the edit effect button in the context menu

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
#3287

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured edit effect is properly enabled for effects that exist, and disabled for effects that don't