### PR TITLE
fix: overlay widgets not respecting overlay instances

### DIFF
--- a/src/server/websocket-server-manager.ts
+++ b/src/server/websocket-server-manager.ts
@@ -164,6 +164,10 @@ class WebSocketServerManager extends EventEmitter {
             return;
         }
 
+        if (overlayInstance != null && overlayInstance !== "") {
+            meta.overlayInstance = overlayInstance;
+        }
+
         const data = { event: eventName, meta: meta, overlayInstance: overlayInstance };
 
         const message: EventMessage = {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fix an issue where overlay widgets don't respect the provided overlay instance.
I've chosen to apply this in the sendToOverlay function so effects and other overlay events can benefit from this change as well. 

### Applicable Issues
Not tracked on github due to being a v5 issue
[discord post](https://discord.com/channels/372817064034959370/372822810168393728/1429479480233169077)

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured overlay widgets now appear on the provided overlay instance
Ensured existing overlay effects (tested: image, text, video, sound, shoutout)