### PR TITLE
fix: eventsub channel reward create/update mangling the cooldown

### DIFF
--- a/src/backend/streaming-platforms/twitch/api/eventsub/eventsub-helpers.ts
+++ b/src/backend/streaming-platforms/twitch/api/eventsub/eventsub-helpers.ts
@@ -31,7 +31,7 @@ export function mapEventSubRewardToTwitchData(event: EventSubChannelRewardEvent)
         },
         globalCooldownSetting: {
             isEnabled: event.globalCooldown !== null,
-            globalCooldownSeconds: event.globalCooldown ? Math.ceil((new Date(event.globalCooldown).getTime() - Date.now()) / 1000) : null
+            globalCooldownSeconds: event.globalCooldown
         },
         isPaused: event.isPaused,
         isInStock: event.isInStock,


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fix a logic issue introduced in #3234 which caused cooldowns from eventsub channel reward create and update to be mangled.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
v5 issue, not tracked

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured saving rewards in Firebot or from Twitch doesn't manipulate the global cooldown