### PR TITLE
fix(effects): Avoid hang with self-referencing preset effect list (#3285)

### DIFF
--- a/src/backend/effects/builtin/effect-group.js
+++ b/src/backend/effects/builtin/effect-group.js
@@ -5,6 +5,7 @@ const { EffectCategory, EffectTrigger } = require('../../../shared/effect-consta
 const { PresetEffectListManager } = require("../preset-lists/preset-effect-list-manager");
 const logger = require("../../logwrapper");
 const { simpleClone } = require("../../utils");
+const { SettingsManager } = require("../../common/settings-manager");
 
 const effectGroup = {
     definition: {
@@ -182,7 +183,8 @@ const effectGroup = {
                 }
                 newTrigger.metadata.stackDepth[presetList.id] += 1;
 
-                if (newTrigger.metadata.stackDepth[presetList.id] > 100) {
+                const recursionLimitEnabled = SettingsManager.getSetting("PresetRecursionLimit");
+                if (recursionLimitEnabled && newTrigger.metadata.stackDepth[presetList.id] > 100) {
                     logger.error(`Preset Effect List '${presetList.name}' (ID: ${presetList.id}) has been triggered more than 100 times in the same chain. Stopping execution to prevent infinite loop.`);
                     return resolve(true);
                 }

--- a/src/gui/app/directives/settings/categories/advanced-settings.js
+++ b/src/gui/app/directives/settings/categories/advanced-settings.js
@@ -165,6 +165,18 @@
                         </setting-description-addon>
                     </firebot-setting>
 
+                    <firebot-setting
+                        name="Preset Effect List Recursion Limit"
+                        description="Limits how many times a preset effect list can recursively call itself to prevent Firebot from hanging. When enabled, execution stops after 100 recursive calls."
+                    >
+                        <toggle-button
+                            toggle-model="settings.getSetting('PresetRecursionLimit')"
+                            on-toggle="settings.saveSetting('PresetRecursionLimit', !settings.getSetting('PresetRecursionLimit'))"
+                            font-size="40"
+                            accessibility-label="(settings.getSetting('PresetRecursionLimit') ? 'Enabled' : 'Disabled') + ' Preset Effect List Recursion Limit'"
+                        />
+                    </firebot-setting>
+
                     <div style="margin-top: 20px">
                         <p class="muted">Looking for a setting that used to be located here? Try checking in the Tools app menu!</p>
                     </div>

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -86,6 +86,7 @@ export type FirebotSettingsTypes = {
     };
     OverlayInstances: string[];
     PersistCustomVariables: boolean;
+    PresetRecursionLimit: boolean;
     QuickActions: Record<string, {
         enabled: boolean;
         position: number;
@@ -215,6 +216,7 @@ export const FirebotSettingsDefaults: FirebotSettingsTypes = {
         height: 720
     },
     PersistCustomVariables: false,
+    PresetRecursionLimit: true,
     QuickActions: {},
     RunCustomScripts: false,
     SeenAdvancedCommandModePopup: false,


### PR DESCRIPTION
### Description of the Change
This PR eliminates Firebot hangs due to a preset effect list that directly or indirectly calls itself. After 100 calls to the same preset effect list while processing a given trigger, this logs an error and stops trying.

100 is an arbitrary "sanity check" which seemed reasonable but this can be adjusted up or down as the maintainers see fit. Doing it this way, instead of preventing any repetition, still allows reasonable recursion.

Note: There's also one linter fix my IDE made, which I left in since I've seen you cleaning up other parts of the project.

### Applicable Issues

https://github.com/crowbartools/Firebot/issues/3285

### Testing

- Preset effect list calling itself
- Preset effect list "A" that calls "B", and "B" that calls "A"

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
