### PR TITLE
fix(effects): Run Program effect settings not showing (v5)

### DIFF
--- a/src/backend/effects/builtin/run-program.ts
+++ b/src/backend/effects/builtin/run-program.ts
@@ -1,4 +1,4 @@
-import process from "process";
+import nodeProcess from "process";
 import path from "path";
 import { ChildProcess, spawn } from "child_process";
 
@@ -151,7 +151,7 @@ const effect: EffectType<{
                 args = splitArgumentsText(argString);
             }
 
-            if (useShell && process.platform === "win32" && programPath.indexOf(" ") !== -1) {
+            if (useShell && nodeProcess.platform === "win32" && programPath.indexOf(" ") !== -1) {
                 // When using shell, we must properly escape the command
                 programPath = `"${programPath}"`;
             }


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fix an issue in the v5 branch where the Run Program effect doesn't load its effect model due to the typescript compiler renaming the frontend `process` global

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the effect shows its effect model
Ensured running the effect doesn't cause errors and produces expected output