### PR TITLE
fix: Manual queues showing as unknown in queue monitor

### DIFF
--- a/src/gui/effect-queue-monitor/modules/queue-header.mjs
+++ b/src/gui/effect-queue-monitor/modules/queue-header.mjs
@@ -11,6 +11,9 @@ const queueHeader = {
             if (this.queue.mode === "auto") {
                 return "Sequential";
             }
+            if (this.queue.mode === "manual") {
+                return "Manual";
+            }
             return "Unknown";
         },
         shouldShowInterval() {


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Fix an issue where the manual effect queue shows as Unknown in the Queue Monitor

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured the Manual Queue now shows as Manual