### PR TITLE
fix: Effect Queue Prioritized Label (#3403)

### DIFF
--- a/src/gui/app/directives/controls/effect-list/queue-panel.ts
+++ b/src/gui/app/directives/controls/effect-list/queue-panel.ts
@@ -141,7 +141,7 @@ type Controller = {
                 const items: PreviewItem[] = [];
 
                 if ($ctrl.validQueueSelected()) {
-                    if ($ctrl.effectsData.queuePriority) {
+                    if ($ctrl.effectsData.queuePriority && $ctrl.effectsData.queuePriority === "high") {
                         items.push({
                             icon: "fa-arrow-up",
                             label: "Prioritized",


### PR DESCRIPTION
### Description of the Change
Fix an issue where enabling, then disabling queue priority in an effect list retains the priority label

### Applicable Issues
#3403

### Testing
Ensured disabling queue priority doesn't show the prioritized label