### PR TITLE
Fix $timeoutDuration description to specify seconds

### DIFF
--- a/src/backend/streaming-platforms/twitch/variables/chat/moderation/timeout-duration.ts
+++ b/src/backend/streaming-platforms/twitch/variables/chat/moderation/timeout-duration.ts
@@ -8,7 +8,7 @@ triggers["event"] = ["twitch:timeout"];
 const model : ReplaceVariable = {
     definition: {
         handle: "timeoutDuration",
-        description: "How long the user is timed out for in minus",
+        description: "How long the user is timed out for in seconds",
         triggers: triggers,
         categories: ["common", "trigger based"],
         possibleDataOutput: ["number"]


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
$timeoutDuration text states
How long the user is timed out for in minus


### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->


### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Logging $timeoutDuration shows it logs in seconds

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
