### PR TITLE
Better management of channel rewards on twitch 

### DIFF
--- a/src/backend/channel-rewards/channel-reward-manager.ts
+++ b/src/backend/channel-rewards/channel-reward-manager.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { JsonDB } from "node-json-db";
 
 import { RewardRedemptionMetadata, SavedChannelReward } from "../../types/channel-rewards";
@@ -44,7 +45,8 @@ class ChannelRewardManager {
         });
 
         frontendCommunicator.on("manually-trigger-reward", (channelRewardId: string) => {
-            const savedReward = this.channelRewards[channelRewardId];
+            // channelRewardId may be a firebotId or Twitch ID, use cascading lookup
+            const savedReward = this.getChannelReward(channelRewardId);
 
             if (savedReward == null) {
                 return;
@@ -55,6 +57,7 @@ class ChannelRewardManager {
                 messageText: "Testing reward",
                 redemptionId: "test-redemption-id",
                 rewardId: savedReward.id,
+                firebotRewardId: savedReward.firebotId,
                 rewardCost: savedReward.twitchData.cost,
                 rewardImage: savedReward.twitchData.image ? savedReward.twitchData.image.url4x : savedReward.twitchData.defaultImage.url4x,
                 rewardName: savedReward.twitchData.title,
@@ -81,6 +84,16 @@ class ChannelRewardManager {
         return ProfileManager.getJsonDbInProfile("channel-rewards");
     }
 
+    /**
+     * Ensures a reward has a stable firebotId. Generates one if missing (migration for pre-firebotId data).
+     */
+    private ensureFirebotId(reward: SavedChannelReward): SavedChannelReward {
+        if (!reward.firebotId) {
+            reward.firebotId = crypto.randomUUID();
+        }
+        return reward;
+    }
+
     async loadChannelRewards() {
         logger.debug(`Attempting to load channel rewards...`);
 
@@ -89,11 +102,24 @@ class ChannelRewardManager {
             const channelRewardsData = (this.getChannelRewardsDb().getData("/") || {}) as Record<string, SavedChannelReward>;
             const rewards = Object.values(channelRewardsData);
 
+            // Migration: ensure all existing rewards have a firebotId
+            for (const reward of rewards) {
+                this.ensureFirebotId(reward);
+            }
+
+            // Separate locally-disabled rewards (deleted from Twitch) from active ones
+            const disabledRewards = rewards.filter(r => r.deletedOnTwitch === true);
+            const activeRewards = rewards.filter(r => r.deletedOnTwitch !== true);
+
             // Get all manageable rewards from Twitch
             const twitchManageableRewards: CustomReward[] = await TwitchApi.channelRewards.getManageableCustomChannelRewards();
             if (twitchManageableRewards == null) {
                 logger.error("Manageable Twitch channel rewards returned null!");
-                this.channelRewards = channelRewardsData;
+                // Re-key by firebotId for in-memory storage
+                this.channelRewards = rewards.reduce((acc, r) => {
+                    acc[r.firebotId] = r;
+                    return acc;
+                }, {} as Record<string, SavedChannelReward>);
 
                 this._eligible = false;
                 frontendCommunicator.send("channel-rewards-eligibility-changed", false);
@@ -101,11 +127,12 @@ class ChannelRewardManager {
                 return;
             }
 
-            // Determine new manageable rewards
-            const newManageableChannelRewards = twitchManageableRewards
-                .filter(nr => rewards.every(r => r.id !== nr.id))
+            // Determine new manageable rewards (not already tracked locally)
+            const newManageableChannelRewards: SavedChannelReward[] = twitchManageableRewards
+                .filter(nr => activeRewards.every(r => r.id !== nr.id))
                 .map((nr) => {
                     return {
+                        firebotId: crypto.randomUUID(),
                         id: nr.id,
                         manageable: true,
                         twitchData: nr
@@ -116,7 +143,10 @@ class ChannelRewardManager {
             const twitchUnmanageableRewards = await TwitchApi.channelRewards.getUnmanageableCustomChannelRewards();
             if (twitchUnmanageableRewards == null) {
                 logger.error("Unmanageable Twitch channel rewards returned null!");
-                this.channelRewards = channelRewardsData;
+                this.channelRewards = rewards.reduce((acc, r) => {
+                    acc[r.firebotId] = r;
+                    return acc;
+                }, {} as Record<string, SavedChannelReward>);
 
                 this._eligible = false;
                 frontendCommunicator.send("channel-rewards-eligibility-changed", false);
@@ -126,9 +156,10 @@ class ChannelRewardManager {
 
             // Determine new unmanageable rewards
             const newTwitchUnmanageableRewards: SavedChannelReward[] = twitchUnmanageableRewards
-                .filter(ur => rewards.every(r => r.id !== ur.id))
+                .filter(ur => activeRewards.every(r => r.id !== ur.id))
                 .map((ur) => {
                     return {
+                        firebotId: crypto.randomUUID(),
                         id: ur.id,
                         manageable: false,
                         twitchData: ur
@@ -136,7 +167,8 @@ class ChannelRewardManager {
                 });
 
             // Sync current reward Twitch data/manageability status, remove deleted rewards, then add new rewards
-            const syncedRewards: Record<string, SavedChannelReward> = rewards.map((r) => {
+            // Only sync active (non-disabled) rewards against Twitch
+            const syncedRewards: Record<string, SavedChannelReward> = activeRewards.map((r) => {
                 const rewardTwitchData = twitchManageableRewards.find(tc => tc.id === r.id);
 
                 // If we have a match, this is a manageable reward
@@ -154,10 +186,11 @@ class ChannelRewardManager {
                 .filter(r => r.twitchData != null)
                 .concat(newManageableChannelRewards)
                 .concat(newTwitchUnmanageableRewards)
+                .concat(disabledRewards) // Preserve locally-disabled rewards
                 .reduce((acc, current) => {
-                    acc[current.id] = current;
+                    acc[current.firebotId] = current;
                     return acc;
-                }, {});
+                }, {} as Record<string, SavedChannelReward>);
 
             this.getChannelRewardsDb().push("/", syncedRewards);
 
@@ -178,7 +211,11 @@ class ChannelRewardManager {
             return null;
         }
 
+        // Ensure the reward has a stable firebotId
+        this.ensureFirebotId(channelReward);
+
         if (channelReward.id == null) {
+            // New reward: create on Twitch
             const twitchData = await TwitchApi.channelRewards.createCustomChannelReward(channelReward.twitchData);
             if (twitchData == null) {
                 return null;
@@ -186,17 +223,56 @@ class ChannelRewardManager {
             channelReward.twitchData = twitchData;
             channelReward.id = twitchData.id;
         } else if (channelReward.manageable) {
-            await TwitchApi.channelRewards.updateCustomChannelReward(channelReward.twitchData);
+            if (!channelReward.twitchData.isEnabled && !channelReward.deletedOnTwitch) {
+                // Disabling: delete from Twitch, keep locally
+                await TwitchApi.channelRewards.deleteCustomChannelReward(channelReward.id);
+                channelReward.deletedOnTwitch = true;
+                // Store old Twitch ID for backward-compat lookups
+                if (channelReward.previousTwitchIds == null) {
+                    channelReward.previousTwitchIds = [];
+                }
+                if (!channelReward.previousTwitchIds.includes(channelReward.id)) {
+                    channelReward.previousTwitchIds.push(channelReward.id);
+                }
+            } else if (channelReward.twitchData.isEnabled && channelReward.deletedOnTwitch) {
+                // Re-enabling: check if there's room before recreating on Twitch
+                const activeCount = Object.values(this.channelRewards)
+                    .filter(r => !r.deletedOnTwitch).length;
+                if (activeCount >= 50) {
+                    logger.warn("Cannot re-enable channel reward: Twitch limit of 50 rewards reached.");
+                    channelReward.twitchData.isEnabled = false;
+                    return null;
+                }
+                channelReward.twitchData.isEnabled = true;
+                const twitchData = await TwitchApi.channelRewards.createCustomChannelReward(channelReward.twitchData);
+                if (twitchData == null) {
+                    return null;
+                }
+                // Store old Twitch ID for backward-compat lookups
+                if (channelReward.previousTwitchIds == null) {
+                    channelReward.previousTwitchIds = [];
+                }
+                if (channelReward.id && !channelReward.previousTwitchIds.includes(channelReward.id)) {
+                    channelReward.previousTwitchIds.push(channelReward.id);
+                }
+                channelReward.twitchData = twitchData;
+                channelReward.id = twitchData.id;
+                channelReward.deletedOnTwitch = false;
+            } else if (!channelReward.deletedOnTwitch) {
+                // Normal update: reward exists on Twitch
+                await TwitchApi.channelRewards.updateCustomChannelReward(channelReward.twitchData);
+            }
+            // If deletedOnTwitch && !isEnabled: just save locally, no Twitch API call
         }
 
-        this.channelRewards[channelReward.id] = channelReward;
+        this.channelRewards[channelReward.firebotId] = channelReward;
 
         try {
             const channelRewardsDb = this.getChannelRewardsDb();
 
-            channelRewardsDb.push(`/${channelReward.id}`, channelReward);
+            channelRewardsDb.push(`/${channelReward.firebotId}`, channelReward);
 
-            logger.debug(`Saved channel reward ${channelReward.id} to file.`);
+            logger.debug(`Saved channel reward ${channelReward.firebotId} to file.`);
 
             if (emitUpdateEvent) {
                 frontendCommunicator.send("channel-reward-updated", channelReward);
@@ -216,23 +292,27 @@ class ChannelRewardManager {
 
         let channelReward: SavedChannelReward;
 
-        if (!this.channelRewards[twitchData.id]) {
+        // Look up by Twitch ID since this data comes from Twitch events
+        const existing = this.getChannelRewardByTwitchId(twitchData.id);
+
+        if (!existing) {
             channelReward = {
+                firebotId: crypto.randomUUID(),
                 id: twitchData.id,
                 twitchData,
                 manageable: false
             };
         } else {
-            channelReward = this.channelRewards[twitchData.id];
+            channelReward = existing;
             channelReward.twitchData = twitchData;
         }
 
-        this.channelRewards[twitchData.id] = channelReward;
+        this.channelRewards[channelReward.firebotId] = channelReward;
 
         try {
             const channelRewardsDb = this.getChannelRewardsDb();
 
-            channelRewardsDb.push(`/${channelReward.id}`, channelReward);
+            channelRewardsDb.push(`/${channelReward.firebotId}`, channelReward);
 
             frontendCommunicator.send("channel-reward-updated", channelReward);
 
@@ -246,14 +326,18 @@ class ChannelRewardManager {
     async saveAllChannelRewards(allChannelRewards: SavedChannelReward[], updateTwitch = false): Promise<void> {
         if (updateTwitch) {
             for (const channelReward of allChannelRewards) {
+                // Skip Twitch API updates for rewards deleted from Twitch
+                if (channelReward.deletedOnTwitch) {
+                    continue;
+                }
                 await TwitchApi.channelRewards.updateCustomChannelReward(channelReward.twitchData);
             }
         }
 
         const rewardsObject: Record<string, SavedChannelReward> = allChannelRewards.reduce((acc, current) => {
-            acc[current.id] = current;
+            acc[current.firebotId] = current;
             return acc;
-        }, {});
+        }, {} as Record<string, SavedChannelReward>);
 
         this.channelRewards = rewardsObject;
 
@@ -270,20 +354,27 @@ class ChannelRewardManager {
     }
 
     async deleteChannelReward(channelRewardId: string, propagateToTwitch = true, notifyFrontend = false) {
-        if (channelRewardId == null || this.channelRewards[channelRewardId] == null) {
+        // channelRewardId is now a firebotId
+        const reward = this.channelRewards[channelRewardId];
+        if (channelRewardId == null || reward == null) {
             return;
         }
 
+        const twitchId = reward.id;
+
         delete this.channelRewards[channelRewardId];
-        delete this._channelRewardRedemptions[channelRewardId];
+        // Redemptions are keyed by Twitch ID
+        if (twitchId) {
+            delete this._channelRewardRedemptions[twitchId];
+        }
 
         try {
             const channelRewardsDb = this.getChannelRewardsDb();
 
             channelRewardsDb.delete(`/${channelRewardId}`);
 
-            if (propagateToTwitch) {
-                await TwitchApi.channelRewards.deleteCustomChannelReward(channelRewardId);
+            if (propagateToTwitch && twitchId && !reward.deletedOnTwitch) {
+                await TwitchApi.channelRewards.deleteCustomChannelReward(twitchId);
             }
 
             if (notifyFrontend) {
@@ -297,11 +388,42 @@ class ChannelRewardManager {
         }
     }
 
+    /**
+     * Look up a channel reward by any ID (firebotId, current Twitch ID, or previous Twitch IDs).
+     * Cascading lookup for backward compatibility.
+     */
     getChannelReward(channelRewardId: string): SavedChannelReward {
         if (channelRewardId == null) {
             return null;
         }
-        return this.channelRewards[channelRewardId];
+
+        // 1. Try direct lookup by firebotId (primary key)
+        if (this.channelRewards[channelRewardId]) {
+            return this.channelRewards[channelRewardId];
+        }
+
+        // 2. Try lookup by current Twitch ID
+        const byTwitchId = Object.values(this.channelRewards).find(r => r.id === channelRewardId);
+        if (byTwitchId) {
+            return byTwitchId;
+        }
+
+        // 3. Try lookup by previous Twitch IDs (backward compat after disable/enable cycles)
+        const byPreviousTwitchId = Object.values(this.channelRewards).find(
+            r => r.previousTwitchIds?.includes(channelRewardId)
+        );
+        return byPreviousTwitchId ?? null;
+    }
+
+    /**
+     * Look up a channel reward by its current Twitch ID.
+     * Used by EventSub handlers that receive Twitch IDs in events.
+     */
+    getChannelRewardByTwitchId(twitchId: string): SavedChannelReward {
+        if (twitchId == null) {
+            return null;
+        }
+        return Object.values(this.channelRewards).find(r => r.id === twitchId) ?? null;
     }
 
     getChannelRewardIdByName(channelRewardName: string): string {
@@ -312,7 +434,7 @@ class ChannelRewardManager {
             .filter(r => r.twitchData != null)
             .find(r => r.twitchData.title === channelRewardName);
 
-        return channelReward ? channelReward.id : null;
+        return channelReward ? channelReward.firebotId : null;
     }
 
     private async triggerRewardEffects(metadata: RewardRedemptionMetadata, effectList?: EffectList, manual = false): Promise<void> {
@@ -336,7 +458,7 @@ class ChannelRewardManager {
     }
 
     async triggerChannelReward(rewardId: string, metadata: RewardRedemptionMetadata, manual = false): Promise<boolean | void> {
-        const savedReward = this.channelRewards[rewardId];
+        const savedReward = this.getChannelReward(rewardId);
         if (metadata.username && metadata.userId && metadata.userDisplayName) {
             /*
             If all user data is present mark user as active
@@ -414,7 +536,7 @@ class ChannelRewardManager {
     }
 
     async triggerChannelRewardFulfilled(rewardId: string, metadata: RewardRedemptionMetadata, manual = false): Promise<void> {
-        const savedReward = this.channelRewards[rewardId];
+        const savedReward = this.getChannelReward(rewardId);
         if (savedReward == null) {
             return;
         }
@@ -423,7 +545,7 @@ class ChannelRewardManager {
     }
 
     async triggerChannelRewardCanceled(rewardId: string, metadata: RewardRedemptionMetadata, manual = false): Promise<void> {
-        const savedReward = this.channelRewards[rewardId];
+        const savedReward = this.getChannelReward(rewardId);
         if (savedReward == null) {
             return;
         }

--- a/src/backend/effects/builtin/update-channel-reward.ts
+++ b/src/backend/effects/builtin/update-channel-reward.ts
@@ -150,7 +150,7 @@ const effect: EffectType<EffectMeta> = {
 
         $scope.manageableRewards = channelRewardsService
             .channelRewards.filter(r => r.manageable)
-            .map(r => ({ id: r.twitchData.id, name: r.twitchData.title }));
+            .map(r => ({ id: r.firebotId, name: r.twitchData.title }));
 
         $scope.sortTags = sortTagsService.getSortTags("channel rewards");
 
@@ -315,7 +315,9 @@ const effect: EffectType<EffectMeta> = {
 
         switch (selectMode) {
             case "dropdown":
-                rewardName = channelRewardsService.channelRewards.find(r => r.twitchData.id === effect.channelRewardId)?.twitchData.title ?? "Unknown Reward";
+                rewardName = channelRewardsService.channelRewards.find(
+                    r => r.firebotId === effect.channelRewardId || r.twitchData.id === effect.channelRewardId
+                )?.twitchData.title ?? "Unknown Reward";
                 break;
             case "associated":
                 rewardName = "Associated Reward";
@@ -389,7 +391,8 @@ const effect: EffectType<EffectMeta> = {
                     rewardId = effect.channelRewardId;
                     break;
                 case "associated":
-                    rewardId = (trigger.metadata.eventData?.rewardId ?? trigger.metadata.rewardId) as string;
+                    rewardId = (trigger.metadata.eventData?.firebotRewardId ?? trigger.metadata.firebotRewardId
+                        ?? trigger.metadata.eventData?.rewardId ?? trigger.metadata.rewardId) as string;
                     break;
                 case "custom":
                     rewardId = isValidUUID(effect.customId)

--- a/src/backend/events/filters/builtin/twitch/reward.ts
+++ b/src/backend/events/filters/builtin/twitch/reward.ts
@@ -7,15 +7,17 @@ const filter = createPresetFilter({
     events: [
         { eventSourceId: "twitch", eventId: "channel-reward-redemption" }
     ],
-    eventMetaKey: "rewardId",
+    eventMetaKey: "firebotRewardId",
     allowIsNot: true,
     presetValues: async (backendCommunicator: any) => {
         const rewards = await backendCommunicator.fireEventAsync("get-channel-rewards");
-        return rewards.map(r => ({value: r.id, display: r.twitchData.title}));
+        return rewards.map(r => ({value: r.firebotId, display: r.twitchData.title}));
     },
     valueIsStillValid: async (filterSettings, backendCommunicator: any) => {
         const rewards = await backendCommunicator.fireEventAsync("get-channel-rewards");
-        return rewards.some(r => r.id === filterSettings.value);
+        // Support both firebotId (new) and Twitch ID (legacy) for backward compat
+        return rewards.some(r => r.firebotId === filterSettings.value || r.id === filterSettings.value
+            || (r.previousTwitchIds && r.previousTwitchIds.includes(filterSettings.value)));
     }
 });
 

--- a/src/backend/streaming-platforms/twitch/api/eventsub/eventsub-client.ts
+++ b/src/backend/streaming-platforms/twitch/api/eventsub/eventsub-client.ts
@@ -211,13 +211,18 @@ class TwitchEventSubClient {
 
         // Channel custom reward remove
         const customRewardRemoveSubscription = this._eventSubListener.onChannelRewardRemove(streamer.userId, async (event) => {
-            const firebotReward: SavedChannelReward | null = channelRewardManager.getChannelReward(event.id);
+            const firebotReward: SavedChannelReward | null = channelRewardManager.getChannelRewardByTwitchId(event.id);
 
             if (!firebotReward) {
                 return;
             }
 
-            await channelRewardManager.deleteChannelReward(event.id, false, true);
+            // If the reward was intentionally disabled (deleted from Twitch by Firebot), don't delete locally
+            if (firebotReward.deletedOnTwitch) {
+                return;
+            }
+
+            await channelRewardManager.deleteChannelReward(firebotReward.firebotId, false, true);
         });
         this._subscriptions.push(customRewardRemoveSubscription);
 

--- a/src/backend/streaming-platforms/twitch/events/reward-redemption.ts
+++ b/src/backend/streaming-platforms/twitch/events/reward-redemption.ts
@@ -33,6 +33,7 @@ export function handleRewardRedemption(
     });
 
     setTimeout(() => {
+        const reward = rewardManager.getChannelRewardByTwitchId(rewardId);
         const redemptionMeta = {
             username,
             userId,
@@ -41,6 +42,7 @@ export function handleRewardRedemption(
             args: (messageText ?? "").split(" "),
             redemptionId,
             rewardId,
+            firebotRewardId: reward?.firebotId ?? rewardId,
             rewardImage: rewardImageUrl,
             rewardName: rewardTitle,
             rewardDescription: rewardPrompt,
@@ -65,6 +67,7 @@ export function handleRewardUpdated(
     rewardCost: number,
     rewardImageUrl: string
 ): void {
+    const reward = rewardManager.getChannelRewardByTwitchId(rewardId);
     const redemptionMeta = {
         username,
         userId,
@@ -73,6 +76,7 @@ export function handleRewardUpdated(
         args: (messageText ?? "").split(" "),
         redemptionId,
         rewardId,
+        firebotRewardId: reward?.firebotId ?? rewardId,
         rewardImage: rewardImageUrl,
         rewardName: rewardTitle,
         rewardDescription: rewardPrompt,

--- a/src/gui/app/controllers/channel-rewards.controller.js
+++ b/src/gui/app/controllers/channel-rewards.controller.js
@@ -6,7 +6,8 @@
             $scope,
             channelRewardsService,
             utilityService,
-            accountAccess
+            accountAccess,
+            ngToast
         ) {
             $scope.channelRewardsService = channelRewardsService;
 
@@ -56,7 +57,14 @@
                     cellController: () => { }
                 },
                 {
-                    cellTemplate: `<span class="paused-dot" style="margin-right: 5px" ng-class="{'paused': data.twitchData.isPaused, 'unpaused': !data.twitchData.isPaused}"></span>{{data.twitchData.isPaused ? 'Paused' : 'Unpaused' }}`,
+                    cellTemplate: `
+                        <span ng-if="data.deletedOnTwitch">
+                            <i class="fas fa-cloud-slash muted" style="margin-right: 5px"></i>Disabled (Not on Twitch)
+                        </span>
+                        <span ng-if="!data.deletedOnTwitch">
+                            <span class="paused-dot" style="margin-right: 5px" ng-class="{'paused': data.twitchData.isPaused, 'unpaused': !data.twitchData.isPaused}"></span>{{data.twitchData.isPaused ? 'Paused' : 'Unpaused' }}
+                        </span>
+                    `,
                     cellController: () => { }
                 }
             ];
@@ -71,8 +79,12 @@
                         }
                     },
                     {
-                        html: `<a href uib-tooltip="This reward was created either outside of Firebot or in an older version. Its enabled status cannot be edited." tooltip-enable="${!item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> ${item.twitchData.isEnabled ? "Disable Channel Reward" : "Enable Channel Reward"}</a>`,
+                        html: `<a href uib-tooltip="${!item.manageable ? 'This reward was created either outside of Firebot or in an older version. Its enabled status cannot be edited.' : (item.twitchData.isEnabled ? 'Disabling will delete the reward from Twitch to free up a slot. Your configuration is preserved locally.' : 'Enabling will recreate the reward on Twitch.')}" tooltip-enable="${!item.manageable || item.manageable}"><i class="far fa-toggle-off" style="margin-right: 10px;"></i> ${item.deletedOnTwitch ? "Enable Channel Reward" : (item.twitchData.isEnabled ? "Disable Channel Reward" : "Enable Channel Reward")}</a>`,
                         click: function () {
+                            if (item.deletedOnTwitch && channelRewardsService.getActiveRewardCount() >= 50) {
+                                ngToast.create("Cannot re-enable: Twitch's 50 reward limit has been reached.");
+                                return;
+                            }
                             item.twitchData.isEnabled = !item.twitchData.isEnabled;
                             channelRewardsService.saveChannelReward(item);
                         },
@@ -86,14 +98,14 @@
                             channelRewardsService.saveChannelReward(item);
                         },
                         compile: true,
-                        enabled: item.manageable
+                        enabled: item.manageable && !item.deletedOnTwitch
                     },
                     {
                         html: `<a href ><i class="far fa-clone" style="margin-right: 10px;"></i> Duplicate</a>`,
                         click: function () {
-                            channelRewardsService.duplicateChannelReward(item.id);
+                            channelRewardsService.duplicateChannelReward(item.firebotId);
                         },
-                        enabled: channelRewardsService.channelRewards.length < 50
+                        enabled: channelRewardsService.getActiveRewardCount() < 50
                     },
                     {
                         html: `<a href style="${item.manageable ? 'color: #fb7373;' : ''}" uib-tooltip="This reward was created either outside of Firebot or in an older version. It cannot be deleted from here." tooltip-enable="${!item.manageable}"><i class="far fa-trash-alt" style="margin-right: 10px;"></i> Delete</a>`,
@@ -107,7 +119,7 @@
                                 })
                                 .then((confirmed) => {
                                     if (confirmed) {
-                                        channelRewardsService.deleteChannelReward(item.id);
+                                        channelRewardsService.deleteChannelReward(item.firebotId);
                                     }
                                 });
 

--- a/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
+++ b/src/gui/app/directives/modals/channel-rewards/add-edit-channel-reward.js
@@ -313,7 +313,7 @@
 
                     return channelRewardsService.channelRewards.some(r => r
                         .twitchData.title.toLowerCase() === name.toLowerCase()
-                        && r.id !== $ctrl.reward.id);
+                        && r.firebotId !== $ctrl.reward.firebotId);
                 };
 
                 $ctrl.validationErrors = {};

--- a/src/gui/app/services/channel-rewards.service.js
+++ b/src/gui/app/services/channel-rewards.service.js
@@ -15,8 +15,16 @@
 
             service.searchQuery = "";
 
+            /**
+             * Returns the count of rewards that actually exist on Twitch
+             * (excludes locally-disabled rewards that have been deleted from Twitch).
+             */
+            service.getActiveRewardCount = () => {
+                return service.channelRewards.filter(r => !r.deletedOnTwitch).length;
+            };
+
             function updateChannelReward(channelReward) {
-                const index = service.channelRewards.findIndex(r => r.id === channelReward.id);
+                const index = service.channelRewards.findIndex(r => r.firebotId === channelReward.firebotId);
                 if (index > -1) {
                     service.channelRewards[index] = channelReward;
                 } else {
@@ -49,9 +57,9 @@
                 });
             };
 
-            service.deleteChannelReward = (channelRewardId) => {
-                service.channelRewards = service.channelRewards.filter(cr => cr.id !== channelRewardId);
-                backendCommunicator.fireEvent("delete-channel-reward", channelRewardId);
+            service.deleteChannelReward = (firebotId) => {
+                service.channelRewards = service.channelRewards.filter(cr => cr.firebotId !== firebotId);
+                backendCommunicator.fireEvent("delete-channel-reward", firebotId);
             };
 
             service.showAddOrEditRewardModal = (reward) => {
@@ -73,19 +81,22 @@
                 return service.channelRewards.some(r => r.twitchData.title === name);
             };
 
-            service.duplicateChannelReward = (rewardId) => {
-                if (service.channelRewards.length >= 50) {
+            service.duplicateChannelReward = (firebotId) => {
+                if (service.getActiveRewardCount() >= 50) {
                     return;
                 }
 
-                const reward = service.channelRewards.find(r => r.id === rewardId);
+                const reward = service.channelRewards.find(r => r.firebotId === firebotId);
                 if (reward == null) {
                     return;
                 }
                 const copiedReward = objectCopyHelper.copyObject("channel_reward", reward);
                 copiedReward.id = null;
+                copiedReward.firebotId = null;
                 copiedReward.twitchData.id = null;
                 copiedReward.manageable = true;
+                copiedReward.deletedOnTwitch = false;
+                copiedReward.previousTwitchIds = [];
 
                 while (service.channelRewardNameExists(copiedReward.twitchData.title)) {
                     copiedReward.twitchData.title += "copy";
@@ -169,9 +180,9 @@
                 updateChannelReward(channelReward);
             });
 
-            backendCommunicator.on("channel-reward-deleted", (channelRewardId) => {
-                service.channelRewards = service.channelRewards.filter(cr => cr.id !== channelRewardId);
-                delete service.redemptions[channelRewardId];
+            backendCommunicator.on("channel-reward-deleted", (firebotId) => {
+                service.channelRewards = service.channelRewards.filter(cr => cr.firebotId !== firebotId);
+                delete service.redemptions[firebotId];
             });
 
             backendCommunicator.on("channel-reward-redemptions-updated", (redemptions) => {

--- a/src/gui/app/templates/_channel-rewards.html
+++ b/src/gui/app/templates/_channel-rewards.html
@@ -13,7 +13,7 @@
       headers="rewardHeaders"
       sort-tag-context="channel rewards"
       orderable="true"
-      add-new-button-disabled="channelRewardsService.channelRewards.length >= 50"
+      add-new-button-disabled="channelRewardsService.getActiveRewardCount() >= 50"
       add-new-button-text="New Channel Reward"
       on-add-new-clicked="channelRewardsService.showAddOrEditRewardModal()"
       context-menu-options="rewardMenuOptions(item)"
@@ -36,7 +36,7 @@
               <tooltip text="'Twitch limits channels to 50 total channel rewards.'" />
             </span>
             <span class="my-0 mx-4" style="font-size: 20px;">
-              {{channelRewardsService.channelRewards.length}} / 50
+              {{channelRewardsService.getActiveRewardCount()}} / 50
             </span>
           </div>
           <div style="width: 100%">
@@ -48,7 +48,7 @@
                 overflow: hidden;
               ">
               <div style="height: 100%; background: #2aa2c0"
-                ng-style="{ width: ((channelRewardsService.channelRewards.length / 50) * 100) + '%' }"></div>
+                ng-style="{ width: ((channelRewardsService.getActiveRewardCount() / 50) * 100) + '%' }"></div>
             </div>
           </div>
         </div>

--- a/src/types/channel-rewards.d.ts
+++ b/src/types/channel-rewards.d.ts
@@ -3,9 +3,12 @@ import type { EffectList } from "./effects";
 import type { RestrictionData } from "./restrictions";
 
 export type SavedChannelReward = {
+    firebotId: string;
     id: string;
     twitchData: CustomReward;
     manageable: boolean;
+    deletedOnTwitch?: boolean;
+    previousTwitchIds?: string[];
     effects?: EffectList;
     effectsFulfilled?: EffectList;
     effectsCanceled?: EffectList;
@@ -20,6 +23,7 @@ export type RewardRedemptionMetadata = {
     messageText: string;
     redemptionId: string;
     rewardId: string;
+    firebotRewardId?: string;
     rewardImage: string;
     rewardName: string;
     rewardCost: number;


### PR DESCRIPTION
### Description of the Change
By default Twitch only allows 50 channel redeems max. When disabling rewards in Firebot, this does not free up a slot, as the channel redeem stays on Twitch. 
With this change the redeem gets deleted on twitch, but still is stored locally. You can re-enable the redeem at any point in Firebot to re-add it to twitch (if there is a slot left). 
This way you can store more than 50 channel redeems locally, but still only have 50 active at a time. 
It's great for people like me who have sets of channel redeems per category and constantly want to turn them on/off per game. 


### Testing
Create 49 channel redeems on twitch.
Create a 50th one with Firebot.
Trying to create a 51st will still cause an error. 
Right click the 50th redeem and disable it. This will now delete it from Twitch but keep it in Firebot.
You are now able to create another channel redeem to take the 50th spot. 


### Screenshots
<img width="2536" height="1374" alt="screenshot-2026-02-11_18-44-19" src="https://github.com/user-attachments/assets/ac7938f0-c592-4eb2-b20b-c784ee8c6774" />
<img width="2536" height="1374" alt="screenshot-2026-02-11_18-44-25" src="https://github.com/user-attachments/assets/a0820f0e-0587-48f3-953d-c4808a7cb7bb" />
<img width="2536" height="1374" alt="screenshot-2026-02-11_18-44-34" src="https://github.com/user-attachments/assets/2f5bff64-9933-4e66-bbce-2b2c0a9963cd" />