### PR TITLE
fix: listen to user:offline event to individually mark viewers offline

### DIFF
--- a/src/backend/viewers/viewer-online-status-manager.ts
+++ b/src/backend/viewers/viewer-online-status-manager.ts
@@ -41,6 +41,10 @@ class ViewerOnlineStatusManager {
         ActiveUserHandler.on("user:online", (user) => {
             void this.setChatViewerOnline(user);
         });
+
+        ActiveUserHandler.on("user:offline", (userId) => {
+            void this.setChatViewerOffline(userId);
+        });
     }
 
     async getOnlineViewers(): Promise<FirebotViewer[]> {


### PR DESCRIPTION
### Description of the Change
The ActiveUserHandler emits "user:offline" when a viewer's online cache TTL expires (7.5 min without activity), but no listener existed for this event. This meant viewers were never individually marked offline in the ViewerDB — only bulk-cleared on chat disconnect or stream end.


### Applicable Issues
#3455 


### Testing
- Start Firebot, go live, have a viewer chat
- Viewer leaves Twitch
- After ~8 minutes, verify viewer is marked offline in Viewer DB
- Verify lastSeen stops updating for that viewer
- Verify view time doesn't accrue for absent viewers on next stream
- Verify bulk setAllViewersOffline() still works on chat disconnect/app restart