### PR TITLE
fix: missing utils.stylesToString() in custom-advanced widgets (#3479)

### DIFF
--- a/src/backend/overlay-widgets/builtin-types/custom/custom-advanced.ts
+++ b/src/backend/overlay-widgets/builtin-types/custom/custom-advanced.ts
@@ -115,7 +115,8 @@ if (eventName === "show") {
                 overlayWrapperElement: document.body.querySelector(".wrapper"),
                 utils: {
                     ...utils,
-                    sendMessageToFirebot: utils.sendMessageToFirebot.bind(utils)
+                    sendMessageToFirebot: utils.sendMessageToFirebot.bind(utils),
+                    stylesToString: utils.stylesToString.bind(utils)
                 }
             });
         }


### PR DESCRIPTION
### Description of the Change
Adds binding the `stylesToString()` function to the utils object passed on to the custom widget code evaluation. 


### Applicable Issues
#3479


### Testing
Exemple widget displays the red square as it's supposed to and no error is raised in the browser console
