### PR TITLE
fix: currency restriction message

### DIFF
--- a/src/backend/restrictions/restriction-manager.ts
+++ b/src/backend/restrictions/restriction-manager.ts
@@ -84,7 +84,8 @@ class RestrictionsManager extends TypedEmitter<Events> {
             await restrictionDef.predicate(triggerData, restriction, restrictionsAreInherited);
             restrictionPassed = true;
         } catch (reason) {
-            failedReason = (reason as string)?.toLowerCase();
+            failedReason = (reason instanceof Error ? reason.message : (reason as string))?.toLowerCase()
+                ?? "You don't meet the requirements.";
         }
 
         if (restriction.invertCondition) {


### PR DESCRIPTION
### Description of the Change
Add explicit handling for restrictions that throw errors, rather than rejecting a Promise with a string. Fixes restriction message for the Currency restriction.

The commit is named as such for the release notes.

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
Reported in discord

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured both the currency restriction (Error-throwing) and the stream live (string rejecting) restrictions work as expected on a command.