### PR TITLE
feat(filters): add streak count filter to watch streak event

### DIFF
--- a/src/backend/events/filters/builtin/twitch/index.ts
+++ b/src/backend/events/filters/builtin/twitch/index.ts
@@ -22,6 +22,7 @@ import subMonths from "./sub-months";
 import subType from "./sub-type";
 import treasureTrain from "./treasure-train";
 import username from "./username";
+import watchStreakCount from "./watch-streak-count";
 
 export default [
     bitsBadgeTier,
@@ -47,5 +48,6 @@ export default [
     subMonths,
     subType,
     treasureTrain,
-    username
+    username,
+    watchStreakCount
 ];

--- a/src/backend/events/filters/builtin/twitch/watch-streak-count.ts
+++ b/src/backend/events/filters/builtin/twitch/watch-streak-count.ts
@@ -1,0 +1,13 @@
+﻿import { createNumberFilter } from "../../filter-factory";
+
+const filter = createNumberFilter({
+    id: "firebot:watch-streak-count",
+    name: "Watch Streak Count",
+    description: "Filter by the number of consecutive streams watched",
+    eventMetaKey: "streakCount",
+    events: [
+        { eventSourceId: "twitch", eventId: "watch-streak" }
+    ]
+});
+
+export default filter;


### PR DESCRIPTION
### Description of the Change
Added "Streak Count" filter to the "Watch Streak" event for more flexibility.

The Twitch Watch Streak event already passes streakCount into the twitch:watch-streak event.

The filter supports number comparisons:
"is", "is not", "less than", "less than or equal to", "greater than", and "greater than or equal to".

### Applicable Issues
[#3510](https://github.com/crowbartools/Firebot/issues/3510)

### Testing
Confirmed:
- Firebot launches and runs normally
- The filter appears for the "Watch Streak" event
- The filter settings save correctly
- The filter works as intended in a test build
- Watch Streak process correctly with the filter enabled

### Screenshots
<img width="293" height="386" alt="image" src="https://github.com/user-attachments/assets/e80d150c-76d7-4c9a-84a3-51ab140a3af0" />
<img width="402" height="294" alt="image" src="https://github.com/user-attachments/assets/5693aecf-b6ae-405a-b3aa-acfb92a27f65" />