### PR TITLE
implemented gamepad binds as a additional trigger

### DIFF
--- a/src/backend/app-management/electron/events/when-ready.ts
+++ b/src/backend/app-management/electron/events/when-ready.ts
@@ -221,6 +221,9 @@ export async function whenReady() {
     const { HotkeyManager } = await import("../../../hotkeys/hotkey-manager");
     HotkeyManager.loadItems();
 
+    const { GamepadManager } = await import("../../../gamepads/gamepad-manager");
+    GamepadManager.loadItems();
+
     windowManagement.updateSplashScreenStatus("Starting currency timer...");
     const currencyManager = (await import("../../../currency/currency-manager")).default;
     currencyManager.startTimer();

--- a/src/backend/gamepads/gamepad-manager.ts
+++ b/src/backend/gamepads/gamepad-manager.ts
@@ -1,0 +1,71 @@
+import { FirebotGamepadBinding } from "../../types/gamepad-bindings";
+import { Trigger } from "../../types/triggers";
+
+import { AccountAccess } from "../common/account-access";
+import effectRunner from "../common/effect-runner";
+import frontendCommunicator from "../common/frontend-communicator";
+import logger from "../logwrapper";
+import JsonDbManager from "../database/json-db-manager";
+
+class GamepadManager extends JsonDbManager<FirebotGamepadBinding> {
+    constructor() {
+        super("GamepadBinding", "gamepad-bindings");
+
+        frontendCommunicator.on("gamepad:get-bindings",
+            () => this.getAllItems());
+
+        frontendCommunicator.on("gamepad:save-binding",
+            (binding: FirebotGamepadBinding) => this.saveItem(binding));
+
+        frontendCommunicator.on("gamepad:save-all-bindings",
+            (bindings: FirebotGamepadBinding[]) => this.saveAllItems(bindings));
+
+        frontendCommunicator.on("gamepad:delete-binding",
+            (id: string) => this.deleteItem(id));
+
+        frontendCommunicator.on("gamepad:button-pressed",
+            (data: { gamepadIndex: number; buttonIndex: number }) => {
+                this.handleButtonPress(data.gamepadIndex, data.buttonIndex);
+            });
+    }
+
+    override loadItems(): void {
+        super.loadItems();
+        logger.debug("Loaded gamepad bindings");
+    }
+
+    triggerUiRefresh(): void {
+        frontendCommunicator.send("gamepad:all-bindings-updated", this.getAllItems());
+    }
+
+    private handleButtonPress(gamepadIndex: number, buttonIndex: number): void {
+        const binding = this.getAllItems().find(b =>
+            b.active &&
+            b.button === buttonIndex &&
+            (b.gamepadIndex == null || b.gamepadIndex === gamepadIndex)
+        );
+
+        if (!binding?.effects) return;
+
+        const processEffectsRequest = {
+            trigger: {
+                // "hotkey" is used intentionally so gamepad bindings are compatible with all
+                // hotkey-supporting effects without needing to audit every effect definition.
+                // A dedicated "gamepad" trigger type can be introduced in a follow-up.
+                type: "hotkey",
+                metadata: {
+                    username: AccountAccess.getAccounts().streamer.username,
+                    hotkey: binding,
+                    gamepadBinding: binding,
+                    gamepadIndex,
+                    buttonIndex
+                }
+            } as Trigger,
+            effects: binding.effects
+        };
+        void effectRunner.processEffects(processEffectsRequest);
+    }
+}
+
+const gamepadManager = new GamepadManager();
+export { gamepadManager as GamepadManager };

--- a/src/gui/app/app-main.js
+++ b/src/gui/app/app-main.js
@@ -130,6 +130,7 @@
         settingsService,
         countersService,
         hotkeyService,
+        gamepadService,
         gamesService,
         presetEffectListsService,
         startupScriptsService,
@@ -173,6 +174,9 @@
         countersService.loadCounters();
 
         hotkeyService.loadHotkeys();
+
+        gamepadService.loadBindings();
+        gamepadService.startPolling();
 
         gamesService.loadGames();
 

--- a/src/gui/app/controllers/gamepads.controller.js
+++ b/src/gui/app/controllers/gamepads.controller.js
@@ -1,0 +1,60 @@
+"use strict";
+
+(function() {
+    angular
+        .module("firebotApp")
+        .controller("gamepadsController", function($scope, gamepadService, utilityService) {
+            $scope.gamepadService = gamepadService;
+
+            $scope.onBindingsUpdated = (items) => {
+                gamepadService.saveAllBindings(items);
+            };
+
+            $scope.headers = [
+                {
+                    name: "NAME",
+                    icon: "fa-user",
+                    dataField: "name",
+                    sortable: true,
+                    cellTemplate: `{{data.name}}`
+                },
+                {
+                    name: "BUTTON",
+                    icon: "fa-gamepad",
+                    dataField: "button",
+                    cellTemplate: `{{getButtonName(data.button)}}`,
+                    cellController: ($scope) => {
+                        $scope.getButtonName = (button) => gamepadService.getButtonName(button);
+                    }
+                }
+            ];
+
+            $scope.bindingOptions = (item) => [
+                {
+                    html: `<a href><i class="far fa-pen mr-2 text-center" style="width: 20px;"></i> Edit</a>`,
+                    click: () => gamepadService.showAddEditBindingModal(item)
+                },
+                {
+                    html: `<a href><i class="far fa-toggle-off mr-2 text-center" style="width: 20px;"></i> ${item.active ? "Disable" : "Enable"}</a>`,
+                    click: () => gamepadService.toggleBindingActiveState(item)
+                },
+                {
+                    html: `<a href style="color: #fb7373;"><i class="far fa-trash-alt text-center mr-2" style="width: 20px;"></i> Delete</a>`,
+                    click: () => {
+                        utilityService
+                            .showConfirmationModal({
+                                title: "Delete Gamepad Binding",
+                                question: `Are you sure you want to delete the binding "${item.name}"?`,
+                                confirmLabel: "Delete",
+                                confirmBtnType: "btn-danger"
+                            })
+                            .then((confirmed) => {
+                                if (confirmed) {
+                                    gamepadService.deleteBinding(item.id);
+                                }
+                            });
+                    }
+                }
+            ];
+        });
+}());

--- a/src/gui/app/directives/misc/gamepadCapture.js
+++ b/src/gui/app/directives/misc/gamepadCapture.js
@@ -1,0 +1,65 @@
+"use strict";
+
+(function() {
+    angular.module("firebotApp").component("gamepadCapture", {
+        bindings: {
+            onCapture: "&",
+            button: "<"
+        },
+        template: `
+            <div class="hotkey-capture" ng-class="{ 'capturing': $ctrl.gps.isCapturingButton, 'has-value': $ctrl.buttonDisplay }">
+                <div class="hotkey-display">
+                    <div class="hotkey-content">
+                        <i class="fas fa-gamepad" style="margin-right: 8px; opacity: 0.7;"></i>
+                        <span ng-if="!$ctrl.buttonDisplay" class="muted" style="font-weight: 500;">
+                            {{ $ctrl.gps.isCapturingButton ? 'Press any controller button...' : 'No button set' }}
+                        </span>
+                        <span class="hotkey-value">{{$ctrl.buttonDisplay}}</span>
+                    </div>
+                    <button
+                        ng-click="$ctrl.toggleCapture(); $event.stopPropagation()"
+                        class="hotkey-chip-btn"
+                        ng-class="$ctrl.gps.isCapturingButton ? 'recording' : 'idle'"
+                    >
+                        <i class="fas" ng-class="$ctrl.gps.isCapturingButton ? 'fa-stop' : 'fa-dot-circle'"></i>
+                        <span>{{$ctrl.gps.isCapturingButton ? 'Cancel' : ($ctrl.buttonDisplay ? 'Change Button' : 'Record Button')}}</span>
+                    </button>
+                </div>
+            </div>
+        `,
+        controller: function(gamepadService, $rootScope, $scope) {
+            const $ctrl = this;
+
+            $ctrl.gps = gamepadService;
+            $ctrl.buttonDisplay = "";
+
+            $ctrl.toggleCapture = () => {
+                if (gamepadService.isCapturingButton) {
+                    gamepadService.cancelCapture();
+                } else {
+                    gamepadService.startCapture((gamepadIndex, buttonIndex) => {
+                        $ctrl.onCapture({ gamepadIndex, buttonIndex });
+                        $scope.$applyAsync();
+                    });
+                }
+            };
+
+            $ctrl.$onChanges = (changes) => {
+                if (changes.button != null && changes.button.currentValue != null) {
+                    $ctrl.buttonDisplay = gamepadService.getButtonName(changes.button.currentValue);
+                }
+            };
+
+            $ctrl.$onInit = () => {
+                if ($ctrl.button != null) {
+                    $ctrl.buttonDisplay = gamepadService.getButtonName($ctrl.button);
+                }
+            };
+
+            $rootScope.$on("gamepad:capture:update", (event, data) => {
+                $ctrl.buttonDisplay = gamepadService.getButtonName(data.buttonIndex);
+                $scope.$applyAsync();
+            });
+        }
+    });
+}());

--- a/src/gui/app/directives/modals/gamepads/addOrEditGamepadBinding/add-edit-gamepad-binding-modal.js
+++ b/src/gui/app/directives/modals/gamepads/addOrEditGamepadBinding/add-edit-gamepad-binding-modal.js
@@ -1,0 +1,99 @@
+"use strict";
+
+(function() {
+    angular.module("firebotApp").component("addOrEditGamepadBindingModal", {
+        template: `
+            <div class="modal-header">
+                <button type="button" class="close" ng-click="$ctrl.dismiss()">&times;</button>
+                <h4 class="modal-title">
+                    {{$ctrl.isNew ? 'Add Gamepad Binding' : 'Edit Gamepad Binding'}}
+                </h4>
+            </div>
+            <div class="modal-body">
+                <div class="function-button-settings">
+                    <h4>Name</h4>
+                    <input type="text" class="form-control" ng-model="$ctrl.binding.name" placeholder="Enter name">
+
+                    <h4 style="margin-top: 20px;">Button</h4>
+                    <gamepad-capture
+                        on-capture="$ctrl.onButtonCapture(gamepadIndex, buttonIndex)"
+                        button="$ctrl.binding.button"
+                    ></gamepad-capture>
+
+                    <div style="margin-top: 20px;">
+                        <effect-list
+                            header="What should this button do?"
+                            effects="$ctrl.binding.effects"
+                            trigger="hotkey"
+                            trigger-meta="{ rootEffects: $ctrl.binding.effects }"
+                            update="$ctrl.effectListUpdated(effects)"
+                        ></effect-list>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-link" ng-click="$ctrl.dismiss()">Cancel</button>
+                <button type="button" class="btn btn-primary" ng-click="$ctrl.save()">Save</button>
+            </div>
+        `,
+        bindings: {
+            resolve: "<",
+            close: "&",
+            dismiss: "&",
+            modalInstance: "<"
+        },
+        controller: function(gamepadService, ngToast) {
+            const $ctrl = this;
+
+            $ctrl.isNew = true;
+            $ctrl.binding = {
+                name: "",
+                active: true,
+                button: null,
+                gamepadIndex: null,
+                sortTags: []
+            };
+
+            $ctrl.$onInit = () => {
+                if ($ctrl.resolve.binding) {
+                    $ctrl.binding = JSON.parse(angular.toJson($ctrl.resolve.binding));
+                    if ($ctrl.binding.sortTags == null) {
+                        $ctrl.binding.sortTags = [];
+                    }
+                    $ctrl.isNew = false;
+                }
+            };
+
+            $ctrl.onButtonCapture = (gamepadIndex, buttonIndex) => {
+                $ctrl.binding.button = buttonIndex;
+                $ctrl.binding.gamepadIndex = gamepadIndex;
+            };
+
+            $ctrl.effectListUpdated = (effects) => {
+                $ctrl.binding.effects = effects;
+            };
+
+            $ctrl.save = () => {
+                if ($ctrl.binding.name === "") {
+                    ngToast.create("Please provide a name for the binding.");
+                    return;
+                }
+                if ($ctrl.binding.button == null) {
+                    ngToast.create("Please record a controller button.");
+                    return;
+                }
+                if (gamepadService.bindingExists($ctrl.binding.id, $ctrl.binding.button, $ctrl.binding.gamepadIndex)) {
+                    ngToast.create("A binding for this button already exists.");
+                    return;
+                }
+
+                const saved = gamepadService.saveBinding($ctrl.binding);
+                if (saved) {
+                    $ctrl.close({ $value: { binding: $ctrl.binding } });
+                } else {
+                    ngToast.create("Failed to save binding. Check the logs for details.");
+                }
+            };
+        }
+    });
+}());

--- a/src/gui/app/directives/sidebar/sidebar.js
+++ b/src/gui/app/directives/sidebar/sidebar.js
@@ -24,6 +24,7 @@
                             <nav-link page="Power-ups And Rewards" name="{{'SIDEBAR.OTHER.POWERUPSANDREWARDS' | translate }}" icon="fa-gifts"></nav-link>
                             <nav-link page="Preset Effect Lists" name="{{ 'SIDEBAR.OTHER.PRESET_EFFECT_LISTS' | translate }}" icon="fa-magic"></nav-link>
                             <nav-link page="Hotkeys" name="{{'SIDEBAR.OTHER.HOTKEYS' | translate }}" icon="fa-keyboard"></nav-link>
+                            <nav-link page="Gamepad Bindings" name="Gamepad Bindings" icon="fa-gamepad"></nav-link>
                             <nav-link page="Counters" name="{{'SIDEBAR.OTHER.COUNTERS' | translate }}" icon="fa-tally"></nav-link>
                             <nav-link page="Overlay Widgets" name="Overlay Widgets" icon="fa-layer-plus"></nav-link>
 

--- a/src/gui/app/index.html
+++ b/src/gui/app/index.html
@@ -100,6 +100,7 @@
         <script type="text/javascript" src="./controllers/events.controller.js"></script>
         <script type="text/javascript" src="./controllers/games.controller.js"></script>
         <script type="text/javascript" src="./controllers/hotkeys.controller.js"></script>
+        <script type="text/javascript" src="./controllers/gamepads.controller.js"></script>
         <script type="text/javascript" src="./controllers/moderation.controller.js"></script>
         <script type="text/javascript" src="./controllers/preset-effect-lists.controller.js"></script>
         <script type="text/javascript" src="./controllers/quotes.controller.js"></script>
@@ -130,6 +131,7 @@
         <script type="text/javascript" src="./services/font-manager.service.js"></script>
         <script type="text/javascript" src="./services/games.service.js"></script>
         <script type="text/javascript" src="./services/hot-key.service.js"></script>
+        <script type="text/javascript" src="./services/gamepad.service.js"></script>
         <script type="text/javascript" src="./services/icons.service.js"></script>
         <script type="text/javascript" src="./services/import.service.js"></script>
         <script type="text/javascript" src="./services/integration.service.js"></script>
@@ -233,6 +235,7 @@
         <script type="text/javascript" src="./directives/misc/dynamicHtml.js"></script>
         <script type="text/javascript" src="./directives/misc/firebot-item-table/firebot-item-table.js"></script>
         <script type="text/javascript" src="./directives/misc/hotkeyCapture.js"></script>
+        <script type="text/javascript" src="./directives/misc/gamepadCapture.js"></script>
         <script type="text/javascript" src="./directives/misc/hover-class.directive.js"></script>
         <script type="text/javascript" src="./directives/misc/icon-picker.js"></script>
         <script type="text/javascript" src="./directives/misc/imageonload.js"></script>
@@ -270,6 +273,7 @@
         <script type="text/javascript" src="./directives/modals/filters/addOrEditFilter/addOrEditFilterModal.js"></script>
         <script type="text/javascript" src="./directives/modals/games/editGameSettingsModal.js"></script>
         <script type="text/javascript" src="./directives/modals/hotkeys/addOrEditHotkey/add-edit-hotkey-modal.js"></script>
+        <script type="text/javascript" src="./directives/modals/gamepads/addOrEditGamepadBinding/add-edit-gamepad-binding-modal.js"></script>
         <script type="text/javascript" src="./directives/modals/integrations/addOrEditDiscordFileUploadModal.js"></script>
         <script type="text/javascript" src="./directives/modals/integrations/addOrEditDiscordWebhookModal.js"></script>
         <script type="text/javascript" src="./directives/modals/integrations/editIntegrationSettingsModal.js"></script>

--- a/src/gui/app/services/gamepad.service.js
+++ b/src/gui/app/services/gamepad.service.js
@@ -1,0 +1,164 @@
+"use strict";
+
+(function() {
+    angular
+        .module("firebotApp")
+        .factory("gamepadService", function($rootScope, logger, backendCommunicator, modalService) {
+            const service = {};
+
+            service.bindings = [];
+
+            const BUTTON_NAMES = [
+                "A / Cross",
+                "B / Circle",
+                "X / Square",
+                "Y / Triangle",
+                "LB / L1",
+                "RB / R1",
+                "LT / L2",
+                "RT / R2",
+                "Select / Back",
+                "Start / Options",
+                "L3 (Left Stick)",
+                "R3 (Right Stick)",
+                "D-Pad Up",
+                "D-Pad Down",
+                "D-Pad Left",
+                "D-Pad Right",
+                "Home / Guide"
+            ];
+
+            service.getButtonName = (buttonIndex) => {
+                if (buttonIndex == null) return "";
+                return BUTTON_NAMES[buttonIndex] ?? `Button ${buttonIndex}`;
+            };
+
+            service.loadBindings = () => {
+                service.bindings = backendCommunicator.fireEventSync("gamepad:get-bindings") ?? [];
+            };
+
+            service.saveBinding = (binding) => {
+                if (!binding) return false;
+                const saved = backendCommunicator.fireEventSync("gamepad:save-binding", binding);
+                if (saved) {
+                    const index = service.bindings.findIndex(b => b.id === saved.id);
+                    if (index > -1) {
+                        service.bindings[index] = saved;
+                    } else {
+                        service.bindings.push(saved);
+                    }
+                    return true;
+                }
+                return false;
+            };
+
+            service.saveAllBindings = (bindings) => {
+                if (bindings) service.bindings = bindings;
+                backendCommunicator.fireEvent("gamepad:save-all-bindings", service.bindings);
+            };
+
+            service.deleteBinding = (id) => {
+                service.bindings = service.bindings.filter(b => b.id !== id);
+                backendCommunicator.fireEvent("gamepad:delete-binding", id);
+            };
+
+            service.toggleBindingActiveState = (binding) => {
+                if (binding) {
+                    binding.active = !binding.active;
+                    service.saveBinding(binding);
+                }
+            };
+
+            service.bindingExists = (bindingId, button, gamepadIndex) => {
+                return service.bindings.some(
+                    b => b.button === button &&
+                         b.gamepadIndex === gamepadIndex &&
+                         b.id !== bindingId
+                );
+            };
+
+            service.showAddEditBindingModal = (binding) => {
+                modalService.showModal({
+                    component: "AddOrEditGamepadBindingModal",
+                    size: "mdlg",
+                    keyboard: false,
+                    resolveObj: {
+                        binding: () => binding
+                    },
+                    closeCallback: () => {}
+                });
+            };
+
+            backendCommunicator.on("gamepad:all-bindings-updated", (bindings) => {
+                service.bindings = bindings ?? [];
+            });
+
+            // Polling
+            service.isCapturingButton = false;
+            let prevButtonStates = {};
+            let animFrameId = null;
+            let captureCallback = null;
+
+            const pollGamepads = () => {
+                const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+
+                for (let gi = 0; gi < gamepads.length; gi++) {
+                    const gp = gamepads[gi];
+                    if (!gp) continue;
+
+                    if (!prevButtonStates[gi]) {
+                        prevButtonStates[gi] = new Array(gp.buttons.length).fill(false);
+                    }
+
+                    for (let bi = 0; bi < gp.buttons.length; bi++) {
+                        const pressed = gp.buttons[bi].pressed;
+                        const wasPressed = prevButtonStates[gi][bi];
+
+                        if (pressed && !wasPressed) {
+                            if (service.isCapturingButton) {
+                                service.isCapturingButton = false;
+                                $rootScope.$broadcast("gamepad:capture:update", {
+                                    gamepadIndex: gi,
+                                    buttonIndex: bi
+                                });
+                                if (typeof captureCallback === "function") {
+                                    captureCallback(gi, bi);
+                                    captureCallback = null;
+                                }
+                                $rootScope.$applyAsync();
+                            } else {
+                                backendCommunicator.send("gamepad:button-pressed", {
+                                    gamepadIndex: gi,
+                                    buttonIndex: bi
+                                });
+                            }
+                        }
+
+                        prevButtonStates[gi][bi] = pressed;
+                    }
+                }
+
+                animFrameId = requestAnimationFrame(pollGamepads);
+            };
+
+            service.startPolling = () => {
+                if (animFrameId == null) {
+                    prevButtonStates = {};
+                    animFrameId = requestAnimationFrame(pollGamepads);
+                    logger.info("Gamepad polling started");
+                }
+            };
+
+            service.startCapture = (callback) => {
+                captureCallback = callback;
+                service.isCapturingButton = true;
+            };
+
+            service.cancelCapture = () => {
+                service.isCapturingButton = false;
+                captureCallback = null;
+            };
+
+            return service;
+        });
+}());

--- a/src/gui/app/services/sidebar-manager.service.js
+++ b/src/gui/app/services/sidebar-manager.service.js
@@ -58,6 +58,7 @@
                     "settings",
                     "counters",
                     "hotkeys",
+                    "gamepad bindings",
                     "effect queues",
                     "currency",
                     "quotes",
@@ -215,6 +216,11 @@
                 .when("/hotkeys", {
                     templateUrl: "./templates/_hotkeys.html",
                     controller: "hotkeysController"
+                })
+
+                .when("/gamepad-bindings", {
+                    templateUrl: "./templates/_gamepads.html",
+                    controller: "gamepadsController"
                 })
 
                 .when("/currency", {

--- a/src/gui/app/templates/_gamepads.html
+++ b/src/gui/app/templates/_gamepads.html
@@ -1,0 +1,14 @@
+<firebot-item-table
+    items="gamepadService.bindings"
+    on-items-update="onBindingsUpdated(items)"
+    headers="headers"
+    sort-tag-context="gamepad-bindings"
+    orderable="true"
+    add-new-button-text="New Binding"
+    on-add-new-clicked="gamepadService.showAddEditBindingModal()"
+    context-menu-options="bindingOptions(item)"
+    no-data-message="No gamepad bindings saved. Connect a controller and add one!"
+    none-found-message="No bindings found."
+    search-placeholder="Search bindings"
+    status-field="active"
+></firebot-item-table>

--- a/src/types/gamepad-bindings.d.ts
+++ b/src/types/gamepad-bindings.d.ts
@@ -1,0 +1,11 @@
+import type { EffectList } from "./effects";
+
+export type FirebotGamepadBinding = {
+    id: string;
+    name: string;
+    active: boolean;
+    button: number;
+    gamepadIndex: number | null;
+    effects: EffectList;
+    sortTags: string[];
+};


### PR DESCRIPTION
### Description of the Change
Adds game controller (gamepad) binding support, allowing users to map controller buttons to effect lists — similar to how keyboard hotkeys work.

### Applicable Issues
#3525


### Testing
  - Connected a gamepad, created a binding, confirmed button press triggers the assigned effects                                                                                                                                            
  - Verified enable/disable toggle stops and resumes triggering
  - Verified duplicate button detection (same button + controller index) is caught on save                                                                                                                                                  
  - Verified bindings persist across app restarts
  - Verified with test soundeffects binding
  - Tested on POP!OS machine. Pulling should work with mozilla gamepad api under win, mac and linux
  -  src/gui/app/directives/sidebar/sidebar.js => bindings may need a diffrent nav-link variable

### Screenshots
<img width="1676" height="545" alt="image" src="https://github.com/user-attachments/assets/04fbc2d2-820d-4dc4-8830-b39a1925735e" />


<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
