### PR TITLE
chore(types): add showConfirmationModal to modalFactory

### DIFF
--- a/src/types/ui/modal-factory.ts
+++ b/src/types/ui/modal-factory.ts
@@ -27,4 +27,13 @@ export type ModalFactory = {
         trigger?: TriggerType;
         triggerMeta?: unknown;
     }, callback: (result: T) => void, dismissCallback?: () => void) => void;
+    showConfirmationModal: (options: {
+        title: string;
+        question: string;
+        tip?: string;
+        cancelLabel?: string;
+        cancelBtnType?: string;
+        confirmLabel?: string;
+        confirmBtnType?: string;
+    }) => Promise<boolean>;
 };


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
Add showConfirmationModal to the type shim for modalFactory to expose it to plugins

### Applicable Issues
<!-- Please tag any applicable Issues (ie #123) here -->
N/A

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured types are based on usage in the modal and ensured Firebot still compiles and launches