### PR TITLE
feat(vars): Add `obsPreviousSceneName` variable (#3057)

### DIFF
--- a/src/backend/integrations/builtin/obs/obs-integration.ts
+++ b/src/backend/integrations/builtin/obs/obs-integration.ts
@@ -44,6 +44,7 @@ import GroupNameEventFilter from "./filters/group-name-filter";
 import SceneNameEventFilter from "./filters/scene-name-filter";
 
 import { SceneNameVariable } from "./variables/scene-name-variable";
+import { PreviousSceneNameVariable } from "./variables/previous-scene-name";
 import { SceneCollectionNameVariable } from "./variables/scene-collection-name";
 import { IsConnectedVariable } from "./variables/is-connected";
 import { IsStreamingVariable } from "./variables/is-streaming";
@@ -169,6 +170,7 @@ class ObsIntegration
         FilterManager.registerFilter(SceneNameEventFilter);
 
         ReplaceVariableManager.registerReplaceVariable(SceneNameVariable);
+        ReplaceVariableManager.registerReplaceVariable(PreviousSceneNameVariable);
         ReplaceVariableManager.registerReplaceVariable(SceneCollectionNameVariable);
         ReplaceVariableManager.registerReplaceVariable(IsConnectedVariable);
         ReplaceVariableManager.registerReplaceVariable(IsStreamingVariable);

--- a/src/backend/integrations/builtin/obs/obs-remote.ts
+++ b/src/backend/integrations/builtin/obs/obs-remote.ts
@@ -61,6 +61,8 @@ let groupInfos: Array<CachedGroupInfo> = [];
 let previewSceneName: string | null;
 // The cached program scene name.
 let programSceneName: string;
+// The cached previous program scene name.
+let previousProgramSceneName: string;
 
 const TEXT_SOURCE_IDS = ["text_gdiplus_v2", "text_gdiplus_v3", "text_ft2_source_v2"];
 
@@ -179,6 +181,8 @@ async function setupRemoteListeners() {
     });
 
     obs.on("SceneTransitionStarted", async ({ transitionName }) => {
+        previousProgramSceneName = programSceneName || "";
+
         programSceneName = (await obs.call("GetCurrentProgramScene"))?.sceneName || "";
         eventManager?.triggerEvent(
             OBS_EVENT_SOURCE_ID,
@@ -661,6 +665,10 @@ export async function getSceneList(): Promise<string[]> {
 
 export function getCurrentSceneName(): string {
     return programSceneName;
+}
+
+export function getPreviousSceneName(): string {
+    return previousProgramSceneName;
 }
 
 export async function setCurrentScene(sceneName: string): Promise<void> {

--- a/src/backend/integrations/builtin/obs/variables/previous-scene-name.ts
+++ b/src/backend/integrations/builtin/obs/variables/previous-scene-name.ts
@@ -1,0 +1,15 @@
+import { ReplaceVariable } from "../../../../../types/variables";
+import { getPreviousSceneName } from "../obs-remote";
+
+export const PreviousSceneNameVariable: ReplaceVariable = {
+    definition: {
+        handle: "obsPreviousSceneName",
+        description:
+      "The name of the previous OBS scene. If OBS isn't running, it returns 'Unknown'.",
+        possibleDataOutput: ["text"],
+        categories: ["advanced", "integrations", "obs"]
+    },
+    evaluator: () => {
+        return getPreviousSceneName() ?? "Unknown";
+    }
+};


### PR DESCRIPTION
### Description of the Change
Adds a new variable called `obsPreviousSceneName` to access the previous scene that was active after switching scenes (or "" if there was no previous scene)

The value is cached similarly to the `programSceneName` in the file `obs-remote.ts`
https://github.com/crowbartools/Firebot/blob/v5/src/backend/integrations/builtin/obs/obs-remote.ts

The only thing I'm a bit unsure about is the description for the variable.


### Applicable Issues
#3057 


### Testing
This has been tested with some simple `Log Message` effects and works fine in my setup.


### Screenshots
<img width="334" height="72" alt="image" src="https://github.com/user-attachments/assets/e2080d6b-a76a-4c7c-bef2-b7f9cca9e1e0" />



<!--
Note:
  Please be aware that we may require changes if we 
  believe they are needed to meet the vision and standards of Firebot.
  Don't take suggestions for tweaks personally, we are all simply trying to make Firebot
  the best that it can be :)
-->
