### PR TITLE
Feat: horizontal chat (#3578)

### DIFF
--- a/src/backend/overlay-widgets/builtin-types/chat/chat.ts
+++ b/src/backend/overlay-widgets/builtin-types/chat/chat.ts
@@ -25,8 +25,7 @@ export type ChatWidgetSettings = {
     messageExitAnimation?: Animation;
     messageStyle: "compact" | "modern";
     chatOrder: "normal" | "reversed";
-    /** The type of the chat (vertical or horizontal, undefined = vertical) */
-    chatType: "vertical" | "horizontal" | undefined;
+    orientation: "vertical" | "horizontal" | undefined;
     actionDisplayFormat: "modern" | "classic";
     highlightStyle: "normal" | "highlighted";
     highlightColor?: string;
@@ -231,9 +230,8 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
             ]
         },
         {
-            name: "chatType",
-            title: "Chat Type",
-            description: "The type of chat widget",
+            name: "orientation",
+            title: "Orientation",
             type: "radio-cards",
             default: "vertical",
             options: [{
@@ -352,7 +350,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                 gridColumns: 2
             },
             showIf: {
-                chatType: [
+                orientation: [
                     "vertical",
                     undefined
                 ]
@@ -754,7 +752,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                     default:
                         switch (config.settings.verticalAlignment) {
                             case "bottom":
-                                if (config.settings.chatType === "horizontal") {
+                                if (config.settings.orientation === "horizontal") {
                                     anchorToBottom = true;
                                 }
                                 height = "100%";
@@ -770,10 +768,10 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                         break;
                 }
 
-                let flexDirection = config.settings.chatType === "horizontal" ? "row" : "column";
+                let flexDirection = config.settings.orientation === "horizontal" ? "row" : "column";
                 flexDirection = config.settings.chatOrder === "reversed" ? `${flexDirection}-reverse` : flexDirection;
 
-                const horizontalAlignment = config.settings.chatType === "horizontal" ? "left" : config.settings.horizontalAlignment;
+                const horizontalAlignment = config.settings.orientation === "horizontal" ? "left" : config.settings.horizontalAlignment;
 
                 const chatContainerStyles: Record<string, string> = {
                     "display": "flex",
@@ -785,7 +783,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                     "text-align": horizontalAlignment
                 };
 
-                if (config.settings.chatType === "horizontal") {
+                if (config.settings.orientation === "horizontal") {
                     chatContainerStyles["text-wrap"] = "nowrap";
                     chatContainerStyles["align-items"] = "end";
                 }
@@ -883,7 +881,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                     "font-style": config.settings?.actionDisplayFormat === "classic" ? "normal" : "italic"
                 };
 
-                const chatMargin = config.settings.chatType === "horizontal" ?
+                const chatMargin = config.settings.orientation === "horizontal" ?
                     config.settings.chatOrder === "reversed" ? "right" : "left" :
                     config.settings.chatOrder === "reversed" ? "bottom" : "top";
 

--- a/src/backend/overlay-widgets/builtin-types/chat/chat.ts
+++ b/src/backend/overlay-widgets/builtin-types/chat/chat.ts
@@ -23,6 +23,8 @@ export type ChatWidgetSettings = {
     messageExitAnimation?: Animation;
     messageStyle: "compact" | "modern";
     chatOrder: "normal" | "reversed";
+    /** The type of the chat (vertical or horizontal, undefined = vertical) */
+    chatType: "vertical" | "horizontal" | undefined;
     actionDisplayFormat: "modern" | "classic";
     highlightStyle: "normal" | "highlighted";
     highlightColor?: string;
@@ -215,16 +217,31 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                 {
                     value: "normal",
                     label: "Normal",
-                    description: "New messages will appear at the bottom of the chat feed",
+                    description: "New messages will appear at the end of the chat feed (bottom for vertical, right for horizontal)",
                     iconClass: "fa-sort-amount-down-alt"
                 },
                 {
                     value: "reversed",
                     label: "Reversed",
-                    description: "New messages will appear at the top of the chat feed",
+                    description: "New messages will appear at the start of the chat feed (top for vertical, left for horizontal)",
                     iconClass: "fa-sort-amount-up"
                 }
             ]
+        },
+        {
+            name: "chatType",
+            title: "Chat Type",
+            description: "The type of chat widget",
+            type: "radio-cards",
+            default: "vertical",
+            options: [{
+                value: "vertical", label: "Vertical", iconClass: "fa-arrows-alt-v"
+            }, {
+                value: "horizontal", label: "Horizontal", iconClass: "fa-arrows-alt-h"
+            }],
+            settings: {
+                gridColumns: 2
+            }
         },
         {
             name: "actionDisplayFormat",
@@ -894,6 +911,9 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                     default:
                         switch (config.settings.verticalAlignment) {
                             case "bottom":
+                                if (config.settings.chatType === "horizontal") {
+                                    anchorToBottom = true;
+                                }
                                 height = "100%";
                                 maxHeight = "100%";
                                 justifyContent = "end";
@@ -907,15 +927,23 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                         break;
                 }
 
+                let flexDirection = config.settings.chatType === "horizontal" ? "row" : "column";
+                flexDirection = config.settings.chatOrder === "reversed" ? `${flexDirection}-reverse` : flexDirection;
+
                 const chatContainerStyles: Record<string, string> = {
                     "display": "flex",
-                    "flex-direction": config.settings.chatOrder === "reversed" ? "column-reverse" : "column",
+                    "flex-direction": flexDirection,
                     "align-items": config.settings.horizontalAlignment === "right" ? "end" : "start",
                     "justify-content": justifyContent,
                     "height": height,
                     "width": "100%",
                     "text-align": config.settings.horizontalAlignment
                 };
+
+                if (config.settings.chatType === "horizontal") {
+                    chatContainerStyles["text-wrap"] = "nowrap";
+                    chatContainerStyles["align-items"] = "end";
+                }
 
                 if (!!maxHeight?.length) {
                     chatContainerStyles["max-height"] = maxHeight;
@@ -1006,6 +1034,10 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                     "font-style": config.settings?.actionDisplayFormat === "classic" ? "normal" : "italic"
                 };
 
+                const chatMargin = config.settings.chatType === "horizontal" ?
+                    config.settings.chatOrder === "reversed" ? "right" : "left" :
+                    config.settings.chatOrder === "reversed" ? "bottom" : "top";
+
                 const styleMarkup = `
                     <style>
                         .chat-${config.id} {
@@ -1017,7 +1049,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                         }
 
                         .chat-${config.id} > div + div {
-                            ${config.settings.chatOrder === "reversed" ? "margin-bottom" : "margin-top"}: ${config.settings.spaceBetweenMessages ?? 5}px;
+                            margin-${chatMargin}: ${config.settings.spaceBetweenMessages ?? 5}px;
                         }
 
                         .chat-message-root-container-${config.id} {

--- a/src/backend/overlay-widgets/builtin-types/chat/chat.ts
+++ b/src/backend/overlay-widgets/builtin-types/chat/chat.ts
@@ -348,6 +348,12 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
             }],
             settings: {
                 gridColumns: 2
+            },
+            showIf: {
+                chatType: [
+                    "vertical",
+                    undefined
+                ]
             }
         },
         {
@@ -930,14 +936,16 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                 let flexDirection = config.settings.chatType === "horizontal" ? "row" : "column";
                 flexDirection = config.settings.chatOrder === "reversed" ? `${flexDirection}-reverse` : flexDirection;
 
+                const horizontalAlignment = config.settings.chatType === "horizontal" ? "left" : config.settings.horizontalAlignment;
+
                 const chatContainerStyles: Record<string, string> = {
                     "display": "flex",
                     "flex-direction": flexDirection,
-                    "align-items": config.settings.horizontalAlignment === "right" ? "end" : "start",
+                    "align-items": horizontalAlignment === "right" ? "end" : "start",
                     "justify-content": justifyContent,
                     "height": height,
                     "width": "100%",
-                    "text-align": config.settings.horizontalAlignment
+                    "text-align": horizontalAlignment
                 };
 
                 if (config.settings.chatType === "horizontal") {
@@ -957,7 +965,7 @@ export const chat: OverlayWidgetType<ChatWidgetSettings, ChatWidgetState> = {
                 const messageRootContainerStyles: Record<string, string> = {
                     "display": "flex",
                     "gap": "10px",
-                    "flex-direction": config.settings.horizontalAlignment === "right"
+                    "flex-direction": horizontalAlignment === "right"
                         ? "row-reverse"
                         : "row"
                 };


### PR DESCRIPTION
### Description of the Change
<!-- Please describe your change here -->
This PR adds a horizontal chat mode to the built-in chat widget, letting chat messages render right-to-left (default, newest message starts on the right of the widget and pushes older messages to the left) or left-to-right (reversed, newest message starts on the left of the widget and pushes older messages to the right)


### Applicable Issues
#3578

### Testing
<!-- Outline any testing (manual or regression) you've done for these changes -->
Ensured vertical mode still behaves as it did before
Ensured messages appear horizontally and don't break into multiple lines
Ensured when using horizontal mode, the horizontal alignment option is hidden and internally forced to left for a more consistent experience with shared chat info and announcements

### Screenshots
<!-- If applicable, please provide screenshots of any UI changes or additions -->
<img width="687" height="249" alt="image" src="https://github.com/user-attachments/assets/e9003df2-4996-4882-af9a-0acef2e37f72" />
<img width="1926" height="80" alt="image" src="https://github.com/user-attachments/assets/d10384b3-9353-4f29-b038-a2182d74ecc0" />
